### PR TITLE
feat: live trace streaming support — span path propagation

### DIFF
--- a/packages/traceroot/src/processor.ts
+++ b/packages/traceroot/src/processor.ts
@@ -1,5 +1,5 @@
 // src/processor.ts
-import { Context, Span } from '@opentelemetry/api';
+import { trace as otelTrace, Context, Span } from '@opentelemetry/api';
 import {
   BatchSpanProcessor,
   ReadableSpan,
@@ -29,6 +29,11 @@ export class TraceRootSpanProcessor implements SpanProcessor {
   private readonly _environment: string | undefined;
   private readonly _gitRepo: string | undefined;
   private readonly _gitRef: string | undefined;
+  // Keyed by spanId. Allows children to inherit paths even when the parent
+  // is a NonRecordingSpan (remote context) with no attributes — which is
+  // what OpenInference produces for LangGraph-instrumented node spans.
+  private readonly _idsPathBySpanId = new Map<string, string[]>();
+  private readonly _namePathBySpanId = new Map<string, string[]>();
 
   constructor(
     inner: BatchSpanProcessor | SimpleSpanProcessor,
@@ -54,6 +59,49 @@ export class TraceRootSpanProcessor implements SpanProcessor {
     if (this._gitRef !== undefined) {
       span.setAttribute('traceroot.git.ref', this._gitRef);
     }
+
+    // Enrich every span with its full name path from root to current span.
+    // path[0] is always the root span name, so the backend can recover the
+    // correct trace name even when child spans arrive before the root span.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const parentSpan = otelTrace.getSpan(parentContext) as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const spanName = ((span as any).name as string) ?? '';
+
+    // ReadableSpan.parentSpanId is set by the SDK from the parent context at
+    // span creation time, even when the parent is a remote span context and
+    // getSpan() returns undefined. This is the reliable way to get the parent ID.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const parentSpanId: string | undefined =
+      ((span as any).parentSpanId as string | undefined) ||
+      (parentSpan?.spanContext?.()?.spanId as string | undefined);
+
+    // Prefer the in-process map over span attributes: OpenInference creates
+    // LangGraph node spans with a remote/NonRecordingSpan parent that carries
+    // no attributes, so reading parentSpan.attributes would give undefined and
+    // break the ancestry chain.
+    const parentPath: string[] | undefined =
+      (parentSpanId && this._namePathBySpanId.get(parentSpanId)) ||
+      (parentSpan?.attributes?.['traceroot.span.path'] as string[] | undefined);
+    const parentIdsPath: string[] | undefined =
+      (parentSpanId && this._idsPathBySpanId.get(parentSpanId)) ||
+      (parentSpan?.attributes?.['traceroot.span.ids_path'] as string[] | undefined);
+
+    const spanPath: string[] = parentPath ? [...parentPath, spanName] : [spanName];
+    const spanIdsPath: string[] = parentSpanId
+      ? parentIdsPath
+        ? [...parentIdsPath, parentSpanId]
+        : [parentSpanId]
+      : [];
+
+    span.setAttribute('traceroot.span.path', spanPath);
+    span.setAttribute('traceroot.span.ids_path', spanIdsPath);
+
+    // Store paths so descendant spans can inherit them via map lookup.
+    const spanId = span.spanContext().spanId;
+    this._namePathBySpanId.set(spanId, spanPath);
+    this._idsPathBySpanId.set(spanId, spanIdsPath);
+
     // Cast required: inner processor expects the internal sdk-trace-base Span,
     // but the SpanProcessor interface uses the public @opentelemetry/api Span.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -61,6 +109,9 @@ export class TraceRootSpanProcessor implements SpanProcessor {
   }
 
   onEnd(span: ReadableSpan): void {
+    const spanId = span.spanContext().spanId;
+    this._idsPathBySpanId.delete(spanId);
+    this._namePathBySpanId.delete(spanId);
     this.inner.onEnd(span);
   }
 

--- a/packages/traceroot/src/processor.ts
+++ b/packages/traceroot/src/processor.ts
@@ -73,9 +73,8 @@ export class TraceRootSpanProcessor implements SpanProcessor {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const spanName = ((span as any).name as string) ?? '';
 
-    // ReadableSpan.parentSpanId is set by the SDK from the parent context at
-    // span creation time, even when the parent is a remote span context and
-    // getSpan() returns undefined. This is the reliable way to get the parent ID.
+    // `span.name` and `span.parentSpanId` are not on the public @opentelemetry/api
+    // Span interface but are stable internal fields on the SDK implementation.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const parentSpanId: string | undefined =
       ((span as any).parentSpanId as string | undefined) ||
@@ -93,11 +92,15 @@ export class TraceRootSpanProcessor implements SpanProcessor {
       (parentSpan?.attributes?.['traceroot.span.ids_path'] as string[] | undefined);
 
     const spanPath: string[] = parentPath ? [...parentPath, spanName] : [spanName];
-    const spanIdsPath: string[] = parentSpanId
-      ? parentIdsPath
-        ? [...parentIdsPath, parentSpanId]
-        : [parentSpanId]
-      : [];
+    // Gate on parentPath (not just parentSpanId) so path and ids_path stay in sync:
+    // if path resolution failed (map miss + NonRecordingSpan), treat this span as a
+    // root rather than emitting an inconsistent single-element path with a non-empty ids_path.
+    const spanIdsPath: string[] =
+      parentPath && parentSpanId
+        ? parentIdsPath
+          ? [...parentIdsPath, parentSpanId]
+          : [parentSpanId]
+        : [];
 
     span.setAttribute('traceroot.span.path', spanPath);
     span.setAttribute('traceroot.span.ids_path', spanIdsPath);
@@ -118,6 +121,9 @@ export class TraceRootSpanProcessor implements SpanProcessor {
   }
 
   onEnd(span: ReadableSpan): void {
+    // Invariant: children must be started before their parent ends. A child span
+    // started after onEnd runs here loses the map-based ancestry lookup for
+    // NonRecordingSpan parents (no attribute fallback exists for those).
     const spanId = span.spanContext().spanId;
     this._idsPathBySpanId.delete(spanId);
     this._namePathBySpanId.delete(spanId);

--- a/packages/traceroot/src/processor.ts
+++ b/packages/traceroot/src/processor.ts
@@ -63,8 +63,13 @@ export class TraceRootSpanProcessor implements SpanProcessor {
     // Enrich every span with its full name path from root to current span.
     // path[0] is always the root span name, so the backend can recover the
     // correct trace name even when child spans arrive before the root span.
+    // Guard: a bare `{}` context (used in unit tests) has no getValue — skip gracefully.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const parentSpan = otelTrace.getSpan(parentContext) as any;
+    const parentSpan = (
+      typeof (parentContext as any)?.getValue === 'function'
+        ? otelTrace.getSpan(parentContext)
+        : undefined
+    ) as any;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const spanName = ((span as any).name as string) ?? '';
 
@@ -98,9 +103,13 @@ export class TraceRootSpanProcessor implements SpanProcessor {
     span.setAttribute('traceroot.span.ids_path', spanIdsPath);
 
     // Store paths so descendant spans can inherit them via map lookup.
-    const spanId = span.spanContext().spanId;
-    this._namePathBySpanId.set(spanId, spanPath);
-    this._idsPathBySpanId.set(spanId, spanIdsPath);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const spanId =
+      typeof (span as any).spanContext === 'function' ? span.spanContext().spanId : undefined;
+    if (spanId) {
+      this._namePathBySpanId.set(spanId, spanPath);
+      this._idsPathBySpanId.set(spanId, spanIdsPath);
+    }
 
     // Cast required: inner processor expects the internal sdk-trace-base Span,
     // but the SpanProcessor interface uses the public @opentelemetry/api Span.

--- a/packages/traceroot/tests/processor.test.ts
+++ b/packages/traceroot/tests/processor.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { context, propagation, trace } from '@opentelemetry/api';
+import { context, propagation, trace, TraceFlags } from '@opentelemetry/api';
 import { TraceRootSpanProcessor, SDK_VERSION } from '../src/processor';
 
 describe('TraceRootSpanProcessor', () => {
@@ -59,5 +59,208 @@ describe('TraceRootSpanProcessor', () => {
       });
     });
     assert.equal(exporter.getFinishedSpans().length, 1);
+  });
+
+  describe('span path propagation', () => {
+    it('root span gets path containing only its own name', async () => {
+      const tracer = trace.getTracer('test');
+      await new Promise<void>((resolve) => {
+        tracer.startActiveSpan('root', (span) => {
+          span.end();
+          resolve();
+        });
+      });
+      const [span] = exporter.getFinishedSpans();
+      assert.deepEqual(span.attributes['traceroot.span.path'], ['root']);
+    });
+
+    it('child span path includes parent name then own name', async () => {
+      const tracer = trace.getTracer('test');
+      await new Promise<void>((resolve) => {
+        tracer.startActiveSpan('root', (root) => {
+          tracer.startActiveSpan('child', (child) => {
+            child.end();
+            root.end();
+            resolve();
+          });
+        });
+      });
+      const [child] = exporter.getFinishedSpans();
+      assert.deepEqual(child.attributes['traceroot.span.path'], ['root', 'child']);
+    });
+
+    it('deeply nested span accumulates full ancestor path', async () => {
+      const tracer = trace.getTracer('test');
+      await new Promise<void>((resolve) => {
+        tracer.startActiveSpan('root', (root) => {
+          tracer.startActiveSpan('mid', (mid) => {
+            tracer.startActiveSpan('leaf', (leaf) => {
+              leaf.end();
+              mid.end();
+              root.end();
+              resolve();
+            });
+          });
+        });
+      });
+      const [leaf] = exporter.getFinishedSpans();
+      assert.deepEqual(leaf.attributes['traceroot.span.path'], ['root', 'mid', 'leaf']);
+    });
+  });
+
+  describe('ids_path propagation', () => {
+    it('root span gets empty ids_path', async () => {
+      const tracer = trace.getTracer('test');
+      await new Promise<void>((resolve) => {
+        tracer.startActiveSpan('root', (span) => {
+          span.end();
+          resolve();
+        });
+      });
+      const [span] = exporter.getFinishedSpans();
+      assert.deepEqual(span.attributes['traceroot.span.ids_path'], []);
+    });
+
+    it('child ids_path contains parent span id', async () => {
+      const tracer = trace.getTracer('test');
+      let rootId: string;
+      await new Promise<void>((resolve) => {
+        tracer.startActiveSpan('root', (root) => {
+          rootId = root.spanContext().spanId;
+          tracer.startActiveSpan('child', (child) => {
+            child.end();
+            root.end();
+            resolve();
+          });
+        });
+      });
+      const [child] = exporter.getFinishedSpans();
+      assert.deepEqual(child.attributes['traceroot.span.ids_path'], [rootId!]);
+    });
+
+    it('grandchild ids_path is [root_id, mid_id]', async () => {
+      const tracer = trace.getTracer('test');
+      let rootId: string;
+      let midId: string;
+      await new Promise<void>((resolve) => {
+        tracer.startActiveSpan('root', (root) => {
+          rootId = root.spanContext().spanId;
+          tracer.startActiveSpan('mid', (mid) => {
+            midId = mid.spanContext().spanId;
+            tracer.startActiveSpan('leaf', (leaf) => {
+              leaf.end();
+              mid.end();
+              root.end();
+              resolve();
+            });
+          });
+        });
+      });
+      const [leaf] = exporter.getFinishedSpans();
+      assert.deepEqual(leaf.attributes['traceroot.span.ids_path'], [rootId!, midId!]);
+    });
+  });
+
+  describe('Map-based ancestry for remote parent contexts (OpenInference/LangGraph pattern)', () => {
+    // OpenInference creates LangGraph node spans using trace.setSpanContext() rather
+    // than trace.setSpan(). This produces a NonRecordingSpan as the "parent" — it has
+    // a valid spanContext() but NO attributes. The Map fix allows the child to look up
+    // the full ids_path by parentSpanId even when attributes are unavailable.
+
+    it('inherits full ids_path from map when parent is a remote/NonRecordingSpan', async () => {
+      const tracer = trace.getTracer('test');
+      let rootId: string;
+      let midId: string;
+
+      await new Promise<void>((resolve) => {
+        tracer.startActiveSpan('root', (root) => {
+          rootId = root.spanContext().spanId;
+          tracer.startActiveSpan('mid', (mid) => {
+            midId = mid.spanContext().spanId;
+
+            // Simulate OpenInference: replace the active span with a NonRecordingSpan
+            // that has the same spanId but zero attributes.
+            const remoteCtx = trace.setSpanContext(context.active(), {
+              traceId: mid.spanContext().traceId,
+              spanId: midId,
+              traceFlags: TraceFlags.SAMPLED,
+              isRemote: true,
+            });
+            const leaf = tracer.startSpan('leaf', {}, remoteCtx);
+            leaf.end();
+            mid.end();
+            root.end();
+            resolve();
+          });
+        });
+      });
+
+      const leaf = exporter.getFinishedSpans().find((s) => s.name === 'leaf')!;
+      // Without map fix: would be [midId] only — root ancestry lost because
+      // NonRecordingSpan carries no attributes.
+      assert.deepEqual(leaf.attributes['traceroot.span.ids_path'], [rootId!, midId!]);
+      assert.deepEqual(leaf.attributes['traceroot.span.path'], ['root', 'mid', 'leaf']);
+    });
+
+    it('path is also fully inherited via map for remote parent', async () => {
+      const tracer = trace.getTracer('test');
+      let midId: string;
+
+      await new Promise<void>((resolve) => {
+        tracer.startActiveSpan('session', (root) => {
+          tracer.startActiveSpan('agent', (mid) => {
+            midId = mid.spanContext().spanId;
+            const remoteCtx = trace.setSpanContext(context.active(), {
+              traceId: mid.spanContext().traceId,
+              spanId: midId,
+              traceFlags: TraceFlags.SAMPLED,
+              isRemote: true,
+            });
+            const llm = tracer.startSpan('llm_call', {}, remoteCtx);
+            llm.end();
+            mid.end();
+            root.end();
+            resolve();
+          });
+        });
+      });
+
+      const llm = exporter.getFinishedSpans().find((s) => s.name === 'llm_call')!;
+      assert.deepEqual(llm.attributes['traceroot.span.path'], ['session', 'agent', 'llm_call']);
+    });
+
+    it('multiple remote children of the same parent all get correct ancestry', async () => {
+      const tracer = trace.getTracer('test');
+      let rootId: string;
+      let midId: string;
+
+      await new Promise<void>((resolve) => {
+        tracer.startActiveSpan('root', (root) => {
+          rootId = root.spanContext().spanId;
+          tracer.startActiveSpan('mid', (mid) => {
+            midId = mid.spanContext().spanId;
+            const remoteCtx = trace.setSpanContext(context.active(), {
+              traceId: mid.spanContext().traceId,
+              spanId: midId,
+              traceFlags: TraceFlags.SAMPLED,
+              isRemote: true,
+            });
+            const child1 = tracer.startSpan('child1', {}, remoteCtx);
+            const child2 = tracer.startSpan('child2', {}, remoteCtx);
+            child1.end();
+            child2.end();
+            mid.end();
+            root.end();
+            resolve();
+          });
+        });
+      });
+
+      const finished = exporter.getFinishedSpans();
+      const c1 = finished.find((s) => s.name === 'child1')!;
+      const c2 = finished.find((s) => s.name === 'child2')!;
+      assert.deepEqual(c1.attributes['traceroot.span.ids_path'], [rootId!, midId!]);
+      assert.deepEqual(c2.attributes['traceroot.span.ids_path'], [rootId!, midId!]);
+    });
   });
 });


### PR DESCRIPTION
Together with https://github.com/traceroot-ai/traceroot/pull/696.

## Summary

- Adds `traceroot.span.path` (name ancestry array) and `traceroot.span.ids_path` (spanId ancestry array) attributes to every span on `onStart`
- Uses an in-process `Map<spanId, path[]>` so child spans can inherit the full ancestry chain even when the parent is a `NonRecordingSpan` (remote context with no attributes) — the exact pattern OpenInference produces for LangGraph-instrumented node spans
- Cleans up map entries in `onEnd` to prevent unbounded memory growth
- Adds comprehensive test coverage: root/child/deep nesting, ids_path correctness, and the remote-parent/OpenInference simulation scenarios

## Why

The backend needs to resolve the correct trace name and reconstruct ancestry even when child spans arrive before the root span (live/streaming delivery). `traceroot.span.path[0]` is always the root span name, giving the backend a reliable anchor regardless of arrival order.

## Test plan

- [x] Root span gets `path: ['root']` and `ids_path: []`
- [x] Child span path includes parent name then own name
- [x] Deeply nested span accumulates full ancestor path
- [x] Root span ids_path is empty; child ids_path contains parent spanId
- [x] Grandchild ids_path is `[root_id, mid_id]`
- [x] Remote/NonRecordingSpan parent: full ids_path inherited via map (OpenInference/LangGraph pattern)
- [x] Multiple remote children of the same parent all receive correct ancestry

🤖 Generated with [Claude Code](https://claude.com/claude-code)