### PR TITLE
feat: add @openai/agents tracing support

### DIFF
--- a/packages/traceroot/package.json
+++ b/packages/traceroot/package.json
@@ -70,13 +70,17 @@
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": ">=0.20.0",
-    "openai": ">=6.0.0"
+    "openai": ">=6.0.0",
+    "@openai/agents": ">=0.0.1"
   },
   "peerDependenciesMeta": {
     "openai": {
       "optional": true
     },
     "@anthropic-ai/sdk": {
+      "optional": true
+    },
+    "@openai/agents": {
       "optional": true
     }
   }

--- a/packages/traceroot/src/index.ts
+++ b/packages/traceroot/src/index.ts
@@ -11,3 +11,4 @@ export { usingAttributes } from './usingAttributes';
 export { SpanAttributes } from './constants';
 export type { SpanType, ObserveOptions, InitializeOptions } from './types';
 export type { UsingAttributesOptions } from './usingAttributes';
+export { TraceRootTracingProcessor } from './openai-agents';

--- a/packages/traceroot/src/instrumentation.ts
+++ b/packages/traceroot/src/instrumentation.ts
@@ -6,6 +6,7 @@ import { ClaudeAgentSDKInstrumentation } from '@arizeai/openinference-instrument
 import { LangChainInstrumentation } from '@arizeai/openinference-instrumentation-langchain';
 import { OpenAIInstrumentation } from '@arizeai/openinference-instrumentation-openai';
 import { InitializeOptions } from './types';
+import { wireOpenAIAgentsProcessor } from './openai-agents';
 
 /**
  * Wires OpenInference instrumentations based on the instrumentModules option:
@@ -67,6 +68,9 @@ export function wireInstrumentations(
     const instr = new BedrockInstrumentation();
     instrs.push(instr);
     instr.manuallyInstrument(instrumentModules.bedrock as any);
+  }
+  if (instrumentModules.openaiAgents) {
+    wireOpenAIAgentsProcessor(instrumentModules.openaiAgents);
   }
 
   if (instrs.length > 0) {

--- a/packages/traceroot/src/openai-agents.ts
+++ b/packages/traceroot/src/openai-agents.ts
@@ -1,0 +1,211 @@
+import { context, SpanStatusCode, trace } from '@opentelemetry/api';
+import type { Context, Span as OTelSpan } from '@opentelemetry/api';
+
+// Minimal type mirrors for @openai/agents shapes — no runtime import needed.
+export type OASpanData =
+  | { type: 'agent'; name: string; tools?: string[]; handoffs?: string[]; output_type?: string }
+  | { type: 'function'; name: string; input: string; output: string; mcp_data?: string }
+  | {
+      type: 'generation';
+      model?: string;
+      input?: unknown[];
+      output?: unknown[];
+      usage?: { input_tokens?: number; output_tokens?: number };
+    }
+  | { type: 'response'; response_id?: string; _input?: unknown; _response?: unknown }
+  | { type: 'handoff'; from_agent?: string; to_agent?: string }
+  | { type: 'custom'; name: string; data: Record<string, unknown> }
+  | { type: 'guardrail'; name: string; triggered: boolean }
+  | { type: 'transcription'; input?: unknown; output?: string; model?: string }
+  | { type: 'speech'; input?: string; output?: unknown; model?: string }
+  | { type: 'speech_group'; input?: string }
+  | { type: 'mcp_tools'; server?: string; result?: string[] };
+
+export interface OATrace {
+  type: 'trace';
+  traceId: string;
+  name?: string; // optional — SDK may omit it
+}
+
+export interface OASpan {
+  type: 'trace.span';
+  spanId: string;
+  traceId: string;
+  parentId?: string | null;
+  spanData: OASpanData;
+  startedAt?: string | null;
+  endedAt?: string | null;
+  error?: { message: string } | null;
+}
+
+const SPAN_KIND: Record<OASpanData['type'], string> = {
+  agent: 'AGENT',
+  function: 'TOOL',
+  generation: 'LLM',
+  response: 'LLM',
+  handoff: 'AGENT',
+  custom: 'CHAIN',
+  guardrail: 'CHAIN',
+  transcription: 'LLM',
+  speech: 'LLM',
+  speech_group: 'CHAIN',
+  mcp_tools: 'TOOL',
+};
+
+export function getSpanName(data: OASpanData): string {
+  switch (data.type) {
+    case 'agent':
+      return data.name;
+    case 'function':
+      return data.name;
+    case 'generation':
+      return data.model ? `generation [${data.model}]` : 'generation';
+    case 'response':
+      return 'response';
+    case 'handoff':
+      return data.to_agent ? `handoff -> ${data.to_agent}` : 'handoff';
+    case 'custom':
+      return data.name;
+    case 'guardrail':
+      return data.name;
+    case 'transcription':
+      return 'transcription';
+    case 'speech':
+      return 'speech';
+    case 'speech_group':
+      return 'speech_group';
+    case 'mcp_tools':
+      return data.server ? `mcp_tools [${data.server}]` : 'mcp_tools';
+  }
+}
+
+export function getSpanAttributes(data: OASpanData): Record<string, string | number | boolean> {
+  const attrs: Record<string, string | number | boolean> = {
+    'openinference.span.kind': SPAN_KIND[data.type],
+  };
+  switch (data.type) {
+    case 'agent':
+      attrs['agent.name'] = data.name;
+      if (data.tools?.length) attrs['input.value'] = JSON.stringify({ tools: data.tools });
+      break;
+    case 'function':
+      attrs['tool.name'] = data.name;
+      if (data.input) attrs['input.value'] = data.input;
+      if (data.output) attrs['output.value'] = data.output;
+      break;
+    case 'generation':
+      if (data.model) attrs['llm.model_name'] = data.model;
+      if (data.input != null) attrs['input.value'] = JSON.stringify(data.input);
+      if (data.output != null) attrs['output.value'] = JSON.stringify(data.output);
+      if (data.usage?.input_tokens != null)
+        attrs['llm.token_count.prompt'] = data.usage.input_tokens;
+      if (data.usage?.output_tokens != null)
+        attrs['llm.token_count.completion'] = data.usage.output_tokens;
+      break;
+    case 'response': {
+      const r = data._response as Record<string, unknown> | undefined;
+      if (r?.model) attrs['llm.model_name'] = r.model as string;
+      const usage = r?.usage as Record<string, number> | undefined;
+      if (usage?.input_tokens != null) attrs['llm.token_count.prompt'] = usage.input_tokens;
+      if (usage?.output_tokens != null) attrs['llm.token_count.completion'] = usage.output_tokens;
+      if (data._input != null)
+        attrs['input.value'] =
+          typeof data._input === 'string' ? data._input : JSON.stringify(data._input);
+      if (r?.output != null) attrs['output.value'] = JSON.stringify(r.output);
+      break;
+    }
+    case 'handoff':
+      if (data.from_agent) attrs['agent.name'] = data.from_agent;
+      if (data.to_agent)
+        attrs['traceroot.span.metadata'] = JSON.stringify({ to_agent: data.to_agent });
+      break;
+    case 'custom':
+      if (data.data) attrs['input.value'] = JSON.stringify(data.data);
+      break;
+    case 'guardrail':
+      attrs['traceroot.span.metadata'] = JSON.stringify({ triggered: data.triggered });
+      break;
+    case 'transcription':
+      if (data.model) attrs['llm.model_name'] = data.model;
+      if (data.output) attrs['output.value'] = data.output;
+      break;
+    case 'speech':
+      if (data.model) attrs['llm.model_name'] = data.model;
+      if (data.input) attrs['input.value'] = data.input;
+      break;
+    case 'speech_group':
+      if (data.input) attrs['input.value'] = data.input;
+      break;
+    case 'mcp_tools':
+      if (data.server) attrs['tool.name'] = data.server;
+      if (data.result) attrs['output.value'] = JSON.stringify(data.result);
+      break;
+  }
+  return attrs;
+}
+
+export class TraceRootTracingProcessor {
+  private static readonly MAX_SPANS = 2000;
+  private readonly spanMap = new Map<string, OTelSpan>();
+  private readonly ctxMap = new Map<string, Context>();
+  private get tracer() {
+    return trace.getTracer('@traceroot-ai/openai-agents');
+  }
+
+  async onTraceStart(t: OATrace): Promise<void> {
+    if (this.spanMap.size >= TraceRootTracingProcessor.MAX_SPANS) return;
+    const span = this.tracer.startSpan(t.name ?? 'Agent workflow', {
+      attributes: { 'openinference.span.kind': 'CHAIN' },
+    });
+    this.spanMap.set(t.traceId, span);
+    this.ctxMap.set(t.traceId, trace.setSpan(context.active(), span));
+  }
+
+  async onTraceEnd(t: OATrace): Promise<void> {
+    this.spanMap.get(t.traceId)?.end();
+    this.spanMap.delete(t.traceId);
+    this.ctxMap.delete(t.traceId);
+  }
+
+  async onSpanStart(s: OASpan): Promise<void> {
+    if (this.spanMap.size >= TraceRootTracingProcessor.MAX_SPANS) return;
+    const parentCtx =
+      (s.parentId != null && this.ctxMap.get(s.parentId)) ||
+      this.ctxMap.get(s.traceId) ||
+      context.active();
+    const otelSpan = this.tracer.startSpan(getSpanName(s.spanData), {}, parentCtx);
+    this.spanMap.set(s.spanId, otelSpan);
+    this.ctxMap.set(s.spanId, trace.setSpan(parentCtx, otelSpan));
+  }
+
+  async onSpanEnd(s: OASpan): Promise<void> {
+    const otelSpan = this.spanMap.get(s.spanId);
+    if (otelSpan) {
+      const attrs = getSpanAttributes(s.spanData);
+      for (const [k, v] of Object.entries(attrs)) otelSpan.setAttribute(k, v);
+      if (s.error) otelSpan.setStatus({ code: SpanStatusCode.ERROR, message: s.error.message });
+      otelSpan.end(s.endedAt ? new Date(s.endedAt) : undefined);
+    }
+    this.spanMap.delete(s.spanId);
+    this.ctxMap.delete(s.spanId);
+  }
+
+  async shutdown(): Promise<void> {}
+  async forceFlush(): Promise<void> {}
+}
+
+export function wireOpenAIAgentsProcessor(mod: unknown): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const provider = (mod as any).getGlobalTraceProvider?.();
+  if (!provider) {
+    throw new Error(
+      '[TraceRoot] instrumentModules.openaiAgents does not expose getGlobalTraceProvider. Check your @openai/agents version (>=0.0.1 required).',
+    );
+  }
+  if (typeof provider.registerProcessor !== 'function') {
+    throw new Error(
+      '[TraceRoot] provider.registerProcessor is not a function. Check your @openai/agents version (>=0.0.1 required).',
+    );
+  }
+  provider.registerProcessor(new TraceRootTracingProcessor());
+}

--- a/packages/traceroot/src/types.ts
+++ b/packages/traceroot/src/types.ts
@@ -54,6 +54,7 @@ export interface InitializeOptions {
     langchain?: unknown;
     claudeAgentSDK?: unknown;
     bedrock?: unknown;
+    openaiAgents?: unknown; // @openai/agents module ref (ESM — pass `import * as x from '@openai/agents'`)
   };
   /** Use SimpleSpanProcessor instead of BatchSpanProcessor. Useful for scripts/tests. */
   disableBatch?: boolean;

--- a/packages/traceroot/tests/openai-agents.test.ts
+++ b/packages/traceroot/tests/openai-agents.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, afterEach, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { context, propagation, trace } from '@opentelemetry/api';
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import {
+  getSpanName,
+  getSpanAttributes,
+  TraceRootTracingProcessor,
+  wireOpenAIAgentsProcessor,
+} from '../src/openai-agents';
+import type { OASpanData } from '../src/openai-agents';
+
+describe('getSpanName()', () => {
+  it('agent → agent name', () => {
+    assert.equal(
+      getSpanName({ type: 'agent', name: 'SupportAgent', tools: [], handoffs: [] }),
+      'SupportAgent',
+    );
+  });
+  it('function → function name', () => {
+    assert.equal(
+      getSpanName({ type: 'function', name: 'search', input: '', output: '' }),
+      'search',
+    );
+  });
+  it('generation with model', () => {
+    assert.equal(getSpanName({ type: 'generation', model: 'gpt-4o' }), 'generation [gpt-4o]');
+  });
+  it('generation without model', () => {
+    assert.equal(getSpanName({ type: 'generation' }), 'generation');
+  });
+  it('response', () => {
+    assert.equal(getSpanName({ type: 'response' }), 'response');
+  });
+  it('handoff with to_agent', () => {
+    assert.equal(
+      getSpanName({ type: 'handoff', to_agent: 'BillingAgent' }),
+      'handoff -> BillingAgent',
+    );
+  });
+  it('handoff without to_agent', () => {
+    assert.equal(getSpanName({ type: 'handoff' }), 'handoff');
+  });
+  it('custom → custom name', () => {
+    assert.equal(getSpanName({ type: 'custom', name: 'my-step', data: {} }), 'my-step');
+  });
+  it('guardrail → guardrail name', () => {
+    assert.equal(
+      getSpanName({ type: 'guardrail', name: 'safety-check', triggered: false }),
+      'safety-check',
+    );
+  });
+  it('mcp_tools with server', () => {
+    assert.equal(getSpanName({ type: 'mcp_tools', server: 'files' }), 'mcp_tools [files]');
+  });
+  it('mcp_tools without server', () => {
+    assert.equal(getSpanName({ type: 'mcp_tools' }), 'mcp_tools');
+  });
+});
+
+describe('getSpanAttributes()', () => {
+  it('all types set openinference.span.kind', () => {
+    const cases: Array<[OASpanData, string]> = [
+      [{ type: 'agent', name: 'x', tools: [], handoffs: [] }, 'AGENT'],
+      [{ type: 'function', name: 'x', input: '', output: '' }, 'TOOL'],
+      [{ type: 'generation' }, 'LLM'],
+      [{ type: 'response' }, 'LLM'],
+      [{ type: 'handoff' }, 'AGENT'],
+      [{ type: 'custom', name: 'x', data: {} }, 'CHAIN'],
+      [{ type: 'guardrail', name: 'x', triggered: false }, 'CHAIN'],
+      [{ type: 'transcription' }, 'LLM'],
+      [{ type: 'speech' }, 'LLM'],
+      [{ type: 'speech_group' }, 'CHAIN'],
+      [{ type: 'mcp_tools' }, 'TOOL'],
+    ];
+    for (const [data, kind] of cases) {
+      assert.equal(
+        getSpanAttributes(data)['openinference.span.kind'],
+        kind,
+        `wrong kind for ${data.type}`,
+      );
+    }
+  });
+
+  it('function: sets tool.name, input.value, output.value', () => {
+    const attrs = getSpanAttributes({
+      type: 'function',
+      name: 'search',
+      input: '{"q":"hi"}',
+      output: '{"r":1}',
+    });
+    assert.equal(attrs['tool.name'], 'search');
+    assert.equal(attrs['input.value'], '{"q":"hi"}');
+    assert.equal(attrs['output.value'], '{"r":1}');
+  });
+
+  it('generation: sets llm.model_name and token counts', () => {
+    const attrs = getSpanAttributes({
+      type: 'generation',
+      model: 'gpt-4o',
+      input: [{ role: 'user', content: 'hi' }],
+      output: [{ role: 'assistant', content: 'hello' }],
+      usage: { input_tokens: 10, output_tokens: 20 },
+    });
+    assert.equal(attrs['llm.model_name'], 'gpt-4o');
+    assert.equal(attrs['llm.token_count.prompt'], 10);
+    assert.equal(attrs['llm.token_count.completion'], 20);
+    assert.ok(attrs['input.value']);
+    assert.ok(attrs['output.value']);
+  });
+
+  it('generation: omits token counts when usage absent', () => {
+    const attrs = getSpanAttributes({ type: 'generation' });
+    assert.equal(attrs['llm.token_count.prompt'], undefined);
+    assert.equal(attrs['llm.token_count.completion'], undefined);
+  });
+
+  it('agent: sets agent.name', () => {
+    const attrs = getSpanAttributes({
+      type: 'agent',
+      name: 'SupportAgent',
+      tools: ['search'],
+      handoffs: [],
+    });
+    assert.equal(attrs['agent.name'], 'SupportAgent');
+  });
+
+  it('handoff: sets agent.name and metadata with to_agent', () => {
+    const attrs = getSpanAttributes({ type: 'handoff', from_agent: 'A', to_agent: 'B' });
+    assert.equal(attrs['agent.name'], 'A');
+    assert.deepEqual(JSON.parse(attrs['traceroot.span.metadata'] as string), { to_agent: 'B' });
+  });
+
+  it('guardrail: sets metadata with triggered', () => {
+    const attrs = getSpanAttributes({ type: 'guardrail', name: 'safety', triggered: true });
+    assert.deepEqual(JSON.parse(attrs['traceroot.span.metadata'] as string), { triggered: true });
+  });
+
+  it('mcp_tools: sets tool.name and output.value', () => {
+    const attrs = getSpanAttributes({
+      type: 'mcp_tools',
+      server: 'files',
+      result: ['read', 'write'],
+    });
+    assert.equal(attrs['tool.name'], 'files');
+    assert.deepEqual(JSON.parse(attrs['output.value'] as string), ['read', 'write']);
+  });
+
+  it('response: extracts model and tokens from _response', () => {
+    const attrs = getSpanAttributes({
+      type: 'response',
+      _response: { model: 'gpt-4o', usage: { input_tokens: 5, output_tokens: 15 } },
+    });
+    assert.equal(attrs['llm.model_name'], 'gpt-4o');
+    assert.equal(attrs['llm.token_count.prompt'], 5);
+    assert.equal(attrs['llm.token_count.completion'], 15);
+  });
+
+  it('response: sets output.value from _response.output', () => {
+    const attrs = getSpanAttributes({
+      type: 'response',
+      _response: { output: [{ role: 'assistant', content: 'hi' }] },
+    });
+    assert.ok(attrs['output.value']);
+    assert.deepEqual(JSON.parse(attrs['output.value'] as string), [
+      { role: 'assistant', content: 'hi' },
+    ]);
+  });
+});
+
+describe('TraceRootTracingProcessor', () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+  let processor: TraceRootTracingProcessor;
+
+  const mockTrace = { type: 'trace' as const, traceId: 'trace_abc', name: 'Test Workflow' };
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider();
+    provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+    provider.register();
+    processor = new TraceRootTracingProcessor();
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+    exporter.reset();
+    trace.disable();
+    context.disable();
+    propagation.disable();
+  });
+
+  it('onTraceStart/End creates a root CHAIN span with the trace name', async () => {
+    await processor.onTraceStart(mockTrace);
+    await processor.onTraceEnd(mockTrace);
+
+    const spans = exporter.getFinishedSpans();
+    assert.equal(spans.length, 1);
+    assert.equal(spans[0].name, 'Test Workflow');
+    assert.equal(spans[0].attributes['openinference.span.kind'], 'CHAIN');
+  });
+
+  it('onSpanEnd creates a span with attributes set', async () => {
+    const s = {
+      type: 'trace.span' as const,
+      spanId: 'span_001',
+      traceId: 'trace_abc',
+      parentId: null,
+      spanData: {
+        type: 'function' as const,
+        name: 'search',
+        input: '{"q":"hello"}',
+        output: '{"r":1}',
+      },
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      error: null,
+    };
+
+    await processor.onTraceStart(mockTrace);
+    await processor.onSpanStart(s);
+    await processor.onSpanEnd(s);
+    await processor.onTraceEnd(mockTrace);
+
+    const spans = exporter.getFinishedSpans();
+    const toolSpan = spans.find((s) => s.name === 'search')!;
+    assert.ok(toolSpan, 'tool span not found');
+    assert.equal(toolSpan.attributes['tool.name'], 'search');
+    assert.equal(toolSpan.attributes['input.value'], '{"q":"hello"}');
+    assert.equal(toolSpan.attributes['output.value'], '{"r":1}');
+  });
+
+  it('child span parentId is resolved to the correct parent OTel span (3 levels)', async () => {
+    const agentSpan = {
+      type: 'trace.span' as const,
+      spanId: 'span_agent',
+      traceId: 'trace_abc',
+      parentId: null,
+      spanData: { type: 'agent' as const, name: 'SupportAgent', tools: [], handoffs: [] },
+      startedAt: new Date().toISOString(),
+      endedAt: null as string | null,
+      error: null,
+    };
+    const toolSpan = {
+      type: 'trace.span' as const,
+      spanId: 'span_tool',
+      traceId: 'trace_abc',
+      parentId: 'span_agent',
+      spanData: { type: 'function' as const, name: 'search', input: '{}', output: '{}' },
+      startedAt: new Date().toISOString(),
+      endedAt: null as string | null,
+      error: null,
+    };
+    const genSpan = {
+      type: 'trace.span' as const,
+      spanId: 'span_gen',
+      traceId: 'trace_abc',
+      parentId: 'span_tool',
+      spanData: { type: 'generation' as const, model: 'gpt-4o' },
+      startedAt: new Date().toISOString(),
+      endedAt: null as string | null,
+      error: null,
+    };
+
+    await processor.onTraceStart(mockTrace);
+    await processor.onSpanStart(agentSpan);
+    await processor.onSpanStart(toolSpan);
+    await processor.onSpanStart(genSpan);
+    await processor.onSpanEnd({ ...genSpan, endedAt: new Date().toISOString() });
+    await processor.onSpanEnd({ ...toolSpan, endedAt: new Date().toISOString() });
+    await processor.onSpanEnd({ ...agentSpan, endedAt: new Date().toISOString() });
+    await processor.onTraceEnd(mockTrace);
+
+    const spans = exporter.getFinishedSpans();
+    assert.equal(spans.length, 4); // root + agent + tool + generation
+
+    const root = spans.find((s) => s.name === 'Test Workflow')!;
+    const agent = spans.find((s) => s.name === 'SupportAgent')!;
+    const tool = spans.find((s) => s.name === 'search')!;
+    const gen = spans.find((s) => s.name === 'generation [gpt-4o]')!;
+
+    assert.ok(root, 'root span missing');
+    assert.ok(agent, 'agent span missing');
+    assert.ok(tool, 'tool span missing');
+    assert.ok(gen, 'generation span missing');
+
+    // True 3-level nesting: gen → tool → agent → root
+    assert.equal(gen.parentSpanId, tool.spanContext().spanId);
+    assert.equal(tool.parentSpanId, agent.spanContext().spanId);
+    assert.equal(agent.parentSpanId, root.spanContext().spanId);
+  });
+
+  it('span with no parentId is parented to the trace root', async () => {
+    const s = {
+      type: 'trace.span' as const,
+      spanId: 'span_orphan',
+      traceId: 'trace_abc',
+      parentId: null,
+      spanData: { type: 'custom' as const, name: 'step', data: {} },
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      error: null,
+    };
+
+    await processor.onTraceStart(mockTrace);
+    await processor.onSpanStart(s);
+    await processor.onSpanEnd(s);
+    await processor.onTraceEnd(mockTrace);
+
+    const root = exporter.getFinishedSpans().find((sp) => sp.name === 'Test Workflow')!;
+    const step = exporter.getFinishedSpans().find((sp) => sp.name === 'step')!;
+    assert.ok(root, 'root missing');
+    assert.ok(step, 'step missing');
+    assert.equal(step.parentSpanId, root.spanContext().spanId);
+  });
+
+  it('sets SpanStatusCode.ERROR when span has an error', async () => {
+    const s = {
+      type: 'trace.span' as const,
+      spanId: 'span_err',
+      traceId: 'trace_abc',
+      parentId: null,
+      spanData: { type: 'function' as const, name: 'fail', input: '', output: '' },
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      error: { message: 'tool exploded' },
+    };
+
+    await processor.onTraceStart(mockTrace);
+    await processor.onSpanStart(s);
+    await processor.onSpanEnd(s);
+    await processor.onTraceEnd(mockTrace);
+
+    const errSpan = exporter.getFinishedSpans().find((sp) => sp.name === 'fail')!;
+    assert.ok(errSpan, 'error span missing');
+    assert.equal(errSpan.status.code, 2 /* SpanStatusCode.ERROR */);
+    assert.equal(errSpan.status.message, 'tool exploded');
+  });
+
+  it('cleans up internal maps after onSpanEnd and onTraceEnd', async () => {
+    const s = {
+      type: 'trace.span' as const,
+      spanId: 'span_cleanup',
+      traceId: 'trace_abc',
+      parentId: null,
+      spanData: { type: 'custom' as const, name: 'x', data: {} },
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      error: null,
+    };
+
+    await processor.onTraceStart(mockTrace);
+    await processor.onSpanStart(s);
+    // spanMap holds both the trace-root entry (keyed by traceId) and child span entries
+    // (keyed by spanId) in the same map — so after onTraceStart + onSpanStart: size = 2
+    assert.equal((processor as any).spanMap.size, 2);
+    await processor.onSpanEnd(s);
+    assert.equal((processor as any).spanMap.size, 1); // only trace root
+    await processor.onTraceEnd(mockTrace);
+    assert.equal((processor as any).spanMap.size, 0);
+  });
+});
+
+describe('wireOpenAIAgentsProcessor()', () => {
+  it('calls registerProcessor on the module provider with a TraceRootTracingProcessor', () => {
+    let registered: unknown;
+    const mockModule = {
+      getGlobalTraceProvider: () => ({
+        registerProcessor: (p: unknown) => {
+          registered = p;
+        },
+      }),
+    };
+
+    wireOpenAIAgentsProcessor(mockModule);
+    assert.ok(registered instanceof TraceRootTracingProcessor);
+  });
+
+  it('throws if module does not expose getGlobalTraceProvider', () => {
+    assert.throws(() => wireOpenAIAgentsProcessor({}), /getGlobalTraceProvider/);
+  });
+
+  it('throws if provider.registerProcessor is not a function', () => {
+    assert.throws(
+      () =>
+        wireOpenAIAgentsProcessor({
+          getGlobalTraceProvider: () => ({ registerProcessor: 'not-a-function' }),
+        }),
+      /registerProcessor/,
+    );
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/traceroot-ai/traceroot/issues/713

## Summary

- Adds `TraceRootTracingProcessor` — a `TracingProcessor` that bridges the `@openai/agents` SDK's trace/span lifecycle into OTel spans with openinference semantic attributes
- Wires it into the existing `instrumentModules` option via a new `openaiAgents` key (optional peer dep)
- Full unit test suite covering all span types, nesting, error propagation, and map cleanup

## Usage

```ts
import { initialize } from '@traceroot-ai/traceroot';
import * as agents from '@openai/agents';

initialize({
  instrumentModules: { openaiAgents: agents },
});
```

## What's left before merging

- [ ] README / docs update
- [ ] Version bump
- [ ] Manual smoke test against a real `@openai/agents` workflow

## Test plan

- [x] All span types set correct `openinference.span.kind`
- [x] 3-level parent→child nesting verified
- [x] Error status propagation verified
- [x] Internal map cleanup after end verified
- [x] `wireOpenAIAgentsProcessor` error paths covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)