### PR TITLE
feat: extract flush/batch constants from hardcoded defaults

### DIFF
--- a/packages/traceroot/src/constants.ts
+++ b/packages/traceroot/src/constants.ts
@@ -1,9 +1,9 @@
 // src/constants.ts — TraceRoot-specific span attribute keys and SDK defaults
 
 // Flush/batch defaults — mirror traceroot-py/traceroot/constants.py
-export const DEFAULT_FLUSH_INTERVAL_SEC = 5; // BatchSpanProcessor scheduledDelayMillis
+export const DEFAULT_FLUSH_INTERVAL_SEC = 5; // seconds → BatchSpanProcessor scheduledDelayMillis (×1000)
 export const DEFAULT_FLUSH_AT = 100; // BatchSpanProcessor maxExportBatchSize
-export const DEFAULT_TIMEOUT_SEC = 30; // BatchSpanProcessor exportTimeoutMillis
+export const DEFAULT_TIMEOUT_SEC = 30; // seconds → BatchSpanProcessor exportTimeoutMillis (×1000)
 
 // Span-level
 export const SPAN_METADATA = 'traceroot.span.metadata';

--- a/packages/traceroot/src/constants.ts
+++ b/packages/traceroot/src/constants.ts
@@ -1,4 +1,9 @@
-// src/constants.ts — TraceRoot-specific span attribute keys
+// src/constants.ts — TraceRoot-specific span attribute keys and SDK defaults
+
+// Flush/batch defaults — mirror traceroot-py/traceroot/constants.py
+export const DEFAULT_FLUSH_INTERVAL_SEC = 5; // BatchSpanProcessor scheduledDelayMillis
+export const DEFAULT_FLUSH_AT = 100; // BatchSpanProcessor maxExportBatchSize
+export const DEFAULT_TIMEOUT_SEC = 30; // BatchSpanProcessor exportTimeoutMillis
 
 // Span-level
 export const SPAN_METADATA = 'traceroot.span.metadata';

--- a/packages/traceroot/src/traceroot.ts
+++ b/packages/traceroot/src/traceroot.ts
@@ -13,6 +13,7 @@ import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { InitializeOptions } from './types';
 import { SDK_NAME, SDK_VERSION, TraceRootSpanProcessor } from './processor';
 import { wireInstrumentations } from './instrumentation';
+import { DEFAULT_FLUSH_AT, DEFAULT_FLUSH_INTERVAL_SEC, DEFAULT_TIMEOUT_SEC } from './constants';
 import { _resetObserveState } from './observe';
 import { autoDetectGitContext, getGitRoot, _resetGitContextCache } from './git_context';
 
@@ -91,10 +92,12 @@ export class TraceRoot {
       getGitRoot(); // warm git root cache for captureSourceLocation without shelling out for repo/ref
     }
 
-    // Flush/batch tuning — env vars take precedence over hardcoded defaults.
-    const flushIntervalSec = Number(process.env['TRACEROOT_FLUSH_INTERVAL'] || '5');
-    const flushAt = Number(process.env['TRACEROOT_FLUSH_AT'] || '100');
-    const timeoutSec = Number(process.env['TRACEROOT_TIMEOUT'] || '30');
+    // Flush/batch tuning — env vars take precedence over SDK defaults.
+    const flushIntervalSec = Number(
+      process.env['TRACEROOT_FLUSH_INTERVAL'] || DEFAULT_FLUSH_INTERVAL_SEC,
+    );
+    const flushAt = Number(process.env['TRACEROOT_FLUSH_AT'] || DEFAULT_FLUSH_AT);
+    const timeoutSec = Number(process.env['TRACEROOT_TIMEOUT'] || DEFAULT_TIMEOUT_SEC);
 
     const innerProcessor = options.disableBatch
       ? new SimpleSpanProcessor(exporter)


### PR DESCRIPTION
## Summary                                                
                                                                                                                                                                                                                                   
  - Move `DEFAULT_FLUSH_INTERVAL_SEC`, `DEFAULT_FLUSH_AT`, `DEFAULT_TIMEOUT_SEC` into `constants.ts`
  - Update `traceroot.ts` to import from constants instead of hardcoding `'5'`, `'100'`, `'30'`
  - Mirrors `traceroot-py/traceroot/constants.py` which already has these constants
                                                                                                                                                                                                                                   
  Single place to change if defaults need tuning (e.g., reducing flush interval from 5s to 2s for lower live-streaming latency).
