### PR TITLE
chore: add .claude/ with prettier post-edit hook

### DIFF
--- a/.claude/hooks/lint.sh
+++ b/.claude/hooks/lint.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Post-edit format hook: auto-formats TS/JS files with prettier.
+# eslint is intentionally NOT run here — it's slow with typescript-eslint and
+# already runs via lint-staged on commit and in CI. Use a slash command for
+# on-demand eslint feedback.
+
+INPUT=$(cat)
+
+# Guard: jq is required to parse hook input
+if ! command -v jq &>/dev/null; then
+  exit 0
+fi
+
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
+  exit 0
+fi
+
+PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+case "$FILE_PATH" in
+  *.ts|*.tsx|*.js|*.jsx|*.json|*.md|*.yml|*.yaml) ;;
+  *) exit 0 ;;
+esac
+
+# Skip generated/vendored paths
+if [[ "$FILE_PATH" == */node_modules/* || "$FILE_PATH" == */dist/* ]]; then
+  exit 0
+fi
+
+PRETTIER="$PROJECT_ROOT/node_modules/.bin/prettier"
+if [ ! -x "$PRETTIER" ]; then
+  exit 0
+fi
+
+(cd "$PROJECT_ROOT" && "$PRETTIER" --write "$FILE_PATH" >/dev/null 2>&1)
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "permissions": {
+    "defaultMode": "bypassPermissions"
+  },
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CLAUDE_CODE_FORK_SUBAGENT": "1"
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/lint.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  },
+  "enabledPlugins": {
+    "superpowers@claude-plugins-official": true,
+    "code-simplifier@claude-plugins-official": true
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` mirroring `traceroot-py` / `traceroot`: `bypassPermissions`, agent-teams env, `superpowers` + `code-simplifier` plugins, `PostToolUse` hook on `Edit|Write`.
- Adds `.claude/hooks/lint.sh` adapted for this TS pnpm monorepo — runs `prettier --write` on edited `.ts/.tsx/.js/.jsx/.json/.md/.yml/.yaml` files using the root `.prettierrc`. Skips `node_modules/`, `dist/`, and exits silently when prettier isn't installed.
- Intentionally omits eslint from the per-edit hook (slow with `typescript-eslint`); lint-staged + CI continue to handle it.

Closes #83

## Test plan
Locally exercised the hook script with realistic payloads (after `pnpm install`):
- [x] Misformatted TS file → reformatted (spacing, semicolons, line break)
- [x] `.prettierrc` honored (single quotes applied, `printWidth: 100` collapsed array)
- [x] Non-TS extension (`.py`) → skipped, exit 0
- [x] File under `node_modules/` → skipped, exit 0
- [x] Missing file path → skipped gracefully, exit 0
- [x] Empty stdin / malformed JSON → handled, exit 0

## Notes for reviewers
- `.claude/settings.json` is loaded at Claude Code startup, **not** hot-reloaded — after merging, contributors need to restart their Claude Code session once for the hook to activate.
- `enabledPlugins` is checked in (matching upstream). If we'd rather not opt every collaborator into those plugins, we can move that block to `.claude/settings.local.json` (gitignored) in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `.claude/` setup with a post-edit `prettier` hook to auto-format files in Claude Code, improving consistency and keeping edits fast across the pnpm monorepo.

- **New Features**
  - PostToolUse `Edit|Write` hook runs `.claude/hooks/lint.sh` to call `prettier --write` using the root `.prettierrc` (eslint stays in `lint-staged` and CI).
  - Targets `.ts/.tsx/.js/.jsx/.json/.md/.yml/.yaml`; skips `node_modules/` and `dist/`; exits quietly if `prettier` or `jq` is missing.
  - Enables `superpowers@claude-plugins-official` and `code-simplifier@claude-plugins-official`; sets `bypassPermissions` and agent team env flags.

- **Migration**
  - Restart Claude Code once to load `.claude/settings.json`.
  - Run `pnpm install` so `prettier` is available.

<sup>Written for commit eb4efb854524b982fa9158a8b7acbfcb643ed5e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

