### PR TITLE
feat: add @openai/agents tracing support + bump to 0.1.3

### DIFF
--- a/packages/traceroot/package.json
+++ b/packages/traceroot/package.json
@@ -70,13 +70,17 @@
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": ">=0.20.0",
-    "openai": ">=6.0.0"
+    "openai": ">=6.0.0",
+    "@openai/agents": ">=0.0.1"
   },
   "peerDependenciesMeta": {
     "openai": {
       "optional": true
     },
     "@anthropic-ai/sdk": {
+      "optional": true
+    },
+    "@openai/agents": {
       "optional": true
     }
   }

--- a/packages/traceroot/package.json
+++ b/packages/traceroot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traceroot-ai/traceroot",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "TraceRoot TypeScript SDK for AI observability",
   "keywords": [
     "traceroot",

--- a/packages/traceroot/package.json
+++ b/packages/traceroot/package.json
@@ -60,6 +60,7 @@
   "devDependencies": {
     "@eslint/js": "^9.0.0",
     "@langchain/core": "^1.1.39",
+    "@openai/agents": ">=0.0.1",
     "@types/node": "^20.0.0",
     "anthropic": "^0.0.0",
     "eslint": "^9.0.0",

--- a/packages/traceroot/src/index.ts
+++ b/packages/traceroot/src/index.ts
@@ -11,3 +11,4 @@ export { usingAttributes } from './usingAttributes';
 export { SpanAttributes } from './constants';
 export type { SpanType, ObserveOptions, InitializeOptions } from './types';
 export type { UsingAttributesOptions } from './usingAttributes';
+export { TraceRootTracingProcessor } from './openai-agents';

--- a/packages/traceroot/src/index.ts
+++ b/packages/traceroot/src/index.ts
@@ -11,4 +11,4 @@ export { usingAttributes } from './usingAttributes';
 export { SpanAttributes } from './constants';
 export type { SpanType, ObserveOptions, InitializeOptions } from './types';
 export type { UsingAttributesOptions } from './usingAttributes';
-export { TraceRootTracingProcessor } from './openai-agents';
+export { OpenAIAgentsProcessor } from './openai-agents';

--- a/packages/traceroot/src/instrumentation.ts
+++ b/packages/traceroot/src/instrumentation.ts
@@ -6,6 +6,7 @@ import { ClaudeAgentSDKInstrumentation } from '@arizeai/openinference-instrument
 import { LangChainInstrumentation } from '@arizeai/openinference-instrumentation-langchain';
 import { OpenAIInstrumentation } from '@arizeai/openinference-instrumentation-openai';
 import { InitializeOptions } from './types';
+import { wireOpenAIAgentsProcessor } from './openai-agents';
 
 /**
  * Wires OpenInference instrumentations based on the instrumentModules option:
@@ -67,6 +68,9 @@ export function wireInstrumentations(
     const instr = new BedrockInstrumentation();
     instrs.push(instr);
     instr.manuallyInstrument(instrumentModules.bedrock as any);
+  }
+  if (instrumentModules.openaiAgents) {
+    wireOpenAIAgentsProcessor(instrumentModules.openaiAgents);
   }
 
   if (instrs.length > 0) {

--- a/packages/traceroot/src/instrumentation.ts
+++ b/packages/traceroot/src/instrumentation.ts
@@ -70,7 +70,11 @@ export function wireInstrumentations(
     instr.manuallyInstrument(instrumentModules.bedrock as any);
   }
   if (instrumentModules.openaiAgents) {
-    wireOpenAIAgentsProcessor(instrumentModules.openaiAgents);
+    try {
+      wireOpenAIAgentsProcessor(instrumentModules.openaiAgents);
+    } catch (e) {
+      console.warn('[TraceRoot] Failed to wire @openai/agents processor:', (e as Error).message);
+    }
   }
 
   if (instrs.length > 0) {

--- a/packages/traceroot/src/instrumentation.ts
+++ b/packages/traceroot/src/instrumentation.ts
@@ -70,11 +70,7 @@ export function wireInstrumentations(
     instr.manuallyInstrument(instrumentModules.bedrock as any);
   }
   if (instrumentModules.openaiAgents) {
-    try {
-      wireOpenAIAgentsProcessor(instrumentModules.openaiAgents);
-    } catch (e) {
-      console.warn('[TraceRoot] Failed to wire @openai/agents processor:', (e as Error).message);
-    }
+    wireOpenAIAgentsProcessor(instrumentModules.openaiAgents);
   }
 
   if (instrs.length > 0) {

--- a/packages/traceroot/src/openai-agents.ts
+++ b/packages/traceroot/src/openai-agents.ts
@@ -90,8 +90,8 @@ export function getSpanAttributes(data: OASpanData): Record<string, string | num
       break;
     case 'function':
       attrs['tool.name'] = data.name;
-      if (data.input) attrs['input.value'] = data.input;
-      if (data.output) attrs['output.value'] = data.output;
+      if (data.input != null) attrs['input.value'] = data.input;
+      if (data.output != null) attrs['output.value'] = data.output;
       break;
     case 'generation':
       if (data.model) attrs['llm.model_name'] = data.model;

--- a/packages/traceroot/src/openai-agents.ts
+++ b/packages/traceroot/src/openai-agents.ts
@@ -1,0 +1,211 @@
+import { context, SpanStatusCode, trace } from '@opentelemetry/api';
+import type { Context, Span as OTelSpan } from '@opentelemetry/api';
+
+// Minimal type mirrors for @openai/agents shapes — no runtime import needed.
+export type OASpanData =
+  | { type: 'agent'; name: string; tools?: string[]; handoffs?: string[]; output_type?: string }
+  | { type: 'function'; name: string; input: string; output: string; mcp_data?: string }
+  | {
+      type: 'generation';
+      model?: string;
+      input?: unknown[];
+      output?: unknown[];
+      usage?: { input_tokens?: number; output_tokens?: number };
+    }
+  | { type: 'response'; response_id?: string; _input?: unknown; _response?: unknown }
+  | { type: 'handoff'; from_agent?: string; to_agent?: string }
+  | { type: 'custom'; name: string; data: Record<string, unknown> }
+  | { type: 'guardrail'; name: string; triggered: boolean }
+  | { type: 'transcription'; input?: unknown; output?: string; model?: string }
+  | { type: 'speech'; input?: string; output?: unknown; model?: string }
+  | { type: 'speech_group'; input?: string }
+  | { type: 'mcp_tools'; server?: string; result?: string[] };
+
+export interface OATrace {
+  type: 'trace';
+  traceId: string;
+  name?: string; // optional — SDK may omit it
+}
+
+export interface OASpan {
+  type: 'trace.span';
+  spanId: string;
+  traceId: string;
+  parentId?: string | null;
+  spanData: OASpanData;
+  startedAt?: string | null;
+  endedAt?: string | null;
+  error?: { message: string } | null;
+}
+
+const SPAN_KIND: Record<OASpanData['type'], string> = {
+  agent: 'AGENT',
+  function: 'TOOL',
+  generation: 'LLM',
+  response: 'LLM',
+  handoff: 'AGENT',
+  custom: 'CHAIN',
+  guardrail: 'CHAIN',
+  transcription: 'LLM',
+  speech: 'LLM',
+  speech_group: 'CHAIN',
+  mcp_tools: 'TOOL',
+};
+
+export function getSpanName(data: OASpanData): string {
+  switch (data.type) {
+    case 'agent':
+      return data.name;
+    case 'function':
+      return data.name;
+    case 'generation':
+      return data.model ? `generation [${data.model}]` : 'generation';
+    case 'response':
+      return 'response';
+    case 'handoff':
+      return data.to_agent ? `handoff -> ${data.to_agent}` : 'handoff';
+    case 'custom':
+      return data.name;
+    case 'guardrail':
+      return data.name;
+    case 'transcription':
+      return 'transcription';
+    case 'speech':
+      return 'speech';
+    case 'speech_group':
+      return 'speech_group';
+    case 'mcp_tools':
+      return data.server ? `mcp_tools [${data.server}]` : 'mcp_tools';
+  }
+}
+
+export function getSpanAttributes(data: OASpanData): Record<string, string | number | boolean> {
+  const attrs: Record<string, string | number | boolean> = {
+    'openinference.span.kind': SPAN_KIND[data.type],
+  };
+  switch (data.type) {
+    case 'agent':
+      attrs['agent.name'] = data.name;
+      if (data.tools?.length) attrs['input.value'] = JSON.stringify({ tools: data.tools });
+      break;
+    case 'function':
+      attrs['tool.name'] = data.name;
+      if (data.input) attrs['input.value'] = data.input;
+      if (data.output) attrs['output.value'] = data.output;
+      break;
+    case 'generation':
+      if (data.model) attrs['llm.model_name'] = data.model;
+      if (data.input != null) attrs['input.value'] = JSON.stringify(data.input);
+      if (data.output != null) attrs['output.value'] = JSON.stringify(data.output);
+      if (data.usage?.input_tokens != null)
+        attrs['llm.token_count.prompt'] = data.usage.input_tokens;
+      if (data.usage?.output_tokens != null)
+        attrs['llm.token_count.completion'] = data.usage.output_tokens;
+      break;
+    case 'response': {
+      const r = data._response as Record<string, unknown> | undefined;
+      if (r?.model) attrs['llm.model_name'] = r.model as string;
+      const usage = r?.usage as Record<string, number> | undefined;
+      if (usage?.input_tokens != null) attrs['llm.token_count.prompt'] = usage.input_tokens;
+      if (usage?.output_tokens != null) attrs['llm.token_count.completion'] = usage.output_tokens;
+      if (data._input != null)
+        attrs['input.value'] =
+          typeof data._input === 'string' ? data._input : JSON.stringify(data._input);
+      if (r?.output != null) attrs['output.value'] = JSON.stringify(r.output);
+      break;
+    }
+    case 'handoff':
+      if (data.from_agent) attrs['agent.name'] = data.from_agent;
+      if (data.to_agent)
+        attrs['traceroot.span.metadata'] = JSON.stringify({ to_agent: data.to_agent });
+      break;
+    case 'custom':
+      if (data.data) attrs['input.value'] = JSON.stringify(data.data);
+      break;
+    case 'guardrail':
+      attrs['traceroot.span.metadata'] = JSON.stringify({ triggered: data.triggered });
+      break;
+    case 'transcription':
+      if (data.model) attrs['llm.model_name'] = data.model;
+      if (data.output) attrs['output.value'] = data.output;
+      break;
+    case 'speech':
+      if (data.model) attrs['llm.model_name'] = data.model;
+      if (data.input) attrs['input.value'] = data.input;
+      break;
+    case 'speech_group':
+      if (data.input) attrs['input.value'] = data.input;
+      break;
+    case 'mcp_tools':
+      if (data.server) attrs['tool.name'] = data.server;
+      if (data.result) attrs['output.value'] = JSON.stringify(data.result);
+      break;
+  }
+  return attrs;
+}
+
+export class TraceRootTracingProcessor {
+  private static readonly MAX_SPANS = 2000;
+  private readonly spanMap = new Map<string, OTelSpan>();
+  private readonly ctxMap = new Map<string, Context>();
+  private get tracer() {
+    return trace.getTracer('@traceroot-ai/openai-agents');
+  }
+
+  async onTraceStart(t: OATrace): Promise<void> {
+    if (this.spanMap.size >= TraceRootTracingProcessor.MAX_SPANS) return;
+    const span = this.tracer.startSpan(t.name ?? 'Agent workflow', {
+      attributes: { 'openinference.span.kind': 'CHAIN' },
+    });
+    this.spanMap.set(t.traceId, span);
+    this.ctxMap.set(t.traceId, trace.setSpan(context.active(), span));
+  }
+
+  async onTraceEnd(t: OATrace): Promise<void> {
+    this.spanMap.get(t.traceId)?.end();
+    this.spanMap.delete(t.traceId);
+    this.ctxMap.delete(t.traceId);
+  }
+
+  async onSpanStart(s: OASpan): Promise<void> {
+    if (this.spanMap.size >= TraceRootTracingProcessor.MAX_SPANS) return;
+    const parentCtx =
+      (s.parentId != null && this.ctxMap.get(s.parentId)) ||
+      this.ctxMap.get(s.traceId) ||
+      context.active();
+    const otelSpan = this.tracer.startSpan(getSpanName(s.spanData), {}, parentCtx);
+    this.spanMap.set(s.spanId, otelSpan);
+    this.ctxMap.set(s.spanId, trace.setSpan(parentCtx, otelSpan));
+  }
+
+  async onSpanEnd(s: OASpan): Promise<void> {
+    const otelSpan = this.spanMap.get(s.spanId);
+    if (otelSpan) {
+      const attrs = getSpanAttributes(s.spanData);
+      for (const [k, v] of Object.entries(attrs)) otelSpan.setAttribute(k, v);
+      if (s.error) otelSpan.setStatus({ code: SpanStatusCode.ERROR, message: s.error.message });
+      otelSpan.end(s.endedAt ? new Date(s.endedAt) : undefined);
+    }
+    this.spanMap.delete(s.spanId);
+    this.ctxMap.delete(s.spanId);
+  }
+
+  async shutdown(): Promise<void> {}
+  async forceFlush(): Promise<void> {}
+}
+
+export function wireOpenAIAgentsProcessor(mod: unknown): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const provider = (mod as any).getGlobalTraceProvider?.();
+  if (!provider) {
+    throw new Error(
+      '[TraceRoot] instrumentModules.openaiAgents does not expose getGlobalTraceProvider. Check your @openai/agents version (>=0.0.1 required).',
+    );
+  }
+  if (typeof provider.registerProcessor !== 'function') {
+    throw new Error(
+      '[TraceRoot] provider.registerProcessor is not a function. Check your @openai/agents version (>=0.0.1 required).',
+    );
+  }
+  provider.registerProcessor(new TraceRootTracingProcessor());
+}

--- a/packages/traceroot/src/openai-agents.ts
+++ b/packages/traceroot/src/openai-agents.ts
@@ -173,7 +173,11 @@ export class TraceRootTracingProcessor {
       (s.parentId != null && this.ctxMap.get(s.parentId)) ||
       this.ctxMap.get(s.traceId) ||
       context.active();
-    const otelSpan = this.tracer.startSpan(getSpanName(s.spanData), {}, parentCtx);
+    const otelSpan = this.tracer.startSpan(
+      getSpanName(s.spanData),
+      { startTime: s.startedAt ? new Date(s.startedAt) : undefined },
+      parentCtx,
+    );
     this.spanMap.set(s.spanId, otelSpan);
     this.ctxMap.set(s.spanId, trace.setSpan(parentCtx, otelSpan));
   }

--- a/packages/traceroot/src/openai-agents.ts
+++ b/packages/traceroot/src/openai-agents.ts
@@ -1,44 +1,30 @@
 import { context, SpanStatusCode, trace } from '@opentelemetry/api';
 import type { Context, Span as OTelSpan } from '@opentelemetry/api';
+import type { SpanData } from '@openai/agents';
 
-// Minimal type mirrors for @openai/agents shapes — no runtime import needed.
-export type OASpanData =
-  | { type: 'agent'; name: string; tools?: string[]; handoffs?: string[]; output_type?: string }
-  | { type: 'function'; name: string; input: string; output: string; mcp_data?: string }
-  | {
-      type: 'generation';
-      model?: string;
-      input?: unknown[];
-      output?: unknown[];
-      usage?: { input_tokens?: number; output_tokens?: number };
-    }
-  | { type: 'response'; response_id?: string; _input?: unknown; _response?: unknown }
-  | { type: 'handoff'; from_agent?: string; to_agent?: string }
-  | { type: 'custom'; name: string; data: Record<string, unknown> }
-  | { type: 'guardrail'; name: string; triggered: boolean }
-  | { type: 'transcription'; input?: unknown; output?: string; model?: string }
-  | { type: 'speech'; input?: string; output?: unknown; model?: string }
-  | { type: 'speech_group'; input?: string }
-  | { type: 'mcp_tools'; server?: string; result?: string[] };
-
-export interface OATrace {
-  type: 'trace';
-  traceId: string;
-  name?: string; // optional — SDK may omit it
-}
-
-export interface OASpan {
+// Structural mirrors of the public read-surface of @openai/agents `Span` and `Trace`.
+// We can't use the SDK class types directly because they hold their state in
+// ECMAScript `#private` fields, which makes plain object fixtures (used in tests)
+// unassignable to them. The runtime objects we receive from the SDK satisfy these
+// shapes via public getters.
+export interface OpenAIAgentsSpan {
   type: 'trace.span';
   spanId: string;
   traceId: string;
   parentId?: string | null;
-  spanData: OASpanData;
+  spanData: SpanData;
   startedAt?: string | null;
   endedAt?: string | null;
   error?: { message: string } | null;
 }
 
-const SPAN_KIND: Record<OASpanData['type'], string> = {
+export interface OpenAIAgentsTrace {
+  type?: 'trace';
+  traceId: string;
+  name?: string;
+}
+
+const SPAN_KIND: Record<SpanData['type'], string> = {
   agent: 'AGENT',
   function: 'TOOL',
   generation: 'LLM',
@@ -52,7 +38,7 @@ const SPAN_KIND: Record<OASpanData['type'], string> = {
   mcp_tools: 'TOOL',
 };
 
-export function getSpanName(data: OASpanData): string {
+export function getSpanName(data: SpanData): string {
   switch (data.type) {
     case 'agent':
       return data.name;
@@ -79,7 +65,7 @@ export function getSpanName(data: OASpanData): string {
   }
 }
 
-export function getSpanAttributes(data: OASpanData): Record<string, string | number | boolean> {
+export function getSpanAttributes(data: SpanData): Record<string, string | number | boolean> {
   const attrs: Record<string, string | number | boolean> = {
     'openinference.span.kind': SPAN_KIND[data.type],
   };
@@ -144,16 +130,12 @@ export function getSpanAttributes(data: OASpanData): Record<string, string | num
   return attrs;
 }
 
-export class TraceRootTracingProcessor {
-  private static readonly MAX_SPANS = 2000;
+export class OpenAIAgentsProcessor {
   private readonly spanMap = new Map<string, OTelSpan>();
   private readonly ctxMap = new Map<string, Context>();
-  private get tracer() {
-    return trace.getTracer('@traceroot-ai/openai-agents');
-  }
+  private readonly tracer = trace.getTracer('@traceroot-ai/openai-agents');
 
-  async onTraceStart(t: OATrace): Promise<void> {
-    if (this.spanMap.size >= TraceRootTracingProcessor.MAX_SPANS) return;
+  async onTraceStart(t: OpenAIAgentsTrace): Promise<void> {
     const span = this.tracer.startSpan(t.name ?? 'Agent workflow', {
       attributes: { 'openinference.span.kind': 'CHAIN' },
     });
@@ -161,14 +143,13 @@ export class TraceRootTracingProcessor {
     this.ctxMap.set(t.traceId, trace.setSpan(context.active(), span));
   }
 
-  async onTraceEnd(t: OATrace): Promise<void> {
+  async onTraceEnd(t: OpenAIAgentsTrace): Promise<void> {
     this.spanMap.get(t.traceId)?.end();
     this.spanMap.delete(t.traceId);
     this.ctxMap.delete(t.traceId);
   }
 
-  async onSpanStart(s: OASpan): Promise<void> {
-    if (this.spanMap.size >= TraceRootTracingProcessor.MAX_SPANS) return;
+  async onSpanStart(s: OpenAIAgentsSpan): Promise<void> {
     const parentCtx =
       (s.parentId != null && this.ctxMap.get(s.parentId)) ||
       this.ctxMap.get(s.traceId) ||
@@ -182,7 +163,7 @@ export class TraceRootTracingProcessor {
     this.ctxMap.set(s.spanId, trace.setSpan(parentCtx, otelSpan));
   }
 
-  async onSpanEnd(s: OASpan): Promise<void> {
+  async onSpanEnd(s: OpenAIAgentsSpan): Promise<void> {
     const otelSpan = this.spanMap.get(s.spanId);
     if (otelSpan) {
       const attrs = getSpanAttributes(s.spanData);
@@ -198,18 +179,24 @@ export class TraceRootTracingProcessor {
   async forceFlush(): Promise<void> {}
 }
 
+/**
+ * Replaces @openai/agents' default tracing processors with TraceRoot's.
+ *
+ * The SDK's umbrella package eagerly registers an OpenAI-hosted exporter at
+ * import time (sends spans to api.openai.com). Calling `setTraceProcessors`
+ * here replaces that default — spans go to TraceRoot only.
+ *
+ * To dual-export (e.g. ship to both TraceRoot *and* OpenAI), call
+ * `addTraceProcessor(otherProcessor)` from `@openai/agents` after `initialize()`.
+ */
 export function wireOpenAIAgentsProcessor(mod: unknown): void {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const provider = (mod as any).getGlobalTraceProvider?.();
-  if (!provider) {
+  const setTraceProcessors = (mod as any)?.setTraceProcessors;
+  if (typeof setTraceProcessors !== 'function') {
     throw new Error(
-      '[TraceRoot] instrumentModules.openaiAgents does not expose getGlobalTraceProvider. Check your @openai/agents version (>=0.0.1 required).',
+      '[TraceRoot] instrumentModules.openaiAgents does not expose setTraceProcessors. ' +
+        'Pass `import * as agents from "@openai/agents"` (the module namespace, not a sub-export).',
     );
   }
-  if (typeof provider.registerProcessor !== 'function') {
-    throw new Error(
-      '[TraceRoot] provider.registerProcessor is not a function. Check your @openai/agents version (>=0.0.1 required).',
-    );
-  }
-  provider.registerProcessor(new TraceRootTracingProcessor());
+  setTraceProcessors([new OpenAIAgentsProcessor()]);
 }

--- a/packages/traceroot/src/types.ts
+++ b/packages/traceroot/src/types.ts
@@ -54,6 +54,7 @@ export interface InitializeOptions {
     langchain?: unknown;
     claudeAgentSDK?: unknown;
     bedrock?: unknown;
+    openaiAgents?: unknown; // @openai/agents module ref (ESM — pass `import * as x from '@openai/agents'`)
   };
   /** Use SimpleSpanProcessor instead of BatchSpanProcessor. Useful for scripts/tests. */
   disableBatch?: boolean;

--- a/packages/traceroot/src/types.ts
+++ b/packages/traceroot/src/types.ts
@@ -54,7 +54,15 @@ export interface InitializeOptions {
     langchain?: unknown;
     claudeAgentSDK?: unknown;
     bedrock?: unknown;
-    openaiAgents?: unknown; // @openai/agents module ref (ESM — pass `import * as x from '@openai/agents'`)
+    /**
+     * @openai/agents module ref. Pass `import * as agents from '@openai/agents'`.
+     *
+     * Replaces the SDK's default OpenAI tracing processor with TraceRoot's —
+     * spans go to TraceRoot only, NOT to OpenAI's tracing backend.
+     * To dual-export, call `addTraceProcessor(...)` from `@openai/agents`
+     * after `initialize()`.
+     */
+    openaiAgents?: unknown;
   };
   /** Use SimpleSpanProcessor instead of BatchSpanProcessor. Useful for scripts/tests. */
   disableBatch?: boolean;

--- a/packages/traceroot/tests/openai-agents.test.ts
+++ b/packages/traceroot/tests/openai-agents.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, afterEach, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { context, propagation, trace } from '@opentelemetry/api';
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import {
+  getSpanName,
+  getSpanAttributes,
+  TraceRootTracingProcessor,
+  wireOpenAIAgentsProcessor,
+} from '../src/openai-agents';
+import type { OASpanData } from '../src/openai-agents';
+
+describe('getSpanName()', () => {
+  it('agent → agent name', () => {
+    assert.equal(
+      getSpanName({ type: 'agent', name: 'SupportAgent', tools: [], handoffs: [] }),
+      'SupportAgent',
+    );
+  });
+  it('function → function name', () => {
+    assert.equal(
+      getSpanName({ type: 'function', name: 'search', input: '', output: '' }),
+      'search',
+    );
+  });
+  it('generation with model', () => {
+    assert.equal(getSpanName({ type: 'generation', model: 'gpt-4o' }), 'generation [gpt-4o]');
+  });
+  it('generation without model', () => {
+    assert.equal(getSpanName({ type: 'generation' }), 'generation');
+  });
+  it('response', () => {
+    assert.equal(getSpanName({ type: 'response' }), 'response');
+  });
+  it('handoff with to_agent', () => {
+    assert.equal(
+      getSpanName({ type: 'handoff', to_agent: 'BillingAgent' }),
+      'handoff -> BillingAgent',
+    );
+  });
+  it('handoff without to_agent', () => {
+    assert.equal(getSpanName({ type: 'handoff' }), 'handoff');
+  });
+  it('custom → custom name', () => {
+    assert.equal(getSpanName({ type: 'custom', name: 'my-step', data: {} }), 'my-step');
+  });
+  it('guardrail → guardrail name', () => {
+    assert.equal(
+      getSpanName({ type: 'guardrail', name: 'safety-check', triggered: false }),
+      'safety-check',
+    );
+  });
+  it('mcp_tools with server', () => {
+    assert.equal(getSpanName({ type: 'mcp_tools', server: 'files' }), 'mcp_tools [files]');
+  });
+  it('mcp_tools without server', () => {
+    assert.equal(getSpanName({ type: 'mcp_tools' }), 'mcp_tools');
+  });
+});
+
+describe('getSpanAttributes()', () => {
+  it('all types set openinference.span.kind', () => {
+    const cases: Array<[OASpanData, string]> = [
+      [{ type: 'agent', name: 'x', tools: [], handoffs: [] }, 'AGENT'],
+      [{ type: 'function', name: 'x', input: '', output: '' }, 'TOOL'],
+      [{ type: 'generation' }, 'LLM'],
+      [{ type: 'response' }, 'LLM'],
+      [{ type: 'handoff' }, 'AGENT'],
+      [{ type: 'custom', name: 'x', data: {} }, 'CHAIN'],
+      [{ type: 'guardrail', name: 'x', triggered: false }, 'CHAIN'],
+      [{ type: 'transcription' }, 'LLM'],
+      [{ type: 'speech' }, 'LLM'],
+      [{ type: 'speech_group' }, 'CHAIN'],
+      [{ type: 'mcp_tools' }, 'TOOL'],
+    ];
+    for (const [data, kind] of cases) {
+      assert.equal(
+        getSpanAttributes(data)['openinference.span.kind'],
+        kind,
+        `wrong kind for ${data.type}`,
+      );
+    }
+  });
+
+  it('function: sets tool.name, input.value, output.value', () => {
+    const attrs = getSpanAttributes({
+      type: 'function',
+      name: 'search',
+      input: '{"q":"hi"}',
+      output: '{"r":1}',
+    });
+    assert.equal(attrs['tool.name'], 'search');
+    assert.equal(attrs['input.value'], '{"q":"hi"}');
+    assert.equal(attrs['output.value'], '{"r":1}');
+  });
+
+  it('generation: sets llm.model_name and token counts', () => {
+    const attrs = getSpanAttributes({
+      type: 'generation',
+      model: 'gpt-4o',
+      input: [{ role: 'user', content: 'hi' }],
+      output: [{ role: 'assistant', content: 'hello' }],
+      usage: { input_tokens: 10, output_tokens: 20 },
+    });
+    assert.equal(attrs['llm.model_name'], 'gpt-4o');
+    assert.equal(attrs['llm.token_count.prompt'], 10);
+    assert.equal(attrs['llm.token_count.completion'], 20);
+    assert.ok(attrs['input.value']);
+    assert.ok(attrs['output.value']);
+  });
+
+  it('generation: omits token counts when usage absent', () => {
+    const attrs = getSpanAttributes({ type: 'generation' });
+    assert.equal(attrs['llm.token_count.prompt'], undefined);
+    assert.equal(attrs['llm.token_count.completion'], undefined);
+  });
+
+  it('agent: sets agent.name', () => {
+    const attrs = getSpanAttributes({
+      type: 'agent',
+      name: 'SupportAgent',
+      tools: ['search'],
+      handoffs: [],
+    });
+    assert.equal(attrs['agent.name'], 'SupportAgent');
+  });
+
+  it('handoff: sets agent.name and metadata with to_agent', () => {
+    const attrs = getSpanAttributes({ type: 'handoff', from_agent: 'A', to_agent: 'B' });
+    assert.equal(attrs['agent.name'], 'A');
+    assert.deepEqual(JSON.parse(attrs['traceroot.span.metadata'] as string), { to_agent: 'B' });
+  });
+
+  it('guardrail: sets metadata with triggered', () => {
+    const attrs = getSpanAttributes({ type: 'guardrail', name: 'safety', triggered: true });
+    assert.deepEqual(JSON.parse(attrs['traceroot.span.metadata'] as string), { triggered: true });
+  });
+
+  it('mcp_tools: sets tool.name and output.value', () => {
+    const attrs = getSpanAttributes({
+      type: 'mcp_tools',
+      server: 'files',
+      result: ['read', 'write'],
+    });
+    assert.equal(attrs['tool.name'], 'files');
+    assert.deepEqual(JSON.parse(attrs['output.value'] as string), ['read', 'write']);
+  });
+
+  it('response: extracts model and tokens from _response', () => {
+    const attrs = getSpanAttributes({
+      type: 'response',
+      _response: { model: 'gpt-4o', usage: { input_tokens: 5, output_tokens: 15 } },
+    });
+    assert.equal(attrs['llm.model_name'], 'gpt-4o');
+    assert.equal(attrs['llm.token_count.prompt'], 5);
+    assert.equal(attrs['llm.token_count.completion'], 15);
+  });
+
+  it('response: sets output.value from _response.output', () => {
+    const attrs = getSpanAttributes({
+      type: 'response',
+      _response: { output: [{ role: 'assistant', content: 'hi' }] },
+    });
+    assert.ok(attrs['output.value']);
+    assert.deepEqual(JSON.parse(attrs['output.value'] as string), [
+      { role: 'assistant', content: 'hi' },
+    ]);
+  });
+});
+
+describe('TraceRootTracingProcessor', () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+  let processor: TraceRootTracingProcessor;
+
+  const mockTrace = { type: 'trace' as const, traceId: 'trace_abc', name: 'Test Workflow' };
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider();
+    provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+    provider.register();
+    processor = new TraceRootTracingProcessor();
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+    exporter.reset();
+    trace.disable();
+    context.disable();
+    propagation.disable();
+  });
+
+  it('onTraceStart/End creates a root CHAIN span with the trace name', async () => {
+    await processor.onTraceStart(mockTrace);
+    await processor.onTraceEnd(mockTrace);
+
+    const spans = exporter.getFinishedSpans();
+    assert.equal(spans.length, 1);
+    assert.equal(spans[0].name, 'Test Workflow');
+    assert.equal(spans[0].attributes['openinference.span.kind'], 'CHAIN');
+  });
+
+  it('onSpanEnd creates a span with attributes set', async () => {
+    const s = {
+      type: 'trace.span' as const,
+      spanId: 'span_001',
+      traceId: 'trace_abc',
+      parentId: null,
+      spanData: {
+        type: 'function' as const,
+        name: 'search',
+        input: '{"q":"hello"}',
+        output: '{"r":1}',
+      },
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      error: null,
+    };
+
+    await processor.onTraceStart(mockTrace);
+    await processor.onSpanStart(s);
+    await processor.onSpanEnd(s);
+    await processor.onTraceEnd(mockTrace);
+
+    const spans = exporter.getFinishedSpans();
+    const toolSpan = spans.find((s) => s.name === 'search')!;
+    assert.ok(toolSpan, 'tool span not found');
+    assert.equal(toolSpan.attributes['tool.name'], 'search');
+    assert.equal(toolSpan.attributes['input.value'], '{"q":"hello"}');
+    assert.equal(toolSpan.attributes['output.value'], '{"r":1}');
+  });
+
+  it('child span parentId is resolved to the correct parent OTel span (3 levels)', async () => {
+    const agentSpan = {
+      type: 'trace.span' as const,
+      spanId: 'span_agent',
+      traceId: 'trace_abc',
+      parentId: null,
+      spanData: { type: 'agent' as const, name: 'SupportAgent', tools: [], handoffs: [] },
+      startedAt: new Date().toISOString(),
+      endedAt: null as string | null,
+      error: null,
+    };
+    const toolSpan = {
+      type: 'trace.span' as const,
+      spanId: 'span_tool',
+      traceId: 'trace_abc',
+      parentId: 'span_agent',
+      spanData: { type: 'function' as const, name: 'search', input: '{}', output: '{}' },
+      startedAt: new Date().toISOString(),
+      endedAt: null as string | null,
+      error: null,
+    };
+    const genSpan = {
+      type: 'trace.span' as const,
+      spanId: 'span_gen',
+      traceId: 'trace_abc',
+      parentId: 'span_tool',
+      spanData: { type: 'generation' as const, model: 'gpt-4o' },
+      startedAt: new Date().toISOString(),
+      endedAt: null as string | null,
+      error: null,
+    };
+
+    await processor.onTraceStart(mockTrace);
+    await processor.onSpanStart(agentSpan);
+    await processor.onSpanStart(toolSpan);
+    await processor.onSpanStart(genSpan);
+    await processor.onSpanEnd({ ...genSpan, endedAt: new Date().toISOString() });
+    await processor.onSpanEnd({ ...toolSpan, endedAt: new Date().toISOString() });
+    await processor.onSpanEnd({ ...agentSpan, endedAt: new Date().toISOString() });
+    await processor.onTraceEnd(mockTrace);
+
+    const spans = exporter.getFinishedSpans();
+    assert.equal(spans.length, 4); // root + agent + tool + generation
+
+    const root = spans.find((s) => s.name === 'Test Workflow')!;
+    const agent = spans.find((s) => s.name === 'SupportAgent')!;
+    const tool = spans.find((s) => s.name === 'search')!;
+    const gen = spans.find((s) => s.name === 'generation [gpt-4o]')!;
+
+    assert.ok(root, 'root span missing');
+    assert.ok(agent, 'agent span missing');
+    assert.ok(tool, 'tool span missing');
+    assert.ok(gen, 'generation span missing');
+
+    // True 3-level nesting: gen → tool → agent → root
+    assert.equal(gen.parentSpanId, tool.spanContext().spanId);
+    assert.equal(tool.parentSpanId, agent.spanContext().spanId);
+    assert.equal(agent.parentSpanId, root.spanContext().spanId);
+  });
+
+  it('span with no parentId is parented to the trace root', async () => {
+    const s = {
+      type: 'trace.span' as const,
+      spanId: 'span_orphan',
+      traceId: 'trace_abc',
+      parentId: null,
+      spanData: { type: 'custom' as const, name: 'step', data: {} },
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      error: null,
+    };
+
+    await processor.onTraceStart(mockTrace);
+    await processor.onSpanStart(s);
+    await processor.onSpanEnd(s);
+    await processor.onTraceEnd(mockTrace);
+
+    const root = exporter.getFinishedSpans().find((sp) => sp.name === 'Test Workflow')!;
+    const step = exporter.getFinishedSpans().find((sp) => sp.name === 'step')!;
+    assert.ok(root, 'root missing');
+    assert.ok(step, 'step missing');
+    assert.equal(step.parentSpanId, root.spanContext().spanId);
+  });
+
+  it('sets SpanStatusCode.ERROR when span has an error', async () => {
+    const s = {
+      type: 'trace.span' as const,
+      spanId: 'span_err',
+      traceId: 'trace_abc',
+      parentId: null,
+      spanData: { type: 'function' as const, name: 'fail', input: '', output: '' },
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      error: { message: 'tool exploded' },
+    };
+
+    await processor.onTraceStart(mockTrace);
+    await processor.onSpanStart(s);
+    await processor.onSpanEnd(s);
+    await processor.onTraceEnd(mockTrace);
+
+    const errSpan = exporter.getFinishedSpans().find((sp) => sp.name === 'fail')!;
+    assert.ok(errSpan, 'error span missing');
+    assert.equal(errSpan.status.code, 2 /* SpanStatusCode.ERROR */);
+    assert.equal(errSpan.status.message, 'tool exploded');
+  });
+
+  it('cleans up internal maps after onSpanEnd and onTraceEnd', async () => {
+    const s = {
+      type: 'trace.span' as const,
+      spanId: 'span_cleanup',
+      traceId: 'trace_abc',
+      parentId: null,
+      spanData: { type: 'custom' as const, name: 'x', data: {} },
+      startedAt: new Date().toISOString(),
+      endedAt: new Date().toISOString(),
+      error: null,
+    };
+
+    await processor.onTraceStart(mockTrace);
+    await processor.onSpanStart(s);
+    // spanMap holds both the trace-root entry (keyed by traceId) and child span entries
+    // (keyed by spanId) in the same map — so after onTraceStart + onSpanStart: size = 2
+    assert.equal((processor as any).spanMap.size, 2);
+    await processor.onSpanEnd(s);
+    assert.equal((processor as any).spanMap.size, 1); // only trace root
+    await processor.onTraceEnd(mockTrace);
+    assert.equal((processor as any).spanMap.size, 0);
+  });
+});
+
+describe('wireOpenAIAgentsProcessor()', () => {
+  it('calls registerProcessor on the module provider with a TraceRootTracingProcessor', () => {
+    let registered: unknown;
+    const mockModule = {
+      getGlobalTraceProvider: () => ({
+        registerProcessor: (p: unknown) => {
+          registered = p;
+        },
+      }),
+    };
+
+    wireOpenAIAgentsProcessor(mockModule);
+    assert.ok(registered instanceof TraceRootTracingProcessor);
+  });
+
+  it('throws if module does not expose getGlobalTraceProvider', () => {
+    assert.throws(() => wireOpenAIAgentsProcessor({}), /getGlobalTraceProvider/);
+  });
+
+  it('throws if provider.registerProcessor is not a function', () => {
+    assert.throws(
+      () =>
+        wireOpenAIAgentsProcessor({
+          getGlobalTraceProvider: () => ({ registerProcessor: 'not-a-function' }),
+        }),
+      /registerProcessor/,
+    );
+  });
+});

--- a/packages/traceroot/tests/openai-agents.test.ts
+++ b/packages/traceroot/tests/openai-agents.test.ts
@@ -6,10 +6,10 @@ import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import {
   getSpanName,
   getSpanAttributes,
-  TraceRootTracingProcessor,
+  OpenAIAgentsProcessor,
   wireOpenAIAgentsProcessor,
 } from '../src/openai-agents';
-import type { OASpanData } from '../src/openai-agents';
+import type { SpanData } from '@openai/agents';
 
 describe('getSpanName()', () => {
   it('agent → agent name', () => {
@@ -61,7 +61,7 @@ describe('getSpanName()', () => {
 
 describe('getSpanAttributes()', () => {
   it('all types set openinference.span.kind', () => {
-    const cases: Array<[OASpanData, string]> = [
+    const cases: Array<[SpanData, string]> = [
       [{ type: 'agent', name: 'x', tools: [], handoffs: [] }, 'AGENT'],
       [{ type: 'function', name: 'x', input: '', output: '' }, 'TOOL'],
       [{ type: 'generation' }, 'LLM'],
@@ -169,10 +169,10 @@ describe('getSpanAttributes()', () => {
   });
 });
 
-describe('TraceRootTracingProcessor', () => {
+describe('OpenAIAgentsProcessor', () => {
   let exporter: InMemorySpanExporter;
   let provider: NodeTracerProvider;
-  let processor: TraceRootTracingProcessor;
+  let processor: OpenAIAgentsProcessor;
 
   const mockTrace = { type: 'trace' as const, traceId: 'trace_abc', name: 'Test Workflow' };
 
@@ -181,7 +181,7 @@ describe('TraceRootTracingProcessor', () => {
     provider = new NodeTracerProvider();
     provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
     provider.register();
-    processor = new TraceRootTracingProcessor();
+    processor = new OpenAIAgentsProcessor();
   });
 
   afterEach(async () => {
@@ -364,31 +364,28 @@ describe('TraceRootTracingProcessor', () => {
 });
 
 describe('wireOpenAIAgentsProcessor()', () => {
-  it('calls registerProcessor on the module provider with a TraceRootTracingProcessor', () => {
-    let registered: unknown;
+  it('calls setTraceProcessors with a single OpenAIAgentsProcessor (replace mode)', () => {
+    let registered: unknown[] | undefined;
     const mockModule = {
-      getGlobalTraceProvider: () => ({
-        registerProcessor: (p: unknown) => {
-          registered = p;
-        },
-      }),
+      setTraceProcessors: (procs: unknown[]) => {
+        registered = procs;
+      },
     };
 
     wireOpenAIAgentsProcessor(mockModule);
-    assert.ok(registered instanceof TraceRootTracingProcessor);
+    assert.ok(Array.isArray(registered), 'setTraceProcessors not called');
+    assert.equal(registered!.length, 1);
+    assert.ok(registered![0] instanceof OpenAIAgentsProcessor);
   });
 
-  it('throws if module does not expose getGlobalTraceProvider', () => {
-    assert.throws(() => wireOpenAIAgentsProcessor({}), /getGlobalTraceProvider/);
+  it('throws if module does not expose setTraceProcessors', () => {
+    assert.throws(() => wireOpenAIAgentsProcessor({}), /setTraceProcessors/);
   });
 
-  it('throws if provider.registerProcessor is not a function', () => {
+  it('throws if setTraceProcessors is not a function', () => {
     assert.throws(
-      () =>
-        wireOpenAIAgentsProcessor({
-          getGlobalTraceProvider: () => ({ registerProcessor: 'not-a-function' }),
-        }),
-      /registerProcessor/,
+      () => wireOpenAIAgentsProcessor({ setTraceProcessors: 'not-a-function' }),
+      /setTraceProcessors/,
     );
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       '@arizeai/openinference-semantic-conventions':
         specifier: ^2.1.7
         version: 2.1.7
+      '@openai/agents':
+        specifier: '>=0.0.1'
+        version: 0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.3.6)
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -624,6 +627,29 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@openai/agents-core@0.8.5':
+    resolution: {integrity: sha512-qs9mmN+D+UmqEZo3qrvhhIIXIOgSvJPic0v4a+ruq+eYgcQMk3PY8lLcsdQwJit6zf2Wyfv1q2cX5m3jzWZpKw==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@openai/agents-openai@0.8.5':
+    resolution: {integrity: sha512-cGYmyiVy8ecgf2Vch0L/ekeNo3xuZsuWnRsxyv+w9ai9dgxUifdEQ6G3dtsjMLtmXVHRVGoO7mVBr+tKcilntw==}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@openai/agents-realtime@0.8.5':
+    resolution: {integrity: sha512-JqKVsR33OvKtTxRp5Ylhw8WfNvJ49ZIhlhMZlSVKqwR2Ks6JuxqFJ0zM9p7JIbTQDSlAZnmnZJv1qlItaildiQ==}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@openai/agents@0.8.5':
+    resolution: {integrity: sha512-OFA7XVV1qXE8lzatvQj080KdSArt8utBExFXRfD5B/R7KT0D+AVaKwg6nLoW3Gxb30vRkIUQf+MaW/Wz+gO3Yg==}
+    peerDependencies:
+      zod: ^4.0.0
+
   '@opentelemetry/api-logs@0.57.2':
     resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
     engines: {node: '>=14'}
@@ -1074,6 +1100,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.58.0':
     resolution: {integrity: sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==}
@@ -3322,6 +3351,57 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@openai/agents-core@0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.3.6)':
+    dependencies:
+      debug: 4.4.3
+      openai: 6.33.0(ws@8.20.0)(zod@4.3.6)
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - ws
+
+  '@openai/agents-openai@0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.3.6)':
+    dependencies:
+      '@openai/agents-core': 0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.3.6)
+      debug: 4.4.3
+      openai: 6.33.0(ws@8.20.0)(zod@4.3.6)
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - ws
+
+  '@openai/agents-realtime@0.8.5(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
+    dependencies:
+      '@openai/agents-core': 0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.3.6)
+      '@types/ws': 8.18.1
+      debug: 4.4.3
+      ws: 8.20.0
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@openai/agents@0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.3.6)':
+    dependencies:
+      '@openai/agents-core': 0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.3.6)
+      '@openai/agents-openai': 0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.3.6)
+      '@openai/agents-realtime': 0.8.5(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      debug: 4.4.3
+      openai: 6.33.0(ws@8.20.0)(zod@4.3.6)
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+
   '@opentelemetry/api-logs@0.57.2':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -3849,6 +3929,10 @@ snapshots:
   '@types/shimmer@1.2.0': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.37
 
   '@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,9 +92,6 @@ importers:
       '@arizeai/openinference-semantic-conventions':
         specifier: ^2.1.7
         version: 2.1.7
-      '@openai/agents':
-        specifier: '>=0.0.1'
-        version: 0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.3.6)
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -123,6 +120,9 @@ importers:
       '@langchain/core':
         specifier: ^1.1.39
         version: 1.1.39(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@openai/agents':
+        specifier: '>=0.0.1'
+        version: 0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.3.6)
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.37


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                       
                                                            
  - `TraceRootTracingProcessor` — bridges `@openai/agents` SDK trace lifecycle to OTel spans with openinference semantic attributes                                                                                                
  - Supports all 11 span types: agent, function, generation, response, handoff, custom, guardrail, transcription, speech, speech_group, mcp_tools
  - `wireOpenAIAgentsProcessor()` registers via `instrumentModules: { openaiAgents }`                                                                                                                                              
  - Bump version to 0.1.3                                                                                                                                                                                                          
  - Based on traceroot-ai/traceroot-ts#76  
  
 Fixes traceroot-ai/traceroot#713    

## Screenshot
<img width="3316" height="1726" alt="image" src="https://github.com/user-attachments/assets/2b62ec92-9482-474a-9002-abe9ab069416" />
<img width="3302" height="1626" alt="image" src="https://github.com/user-attachments/assets/f3bf7015-7153-4b7e-ad7c-e5d04f690c76" />
<img width="3312" height="1702" alt="image" src="https://github.com/user-attachments/assets/318c25d3-7c44-4d43-a5a4-61dda3f4635e" />
