### PR TITLE
feat(sdk): add Groq TypeScript instrumentation and tests

### DIFF
--- a/packages/traceroot/package.json
+++ b/packages/traceroot/package.json
@@ -70,10 +70,14 @@
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": ">=0.20.0",
+    "groq-sdk": ">=1.0.0",
     "openai": ">=6.0.0"
   },
   "peerDependenciesMeta": {
     "openai": {
+      "optional": true
+    },
+    "groq-sdk": {
       "optional": true
     },
     "@anthropic-ai/sdk": {

--- a/packages/traceroot/src/groq_instrumentation.ts
+++ b/packages/traceroot/src/groq_instrumentation.ts
@@ -1,0 +1,200 @@
+import { SpanStatusCode, trace } from '@opentelemetry/api';
+import {
+  InstrumentationBase,
+  InstrumentationNodeModuleDefinition,
+  InstrumentationNodeModuleFile,
+} from '@opentelemetry/instrumentation';
+
+const SPAN_KIND_ATTR = 'openinference.span.kind';
+const INPUT_VALUE_ATTR = 'input.value';
+const OUTPUT_VALUE_ATTR = 'output.value';
+const MODEL_NAME_ATTR = 'llm.model_name';
+const PROMPT_TOKENS_ATTR = 'llm.token_count.prompt';
+const COMPLETION_TOKENS_ATTR = 'llm.token_count.completion';
+
+type GroqModuleLike = {
+  Groq?: { prototype?: Record<string, unknown> };
+  default?: { prototype?: Record<string, unknown> };
+};
+
+type ChatRequestBody = {
+  model?: string;
+  messages?: Array<Record<string, unknown>>;
+};
+
+type CompletionUsage = {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+};
+
+type ChatCompletionResponse = {
+  model?: string;
+  usage?: CompletionUsage;
+  choices?: Array<{
+    message?: {
+      content?: unknown;
+    };
+  }>;
+};
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function toStringContent(content: unknown): string | undefined {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    const parts = content
+      .map((item) => {
+        if (typeof item === 'string') return item;
+        if (
+          item &&
+          typeof item === 'object' &&
+          'type' in item &&
+          'text' in item &&
+          (item as { type?: string }).type === 'text'
+        ) {
+          return String((item as { text: unknown }).text);
+        }
+        return '';
+      })
+      .filter(Boolean);
+    return parts.length > 0 ? parts.join('\n') : undefined;
+  }
+  if (content == null) return undefined;
+  return String(content);
+}
+
+function extractInputValue(body: ChatRequestBody | undefined): string | undefined {
+  if (!body?.messages || body.messages.length === 0) return undefined;
+
+  const userMessages = body.messages
+    .filter((m) => m.role === 'user')
+    .map((m) => toStringContent(m.content))
+    .filter((v): v is string => Boolean(v));
+
+  if (userMessages.length > 0) {
+    return userMessages.join('\n');
+  }
+
+  return safeJson(body.messages);
+}
+
+function extractOutputValue(response: ChatCompletionResponse | undefined): string | undefined {
+  const content = response?.choices?.[0]?.message?.content;
+  return toStringContent(content);
+}
+
+export class GroqInstrumentation extends InstrumentationBase {
+  private patchedPrototype: Record<string, unknown> | null = null;
+
+  constructor() {
+    super('@traceroot-ai/traceroot-groq-instrumentation', '0.1.0');
+  }
+
+  init() {
+    return [
+      new InstrumentationNodeModuleDefinition<GroqModuleLike>(
+        'groq-sdk',
+        ['*'],
+        (moduleExports) => this.patch(moduleExports ?? {}),
+        (moduleExports) => this.unpatch(moduleExports ?? {}),
+        [
+          new InstrumentationNodeModuleFile<GroqModuleLike>(
+            'client.js',
+            ['*'],
+            (moduleExports) => this.patch(moduleExports ?? {}),
+            (moduleExports) => this.unpatch(moduleExports ?? {}),
+          ),
+        ],
+      ),
+    ];
+  }
+
+  manuallyInstrument(moduleExports: unknown): void {
+    this.patch(moduleExports as GroqModuleLike);
+  }
+
+  private patch(moduleExports: GroqModuleLike): GroqModuleLike {
+    const GroqCtor = moduleExports?.Groq ?? moduleExports?.default;
+    const proto = GroqCtor?.prototype;
+    if (!proto || typeof proto['post'] !== 'function') {
+      return moduleExports;
+    }
+    if (this.patchedPrototype === proto) {
+      return moduleExports;
+    }
+
+    this._wrap(proto, 'post', (original) => {
+      const originalPost = original as (...args: unknown[]) => Promise<unknown>;
+      return function wrappedPost(this: unknown, ...args: unknown[]): Promise<unknown> {
+        const path = args[0];
+        const opts = args[1] as { body?: ChatRequestBody } | undefined;
+
+        if (path !== '/openai/v1/chat/completions') {
+          return originalPost.apply(this, args);
+        }
+
+        return trace
+          .getTracer('traceroot-groq-instrumentation')
+          .startActiveSpan('groq.chat.completions.create', async (span) => {
+            span.setAttribute(SPAN_KIND_ATTR, 'LLM');
+
+            const model = opts?.body?.model;
+            if (model) span.setAttribute(MODEL_NAME_ATTR, model);
+
+            const inputValue = extractInputValue(opts?.body);
+            if (inputValue) span.setAttribute(INPUT_VALUE_ATTR, inputValue);
+
+            try {
+              const response = (await originalPost.apply(this, args)) as ChatCompletionResponse;
+
+              const responseModel = response?.model;
+              if (responseModel) span.setAttribute(MODEL_NAME_ATTR, responseModel);
+
+              const promptTokens = response?.usage?.prompt_tokens;
+              if (typeof promptTokens === 'number') {
+                span.setAttribute(PROMPT_TOKENS_ATTR, promptTokens);
+              }
+
+              const completionTokens = response?.usage?.completion_tokens;
+              if (typeof completionTokens === 'number') {
+                span.setAttribute(COMPLETION_TOKENS_ATTR, completionTokens);
+              }
+
+              const outputValue = extractOutputValue(response);
+              if (outputValue) span.setAttribute(OUTPUT_VALUE_ATTR, outputValue);
+
+              return response as unknown;
+            } catch (error) {
+              span.recordException(error as Error);
+              span.setStatus({ code: SpanStatusCode.ERROR, message: String(error) });
+              throw error;
+            } finally {
+              span.end();
+            }
+          });
+      };
+    });
+
+    this.patchedPrototype = proto;
+    return moduleExports;
+  }
+
+  private unpatch(moduleExports: GroqModuleLike): GroqModuleLike {
+    const GroqCtor = moduleExports?.Groq ?? moduleExports?.default;
+    const proto = GroqCtor?.prototype;
+    if (!proto || typeof proto['post'] !== 'function') {
+      return moduleExports;
+    }
+    this._unwrap(proto, 'post');
+    if (this.patchedPrototype === proto) {
+      this.patchedPrototype = null;
+    }
+    return moduleExports;
+  }
+}

--- a/packages/traceroot/src/groq_instrumentation.ts
+++ b/packages/traceroot/src/groq_instrumentation.ts
@@ -19,7 +19,7 @@ type GroqModuleLike = {
 
 type ChatRequestBody = {
   model?: string;
-  messages?: Array<Record<string, unknown>>;
+  messages?: unknown;
 };
 
 type CompletionUsage = {
@@ -70,9 +70,14 @@ function toStringContent(content: unknown): string | undefined {
 }
 
 function extractInputValue(body: ChatRequestBody | undefined): string | undefined {
-  if (!body?.messages || body.messages.length === 0) return undefined;
+  if (!body?.messages || !Array.isArray(body.messages) || body.messages.length === 0)
+    return undefined;
 
   const userMessages = body.messages
+    .filter(
+      (m): m is { role?: unknown; content?: unknown } =>
+        Boolean(m) && typeof m === 'object' && 'role' in m,
+    )
     .filter((m) => m.role === 'user')
     .map((m) => toStringContent(m.content))
     .filter((v): v is string => Boolean(v));

--- a/packages/traceroot/src/instrumentation.ts
+++ b/packages/traceroot/src/instrumentation.ts
@@ -6,6 +6,7 @@ import { ClaudeAgentSDKInstrumentation } from '@arizeai/openinference-instrument
 import { LangChainInstrumentation } from '@arizeai/openinference-instrumentation-langchain';
 import { OpenAIInstrumentation } from '@arizeai/openinference-instrumentation-openai';
 import { InitializeOptions } from './types';
+import { GroqInstrumentation } from './groq_instrumentation';
 
 /**
  * Wires OpenInference instrumentations based on the instrumentModules option:
@@ -29,6 +30,7 @@ export function wireInstrumentations(
         new LangChainInstrumentation(),
         new ClaudeAgentSDKInstrumentation(),
         new BedrockInstrumentation(),
+        new GroqInstrumentation(),
       ],
     });
     return;
@@ -40,6 +42,7 @@ export function wireInstrumentations(
     | typeof LangChainInstrumentation
     | typeof ClaudeAgentSDKInstrumentation
     | typeof BedrockInstrumentation
+    | typeof GroqInstrumentation
   >[] = [];
 
   if (instrumentModules.openAI) {
@@ -67,6 +70,11 @@ export function wireInstrumentations(
     const instr = new BedrockInstrumentation();
     instrs.push(instr);
     instr.manuallyInstrument(instrumentModules.bedrock as any);
+  }
+  if (instrumentModules.groq) {
+    const instr = new GroqInstrumentation();
+    instrs.push(instr);
+    instr.manuallyInstrument(instrumentModules.groq as any);
   }
 
   if (instrs.length > 0) {

--- a/packages/traceroot/src/types.ts
+++ b/packages/traceroot/src/types.ts
@@ -54,6 +54,7 @@ export interface InitializeOptions {
     langchain?: unknown;
     claudeAgentSDK?: unknown;
     bedrock?: unknown;
+    groq?: unknown;
   };
   /** Use SimpleSpanProcessor instead of BatchSpanProcessor. Useful for scripts/tests. */
   disableBatch?: boolean;

--- a/packages/traceroot/tests/groq-instrumentation.test.ts
+++ b/packages/traceroot/tests/groq-instrumentation.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { GroqInstrumentation } from '../src/groq_instrumentation';
+import { _resetForTesting } from '../src/traceroot';
+
+describe('GroqInstrumentation', () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider();
+    provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+    provider.register();
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+    exporter.reset();
+    _resetForTesting();
+  });
+
+  it('creates an LLM span for Groq chat completions', async () => {
+    class FakeGroqClient {
+      async post(path: string, opts?: { body?: Record<string, unknown> }) {
+        if (path !== '/openai/v1/chat/completions') {
+          return { ok: true };
+        }
+        return {
+          model: String(opts?.body?.model ?? 'llama-3.3-70b-versatile'),
+          usage: { prompt_tokens: 12, completion_tokens: 5 },
+          choices: [{ message: { content: 'Hello from Groq' } }],
+        };
+      }
+    }
+
+    const instr = new GroqInstrumentation();
+    instr.manuallyInstrument({
+      Groq: FakeGroqClient as unknown as { prototype: Record<string, unknown> },
+    });
+
+    const client = new FakeGroqClient();
+    await client.post('/openai/v1/chat/completions', {
+      body: {
+        model: 'llama-3.3-70b-versatile',
+        messages: [{ role: 'user', content: 'Say hello' }],
+      },
+    });
+
+    const spans = exporter.getFinishedSpans();
+    assert.equal(spans.length, 1);
+    const span = spans[0];
+
+    assert.equal(span.name, 'groq.chat.completions.create');
+    assert.equal(span.attributes['openinference.span.kind'], 'LLM');
+    assert.equal(span.attributes['llm.model_name'], 'llama-3.3-70b-versatile');
+    assert.equal(span.attributes['llm.token_count.prompt'], 12);
+    assert.equal(span.attributes['llm.token_count.completion'], 5);
+    assert.equal(span.attributes['input.value'], 'Say hello');
+    assert.equal(span.attributes['output.value'], 'Hello from Groq');
+  });
+
+  it('does not create a span for non-chat Groq post routes', async () => {
+    class FakeGroqClient {
+      async post(_path: string, _opts?: unknown) {
+        return { ok: true };
+      }
+    }
+
+    const instr = new GroqInstrumentation();
+    instr.manuallyInstrument({
+      Groq: FakeGroqClient as unknown as { prototype: Record<string, unknown> },
+    });
+
+    const client = new FakeGroqClient();
+    await client.post('/openai/v1/embeddings', { body: { model: 'text-embedding' } });
+
+    const spans = exporter.getFinishedSpans();
+    assert.equal(spans.length, 0);
+  });
+});

--- a/packages/traceroot/tests/groq-instrumentation.test.ts
+++ b/packages/traceroot/tests/groq-instrumentation.test.ts
@@ -80,4 +80,37 @@ describe('GroqInstrumentation', () => {
     const spans = exporter.getFinishedSpans();
     assert.equal(spans.length, 0);
   });
+
+  it('does not throw on malformed messages payloads', async () => {
+    class FakeGroqClient {
+      async post(path: string, opts?: { body?: Record<string, unknown> }) {
+        if (path !== '/openai/v1/chat/completions') {
+          return { ok: true };
+        }
+        return {
+          model: String(opts?.body?.model ?? 'llama-3.3-70b-versatile'),
+          usage: { prompt_tokens: 7, completion_tokens: 3 },
+          choices: [{ message: { content: 'Handled malformed input' } }],
+        };
+      }
+    }
+
+    const instr = new GroqInstrumentation();
+    instr.manuallyInstrument({
+      Groq: FakeGroqClient as unknown as { prototype: Record<string, unknown> },
+    });
+
+    const client = new FakeGroqClient();
+    await client.post('/openai/v1/chat/completions', {
+      body: {
+        model: 'llama-3.3-70b-versatile',
+        messages: [null, 42, 'bad', { nope: true }, { role: 'user', content: 'hello' }],
+      },
+    });
+
+    const spans = exporter.getFinishedSpans();
+    assert.equal(spans.length, 1);
+    const span = spans[0];
+    assert.equal(span.attributes['input.value'], 'hello');
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       '@opentelemetry/semantic-conventions':
         specifier: ^1.40.0
         version: 1.40.0
+      groq-sdk:
+        specifier: ^1.1.2
+        version: 1.1.2
     devDependencies:
       '@eslint/js':
         specifier: ^9.0.0
@@ -1632,6 +1635,10 @@ packages:
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
+
+  groq-sdk@1.1.2:
+    resolution: {integrity: sha512-CZO0XUQQDhn43ri1+lZHxZKpb+bGutgTvFmCJtooexiitGmPqhm1hntOT3nCoaq07e+OpeokVnfUs0i/oQuUaQ==}
+    hasBin: true
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -4527,6 +4534,8 @@ snapshots:
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
+
+  groq-sdk@1.1.2: {}
 
   has-flag@4.0.0: {}
 


### PR DESCRIPTION
Fixes #738

## Summary
Add Groq auto-instrumentation support to the TraceRoot TypeScript SDK using a custom instrumentor.

## Type of Change
- [x] feat - A new feature
- [x] test - Adding missing tests
- [ ] docs
- [ ] refactor
- [ ] fix
- [ ] other

## Details
- Added `GroqInstrumentation` to instrument Groq chat completions.
- Wired Groq into SDK instrumentation initialization flow.
- Extended `InitializeOptions.instrumentModules` with `groq`.
- Added focused unit tests for Groq instrumentation behavior.
- Added optional `groq-sdk` peer dependency metadata.

Captured OpenInference-compatible attributes:
- `openinference.span.kind = "LLM"`
- `llm.model_name`
- `llm.token_count.prompt`
- `llm.token_count.completion`
- `input.value`
- `output.value`

## Changed files
- `packages/traceroot/src/groq_instrumentation.ts` (new)
- `packages/traceroot/tests/groq-instrumentation.test.ts` (new)
- `packages/traceroot/src/instrumentation.ts`
- `packages/traceroot/src/types.ts`
- `packages/traceroot/package.json`
- `pnpm-lock.yaml`

## Screenshots / Recordings (if applicable)
<img width="961" height="551" alt="Rec" src="https://github.com/user-attachments/assets/5785d99c-8d64-402a-8223-676f6b01cef8" />


## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Groq support to the TypeScript SDK, creating OpenInference LLM spans for Groq chat completions with model, token, input, and output attributes. Also hardens message parsing to handle malformed entries safely.

- **New Features**
  - Added `GroqInstrumentation` to trace `/openai/v1/chat/completions` and record model name, prompt/completion tokens, `input.value`, and `output.value`.
  - Integrated into `wireInstrumentations` and extended `InitializeOptions.instrumentModules` with `groq` for manual wiring; ignores non-chat routes.
  - Added unit tests; declared optional peer dependency `groq-sdk` (>=1.0.0).

- **Bug Fixes**
  - Guarded messages parsing against nulls, non-objects, and mixed arrays to avoid exceptions and still extract user content.

<sup>Written for commit fb6604a640d81fc63e4ae879cff36121d5496dc3. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot-ts/pull/79?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

