### PR TITLE
feat(instrumentation): add Vercel AI SDK tracing via OpenInference span processor

### DIFF
--- a/packages/traceroot/package.json
+++ b/packages/traceroot/package.json
@@ -49,6 +49,7 @@
     "@arizeai/openinference-instrumentation-langchain": "^4.0.6",
     "@arizeai/openinference-instrumentation-openai": "^4.0.5",
     "@arizeai/openinference-semantic-conventions": "^2.1.7",
+    "@arizeai/openinference-vercel": "^2.7.2",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.57.2",
     "@opentelemetry/instrumentation": "^0.46.0",

--- a/packages/traceroot/src/processor.ts
+++ b/packages/traceroot/src/processor.ts
@@ -1,11 +1,6 @@
 // src/processor.ts
 import { Context, Span } from '@opentelemetry/api';
-import {
-  BatchSpanProcessor,
-  ReadableSpan,
-  SimpleSpanProcessor,
-  SpanProcessor,
-} from '@opentelemetry/sdk-trace-base';
+import { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace-base';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { version } = require('../package.json') as { version: string };
@@ -20,18 +15,19 @@ export interface TraceRootSpanProcessorOptions {
 }
 
 /**
- * Wraps an inner SpanProcessor (Batch or Simple) and injects TraceRoot SDK
- * metadata attributes on every span start. This is the only processor TraceRoot
- * registers; the inner processor handles actual export batching.
+ * Wraps an inner SpanProcessor and injects TraceRoot SDK metadata attributes
+ * on every span start. The inner processor handles export batching and, when
+ * the Vercel AI SDK is in use, OpenInference attribute enrichment.
  */
 export class TraceRootSpanProcessor implements SpanProcessor {
-  private readonly inner: BatchSpanProcessor | SimpleSpanProcessor;
+  private readonly inner: SpanProcessor; // ← WIDENED from BatchSpanProcessor | SimpleSpanProcessor
+
   private readonly _environment: string | undefined;
   private readonly _gitRepo: string | undefined;
   private readonly _gitRef: string | undefined;
 
   constructor(
-    inner: BatchSpanProcessor | SimpleSpanProcessor,
+    inner: SpanProcessor, // ← WIDENED
     opts: TraceRootSpanProcessorOptions = {},
   ) {
     this.inner = inner;
@@ -54,8 +50,6 @@ export class TraceRootSpanProcessor implements SpanProcessor {
     if (this._gitRef !== undefined) {
       span.setAttribute('traceroot.git.ref', this._gitRef);
     }
-    // Cast required: inner processor expects the internal sdk-trace-base Span,
-    // but the SpanProcessor interface uses the public @opentelemetry/api Span.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.inner.onStart(span as any, parentContext);
   }

--- a/packages/traceroot/src/processor.ts
+++ b/packages/traceroot/src/processor.ts
@@ -1,11 +1,6 @@
 // src/processor.ts
 import { trace as otelTrace, Context, Span } from '@opentelemetry/api';
-import {
-  BatchSpanProcessor,
-  ReadableSpan,
-  SimpleSpanProcessor,
-  SpanProcessor,
-} from '@opentelemetry/sdk-trace-base';
+import { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace-base';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { version } = require('../package.json') as { version: string };
@@ -20,12 +15,13 @@ export interface TraceRootSpanProcessorOptions {
 }
 
 /**
- * Wraps an inner SpanProcessor (Batch or Simple) and injects TraceRoot SDK
- * metadata attributes on every span start. This is the only processor TraceRoot
- * registers; the inner processor handles actual export batching.
+ * Wraps an inner SpanProcessor and injects TraceRoot SDK metadata attributes
+ * on every span start. The inner processor handles export batching and, when
+ * the Vercel AI SDK is in use, OpenInference attribute enrichment.
  */
 export class TraceRootSpanProcessor implements SpanProcessor {
-  private readonly inner: BatchSpanProcessor | SimpleSpanProcessor;
+  private readonly inner: SpanProcessor; // ← WIDENED from BatchSpanProcessor | SimpleSpanProcessor
+
   private readonly _environment: string | undefined;
   private readonly _gitRepo: string | undefined;
   private readonly _gitRef: string | undefined;
@@ -36,7 +32,7 @@ export class TraceRootSpanProcessor implements SpanProcessor {
   private readonly _namePathBySpanId = new Map<string, string[]>();
 
   constructor(
-    inner: BatchSpanProcessor | SimpleSpanProcessor,
+    inner: SpanProcessor, // ← WIDENED
     opts: TraceRootSpanProcessorOptions = {},
   ) {
     this.inner = inner;

--- a/packages/traceroot/src/traceroot.ts
+++ b/packages/traceroot/src/traceroot.ts
@@ -10,6 +10,10 @@ import {
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
 import { BatchSpanProcessor, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import {
+  OpenInferenceBatchSpanProcessor,
+  OpenInferenceSimpleSpanProcessor,
+} from '@arizeai/openinference-vercel';
 import { InitializeOptions } from './types';
 import { SDK_NAME, SDK_VERSION, TraceRootSpanProcessor } from './processor';
 import { wireInstrumentations } from './instrumentation';
@@ -63,6 +67,7 @@ export class TraceRoot {
       process.env['TRACEROOT_HOST_URL'] ??
       DEFAULT_BASE_URL
     ).replace(/\/$/, '');
+
     const headers: Record<string, string> = {
       'x-traceroot-sdk-name': SDK_NAME,
       'x-traceroot-sdk-version': SDK_VERSION,
@@ -72,7 +77,6 @@ export class TraceRoot {
     const exporter = new OTLPTraceExporter({
       url: `${baseUrl}/api/v1/public/traces`,
       headers,
-      // CompressionAlgorithm.GZIP = "gzip"; using string literal to avoid importing transitive dep
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       compression: 'gzip' as any,
     });
@@ -84,24 +88,30 @@ export class TraceRoot {
     let gitRepo = gitRepoOverride;
     let gitRef = gitRefOverride;
     if (gitRepo === undefined || gitRef === undefined) {
-      const autoGit = autoDetectGitContext(); // also warms the git root cache
+      const autoGit = autoDetectGitContext();
       gitRepo ??= autoGit.gitRepo;
       gitRef ??= autoGit.gitRef;
     } else {
-      getGitRoot(); // warm git root cache for captureSourceLocation without shelling out for repo/ref
+      getGitRoot();
     }
 
-    // Flush/batch tuning — env vars take precedence over hardcoded defaults.
     const flushIntervalSec = Number(process.env['TRACEROOT_FLUSH_INTERVAL'] || '5');
     const flushAt = Number(process.env['TRACEROOT_FLUSH_AT'] || '100');
     const timeoutSec = Number(process.env['TRACEROOT_TIMEOUT'] || '30');
 
+    // ── Vercel AI SDK: wrap the exporter in OpenInference span processors ──────
+    // These processors enrich spans emitted by Vercel AI SDK's experimental_telemetry
+    // with OpenInference semantic conventions (model name, token counts, IO, etc.)
+    // before they reach the OTLP exporter. All other SDK spans pass through unchanged.
     const innerProcessor = options.disableBatch
-      ? new SimpleSpanProcessor(exporter)
-      : new BatchSpanProcessor(exporter, {
-          scheduledDelayMillis: flushIntervalSec * 1000,
-          maxExportBatchSize: flushAt,
-          exportTimeoutMillis: timeoutSec * 1000,
+      ? new OpenInferenceSimpleSpanProcessor({ exporter })
+      : new OpenInferenceBatchSpanProcessor({
+          exporter,
+          config: {
+            scheduledDelayMillis: flushIntervalSec * 1000,
+            maxExportBatchSize: flushAt,
+            exportTimeoutMillis: timeoutSec * 1000,
+          },
         });
 
     _provider = new NodeTracerProvider();
@@ -113,8 +123,6 @@ export class TraceRoot {
     wireInstrumentations(options.instrumentModules);
 
     _isInitialized = true;
-    // forceFlush() is async and keeps the event loop alive via its HTTP export request,
-    // so beforeExit + forceFlush() is sufficient — no keepAlive timer needed.
     process.once('beforeExit', () => {
       void _provider?.forceFlush();
     });

--- a/packages/traceroot/src/traceroot.ts
+++ b/packages/traceroot/src/traceroot.ts
@@ -8,7 +8,6 @@ import {
   trace,
 } from '@opentelemetry/api';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
-import { BatchSpanProcessor, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import {
   OpenInferenceBatchSpanProcessor,

--- a/packages/traceroot/src/traceroot.ts
+++ b/packages/traceroot/src/traceroot.ts
@@ -10,6 +10,10 @@ import {
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
 import { BatchSpanProcessor, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import {
+  OpenInferenceBatchSpanProcessor,
+  OpenInferenceSimpleSpanProcessor,
+} from '@arizeai/openinference-vercel';
 import { InitializeOptions } from './types';
 import { SDK_NAME, SDK_VERSION, TraceRootSpanProcessor } from './processor';
 import { wireInstrumentations } from './instrumentation';
@@ -64,6 +68,7 @@ export class TraceRoot {
       process.env['TRACEROOT_HOST_URL'] ??
       DEFAULT_BASE_URL
     ).replace(/\/$/, '');
+
     const headers: Record<string, string> = {
       'x-traceroot-sdk-name': SDK_NAME,
       'x-traceroot-sdk-version': SDK_VERSION,
@@ -73,7 +78,6 @@ export class TraceRoot {
     const exporter = new OTLPTraceExporter({
       url: `${baseUrl}/api/v1/public/traces`,
       headers,
-      // CompressionAlgorithm.GZIP = "gzip"; using string literal to avoid importing transitive dep
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       compression: 'gzip' as any,
     });
@@ -85,11 +89,11 @@ export class TraceRoot {
     let gitRepo = gitRepoOverride;
     let gitRef = gitRefOverride;
     if (gitRepo === undefined || gitRef === undefined) {
-      const autoGit = autoDetectGitContext(); // also warms the git root cache
+      const autoGit = autoDetectGitContext();
       gitRepo ??= autoGit.gitRepo;
       gitRef ??= autoGit.gitRef;
     } else {
-      getGitRoot(); // warm git root cache for captureSourceLocation without shelling out for repo/ref
+      getGitRoot();
     }
 
     // Flush/batch tuning — env vars take precedence over SDK defaults.
@@ -99,12 +103,19 @@ export class TraceRoot {
     const flushAt = Number(process.env['TRACEROOT_FLUSH_AT'] || DEFAULT_FLUSH_AT);
     const timeoutSec = Number(process.env['TRACEROOT_TIMEOUT'] || DEFAULT_TIMEOUT_SEC);
 
+    // ── Vercel AI SDK: wrap the exporter in OpenInference span processors ──────
+    // These processors enrich spans emitted by Vercel AI SDK's experimental_telemetry
+    // with OpenInference semantic conventions (model name, token counts, IO, etc.)
+    // before they reach the OTLP exporter. All other SDK spans pass through unchanged.
     const innerProcessor = options.disableBatch
-      ? new SimpleSpanProcessor(exporter)
-      : new BatchSpanProcessor(exporter, {
-          scheduledDelayMillis: flushIntervalSec * 1000,
-          maxExportBatchSize: flushAt,
-          exportTimeoutMillis: timeoutSec * 1000,
+      ? new OpenInferenceSimpleSpanProcessor({ exporter })
+      : new OpenInferenceBatchSpanProcessor({
+          exporter,
+          config: {
+            scheduledDelayMillis: flushIntervalSec * 1000,
+            maxExportBatchSize: flushAt,
+            exportTimeoutMillis: timeoutSec * 1000,
+          },
         });
 
     _provider = new NodeTracerProvider();
@@ -116,8 +127,6 @@ export class TraceRoot {
     wireInstrumentations(options.instrumentModules);
 
     _isInitialized = true;
-    // forceFlush() is async and keeps the event loop alive via its HTTP export request,
-    // so beforeExit + forceFlush() is sufficient — no keepAlive timer needed.
     process.once('beforeExit', () => {
       void _provider?.forceFlush();
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       '@arizeai/openinference-semantic-conventions':
         specifier: ^2.1.7
         version: 2.1.7
+      '@arizeai/openinference-vercel':
+        specifier: ^2.7.2
+        version: 2.7.2(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.40.0)
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -200,6 +203,15 @@ packages:
   '@arizeai/openinference-core@2.0.5':
     resolution: {integrity: sha512-BnufYaFqmG9twkz/9DHX9WTcOs7YvVAYaufau5tdjOT1c0Y8niJwmNWzV36phNPg3c7SmdD5OYLuzeAUN0T3pQ==}
 
+  '@arizeai/openinference-core@2.0.6':
+    resolution: {integrity: sha512-hsMax4Yq9x0S+F6QJYcdzKWiKI5OpIeYqLl5TptS4MUDwyfgwz7pOmmy3wiewEktcxB8NY5S/T32S01naAgLxA==}
+
+  '@arizeai/openinference-genai@0.1.7':
+    resolution: {integrity: sha512-w1sevI+y1tFusyzlLkuI7mdT87IsvO9cBGljxB0cd/tM9/TWV5/A0m9fZd/hys/jgMRRQCU+AW4tGBWcCZ/WCQ==}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0'
+      '@opentelemetry/semantic-conventions': '>=1.37.0'
+
   '@arizeai/openinference-instrumentation-anthropic@0.1.7':
     resolution: {integrity: sha512-TaxOkNLQftIgqvtT5R64FaRPGGf6E0nm6+8J3g7JF4A6lPYnLLquc/HyMN+ttckqavXcIfLYn7qKa4AfZm4kuA==}
 
@@ -223,6 +235,14 @@ packages:
 
   '@arizeai/openinference-semantic-conventions@2.1.7':
     resolution: {integrity: sha512-KyBfwxkSusPvxHBaW/TJ0japEbXCNziW9o6/IRKiPu+gp5TMKIagV2NKvt47rWYa4Jc0Nl+SvAPm+yxkdJqVbg==}
+
+  '@arizeai/openinference-semantic-conventions@2.2.0':
+    resolution: {integrity: sha512-jyVeggDSuVFyOXWXqShKsRxHc5RrE7jRN2D0LGMGYDbo4oHeCJCgUezHQITT7t7FPNQxj5O+NcqERhznnDx6UQ==}
+
+  '@arizeai/openinference-vercel@2.7.2':
+    resolution: {integrity: sha512-hr8ccq8Hm/kR8yYi/u6h/05jIp3ndxM4DdRjj0kjyt6sUCpXLTK+vgIsJY73Ruc+cWqOJhSvl0A/Myi3dsbQaw==}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.7.0 <2.0.0'
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -2640,6 +2660,18 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
 
+  '@arizeai/openinference-core@2.0.6':
+    dependencies:
+      '@arizeai/openinference-semantic-conventions': 2.2.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@arizeai/openinference-genai@0.1.7(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@arizeai/openinference-semantic-conventions': 2.2.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+
   '@arizeai/openinference-instrumentation-anthropic@0.1.7':
     dependencies:
       '@arizeai/openinference-core': 2.0.5
@@ -2694,6 +2726,18 @@ snapshots:
       - supports-color
 
   '@arizeai/openinference-semantic-conventions@2.1.7': {}
+
+  '@arizeai/openinference-semantic-conventions@2.2.0': {}
+
+  '@arizeai/openinference-vercel@2.7.2(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@arizeai/openinference-core': 2.0.6
+      '@arizeai/openinference-genai': 0.1.7(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.40.0)
+      '@arizeai/openinference-semantic-conventions': 2.2.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - '@opentelemetry/semantic-conventions'
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       '@arizeai/openinference-semantic-conventions':
         specifier: ^2.1.7
         version: 2.1.7
+      '@arizeai/openinference-vercel':
+        specifier: ^2.7.2
+        version: 2.7.2(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.40.0)
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -203,6 +206,15 @@ packages:
   '@arizeai/openinference-core@2.0.5':
     resolution: {integrity: sha512-BnufYaFqmG9twkz/9DHX9WTcOs7YvVAYaufau5tdjOT1c0Y8niJwmNWzV36phNPg3c7SmdD5OYLuzeAUN0T3pQ==}
 
+  '@arizeai/openinference-core@2.0.6':
+    resolution: {integrity: sha512-hsMax4Yq9x0S+F6QJYcdzKWiKI5OpIeYqLl5TptS4MUDwyfgwz7pOmmy3wiewEktcxB8NY5S/T32S01naAgLxA==}
+
+  '@arizeai/openinference-genai@0.1.7':
+    resolution: {integrity: sha512-w1sevI+y1tFusyzlLkuI7mdT87IsvO9cBGljxB0cd/tM9/TWV5/A0m9fZd/hys/jgMRRQCU+AW4tGBWcCZ/WCQ==}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0'
+      '@opentelemetry/semantic-conventions': '>=1.37.0'
+
   '@arizeai/openinference-instrumentation-anthropic@0.1.7':
     resolution: {integrity: sha512-TaxOkNLQftIgqvtT5R64FaRPGGf6E0nm6+8J3g7JF4A6lPYnLLquc/HyMN+ttckqavXcIfLYn7qKa4AfZm4kuA==}
 
@@ -226,6 +238,14 @@ packages:
 
   '@arizeai/openinference-semantic-conventions@2.1.7':
     resolution: {integrity: sha512-KyBfwxkSusPvxHBaW/TJ0japEbXCNziW9o6/IRKiPu+gp5TMKIagV2NKvt47rWYa4Jc0Nl+SvAPm+yxkdJqVbg==}
+
+  '@arizeai/openinference-semantic-conventions@2.2.0':
+    resolution: {integrity: sha512-jyVeggDSuVFyOXWXqShKsRxHc5RrE7jRN2D0LGMGYDbo4oHeCJCgUezHQITT7t7FPNQxj5O+NcqERhznnDx6UQ==}
+
+  '@arizeai/openinference-vercel@2.7.2':
+    resolution: {integrity: sha512-hr8ccq8Hm/kR8yYi/u6h/05jIp3ndxM4DdRjj0kjyt6sUCpXLTK+vgIsJY73Ruc+cWqOJhSvl0A/Myi3dsbQaw==}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.7.0 <2.0.0'
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -2669,6 +2689,18 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
 
+  '@arizeai/openinference-core@2.0.6':
+    dependencies:
+      '@arizeai/openinference-semantic-conventions': 2.2.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@arizeai/openinference-genai@0.1.7(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@arizeai/openinference-semantic-conventions': 2.2.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+
   '@arizeai/openinference-instrumentation-anthropic@0.1.7':
     dependencies:
       '@arizeai/openinference-core': 2.0.5
@@ -2723,6 +2755,18 @@ snapshots:
       - supports-color
 
   '@arizeai/openinference-semantic-conventions@2.1.7': {}
+
+  '@arizeai/openinference-semantic-conventions@2.2.0': {}
+
+  '@arizeai/openinference-vercel@2.7.2(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@arizeai/openinference-core': 2.0.6
+      '@arizeai/openinference-genai': 0.1.7(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.40.0)
+      '@arizeai/openinference-semantic-conventions': 2.2.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - '@opentelemetry/semantic-conventions'
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:


### PR DESCRIPTION
## Summary

Adds automatic tracing support for the [Vercel AI SDK](https://sdk.vercel.ai/) (`ai` package) by integrating `@arizeai/openinference-vercel`.

## How it works

The Vercel AI SDK emits OpenTelemetry spans natively via `experimental_telemetry`. Unlike other integrations (OpenAI, Anthropic, LangChain) which use `require-in-the-middle` instrumentation plugins, the Vercel SDK has its own built-in OTel support.

`@arizeai/openinference-vercel` provides span processors that enrich those spans with OpenInference semantic conventions before export. This PR wraps TraceRoot's OTLP exporter in `OpenInferenceBatchSpanProcessor` (or `OpenInferenceSimpleSpanProcessor` when `disableBatch` is set), so enrichment happens automatically for all users — no `instrumentModules` config required.

## Changes

- `traceroot.ts` — wrap exporter in `OpenInferenceBatchSpanProcessor` / `OpenInferenceSimpleSpanProcessor`
- `processor.ts` — widen `inner` type from `BatchSpanProcessor | SimpleSpanProcessor` to `SpanProcessor` to accept the OpenInference subclasses
- `package.json` — add `@arizeai/openinference-vercel ^2.7.2`

## Usage

```typescript
import { TraceRoot } from '@traceroot-ai/traceroot';

// No instrumentModules needed
TraceRoot.initialize();

// Add experimental_telemetry to each Vercel AI SDK call
const result = await generateText({
  model: openai('gpt-4o-mini'),
  prompt: 'Hello!',
  experimental_telemetry: { isEnabled: true }, // ← activates tracing
});
```

## What gets traced

| Signal | Details |
|---|---|
| LLM calls | `generateText`, `streamText`, `generateObject`, `streamObject` |
| Tool calls | Each invocation with input/output |
| Token usage | Prompt + completion tokens |
| Model name | Captured on every LLM span |
| Streaming metrics | `msToFirstChunk`, `msToFinish`, `avgOutputTokensPerSecond` |

## Validation

- `pnpm build` — clean
- `pnpm typecheck` — clean
- Manually tested with the example in traceroot-ai/traceroot:   https://github.com/traceroot-ai/traceroot/pull/653
