### PR TITLE
ci: bump Node to 22, add tests to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies
@@ -30,3 +30,6 @@ jobs:
 
       - name: Typecheck
         run: pnpm typecheck
+
+      - name: Test
+        run: pnpm --filter @traceroot-ai/traceroot test

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
           cache: pnpm
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,12 +5,13 @@ on:
     types: [published]
 
 jobs:
-  publish-sdk:
+  # Triggered by tags like: v0.1.1, v1.0.0
+  publish-traceroot:
+    if: "!startsWith(github.event.release.tag_name, 'mastra-')"
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write # required for npm provenance attestation via OIDC
-
     steps:
       - uses: actions/checkout@v4
 
@@ -48,5 +49,49 @@ jobs:
 
       - name: Publish @traceroot-ai/traceroot
         run: pnpm --filter @traceroot-ai/traceroot publish --provenance --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # Triggered by tags like: mastra-v0.1.0, mastra-v1.0.0
+  publish-mastra:
+    if: startsWith(github.event.release.tag_name, 'mastra-')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # required for npm provenance attestation via OIDC
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Fail fast — verify tag matches package.json before running build/tests
+      - name: Verify release tag matches package version
+        run: |
+          PKG_VERSION=$(node -p "require('./packages/mastra/package.json').version")
+          TAG="${{ github.event.release.tag_name }}"
+          TAG_VERSION="${TAG#mastra-v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "❌ packages/mastra/package.json version ($PKG_VERSION) does not match release tag ($TAG)"
+            exit 1
+          fi
+          echo "✅ Version $PKG_VERSION matches tag $TAG"
+
+      - name: Lint
+        run: pnpm --filter @traceroot-ai/mastra lint
+
+      - name: Build
+        run: pnpm --filter @traceroot-ai/mastra build
+
+      - name: Publish @traceroot-ai/mastra
+        run: pnpm --filter @traceroot-ai/mastra publish --provenance --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/mastra/src/exporter.ts
+++ b/packages/mastra/src/exporter.ts
@@ -199,7 +199,7 @@ export class TraceRootExporter extends BaseExporter {
         await this.processor.forceFlush();
       }
     } catch (error) {
-      this.logger.error('[TraceRootExporter] Failed to export span', {
+      console.error('[TraceRootExporter] Failed to export span', {
         error,
         spanId: span.id,
         traceId: span.traceId,
@@ -310,7 +310,7 @@ export class TraceRootExporter extends BaseExporter {
     try {
       await this.processor.forceFlush();
     } catch (error) {
-      this.logger.error('[TraceRootExporter] Error flushing spans', { error });
+      console.error('[TraceRootExporter] Error flushing spans', { error });
     }
   }
 


### PR DESCRIPTION
- Bumps Node from 20 to 22 in both build and publish workflows to match local dev environment
- Adds test step to build.yml so test failures are caught on every PR, not just at publish time
- Fixes the v0.1.1 publish failure (unhandled rejection in Node 20.20.2 that doesn't reproduce on 20.19.x or 22)