### PR TITLE
chore: bump @traceroot-ai/traceroot to v0.1.2

### DIFF
--- a/packages/traceroot/package.json
+++ b/packages/traceroot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traceroot-ai/traceroot",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "TraceRoot TypeScript SDK for AI observability",
   "keywords": [
     "traceroot",


### PR DESCRIPTION
## Summary
- Bumps `@traceroot-ai/traceroot` version from `0.1.1` → `0.1.2`

## Next step after merge
Run the following to trigger npm publish and auto-generate release notes:
```
gh release create v0.1.2 --generate-notes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)