### PR TITLE
feat(instrumentation): Vercel AI SDK tracing via OpenInference (+ tests, +#2651 fix)

### DIFF
--- a/packages/traceroot/package.json
+++ b/packages/traceroot/package.json
@@ -49,6 +49,7 @@
     "@arizeai/openinference-instrumentation-langchain": "^4.0.6",
     "@arizeai/openinference-instrumentation-openai": "^4.0.5",
     "@arizeai/openinference-semantic-conventions": "^2.1.7",
+    "@arizeai/openinference-vercel": "^2.7.2",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.57.2",
     "@opentelemetry/instrumentation": "^0.46.0",

--- a/packages/traceroot/package.json
+++ b/packages/traceroot/package.json
@@ -62,12 +62,14 @@
     "@eslint/js": "^9.0.0",
     "@langchain/core": "^1.1.39",
     "@types/node": "^20.0.0",
+    "ai": "^6.0.175",
     "anthropic": "^0.0.0",
     "eslint": "^9.0.0",
     "openai": "^6.33.0",
     "tsx": "^4.19.0",
     "typescript": "^5.5.0",
-    "typescript-eslint": "^8.0.0"
+    "typescript-eslint": "^8.0.0",
+    "zod": "^4.4.3"
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": ">=0.20.0",

--- a/packages/traceroot/src/processor.ts
+++ b/packages/traceroot/src/processor.ts
@@ -1,11 +1,6 @@
 // src/processor.ts
 import { Context, Span } from '@opentelemetry/api';
-import {
-  BatchSpanProcessor,
-  ReadableSpan,
-  SimpleSpanProcessor,
-  SpanProcessor,
-} from '@opentelemetry/sdk-trace-base';
+import { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace-base';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { version } = require('../package.json') as { version: string };
@@ -20,18 +15,19 @@ export interface TraceRootSpanProcessorOptions {
 }
 
 /**
- * Wraps an inner SpanProcessor (Batch or Simple) and injects TraceRoot SDK
- * metadata attributes on every span start. This is the only processor TraceRoot
- * registers; the inner processor handles actual export batching.
+ * Wraps an inner SpanProcessor and injects TraceRoot SDK metadata attributes
+ * on every span start. The inner processor handles export batching and, when
+ * the Vercel AI SDK is in use, OpenInference attribute enrichment.
  */
 export class TraceRootSpanProcessor implements SpanProcessor {
-  private readonly inner: BatchSpanProcessor | SimpleSpanProcessor;
+  private readonly inner: SpanProcessor; // ← WIDENED from BatchSpanProcessor | SimpleSpanProcessor
+
   private readonly _environment: string | undefined;
   private readonly _gitRepo: string | undefined;
   private readonly _gitRef: string | undefined;
 
   constructor(
-    inner: BatchSpanProcessor | SimpleSpanProcessor,
+    inner: SpanProcessor, // ← WIDENED
     opts: TraceRootSpanProcessorOptions = {},
   ) {
     this.inner = inner;
@@ -54,8 +50,6 @@ export class TraceRootSpanProcessor implements SpanProcessor {
     if (this._gitRef !== undefined) {
       span.setAttribute('traceroot.git.ref', this._gitRef);
     }
-    // Cast required: inner processor expects the internal sdk-trace-base Span,
-    // but the SpanProcessor interface uses the public @opentelemetry/api Span.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.inner.onStart(span as any, parentContext);
   }

--- a/packages/traceroot/src/processor.ts
+++ b/packages/traceroot/src/processor.ts
@@ -1,6 +1,7 @@
 // src/processor.ts
 import { Context, Span } from '@opentelemetry/api';
 import { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { getAttributesFromContext } from '@arizeai/openinference-core';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { version } = require('../package.json') as { version: string };
@@ -20,16 +21,13 @@ export interface TraceRootSpanProcessorOptions {
  * the Vercel AI SDK is in use, OpenInference attribute enrichment.
  */
 export class TraceRootSpanProcessor implements SpanProcessor {
-  private readonly inner: SpanProcessor; // ← WIDENED from BatchSpanProcessor | SimpleSpanProcessor
+  private readonly inner: SpanProcessor;
 
   private readonly _environment: string | undefined;
   private readonly _gitRepo: string | undefined;
   private readonly _gitRef: string | undefined;
 
-  constructor(
-    inner: SpanProcessor, // ← WIDENED
-    opts: TraceRootSpanProcessorOptions = {},
-  ) {
+  constructor(inner: SpanProcessor, opts: TraceRootSpanProcessorOptions = {}) {
     this.inner = inner;
     this._environment = opts.environment;
     this._gitRepo = opts.gitRepo;
@@ -49,6 +47,14 @@ export class TraceRootSpanProcessor implements SpanProcessor {
     }
     if (this._gitRef !== undefined) {
       span.setAttribute('traceroot.git.ref', this._gitRef);
+    }
+    // Propagate session.id / user.id / metadata / tags set via usingAttributes()
+    // to ALL spans, including those created outside observe() (notably Vercel AI
+    // SDK spans, which @arizeai/openinference-vercel does not lift from Context —
+    // see Arize-ai/openinference#2651).
+    const ctxAttrs = getAttributesFromContext(parentContext);
+    if (ctxAttrs && Object.keys(ctxAttrs).length > 0) {
+      span.setAttributes(ctxAttrs);
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.inner.onStart(span as any, parentContext);

--- a/packages/traceroot/src/traceroot.ts
+++ b/packages/traceroot/src/traceroot.ts
@@ -10,6 +10,10 @@ import {
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
 import { BatchSpanProcessor, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import {
+  OpenInferenceBatchSpanProcessor,
+  OpenInferenceSimpleSpanProcessor,
+} from '@arizeai/openinference-vercel';
 import { InitializeOptions } from './types';
 import { SDK_NAME, SDK_VERSION, TraceRootSpanProcessor } from './processor';
 import { wireInstrumentations } from './instrumentation';
@@ -63,6 +67,7 @@ export class TraceRoot {
       process.env['TRACEROOT_HOST_URL'] ??
       DEFAULT_BASE_URL
     ).replace(/\/$/, '');
+
     const headers: Record<string, string> = {
       'x-traceroot-sdk-name': SDK_NAME,
       'x-traceroot-sdk-version': SDK_VERSION,
@@ -72,7 +77,6 @@ export class TraceRoot {
     const exporter = new OTLPTraceExporter({
       url: `${baseUrl}/api/v1/public/traces`,
       headers,
-      // CompressionAlgorithm.GZIP = "gzip"; using string literal to avoid importing transitive dep
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       compression: 'gzip' as any,
     });
@@ -84,24 +88,30 @@ export class TraceRoot {
     let gitRepo = gitRepoOverride;
     let gitRef = gitRefOverride;
     if (gitRepo === undefined || gitRef === undefined) {
-      const autoGit = autoDetectGitContext(); // also warms the git root cache
+      const autoGit = autoDetectGitContext();
       gitRepo ??= autoGit.gitRepo;
       gitRef ??= autoGit.gitRef;
     } else {
-      getGitRoot(); // warm git root cache for captureSourceLocation without shelling out for repo/ref
+      getGitRoot();
     }
 
-    // Flush/batch tuning — env vars take precedence over hardcoded defaults.
     const flushIntervalSec = Number(process.env['TRACEROOT_FLUSH_INTERVAL'] || '5');
     const flushAt = Number(process.env['TRACEROOT_FLUSH_AT'] || '100');
     const timeoutSec = Number(process.env['TRACEROOT_TIMEOUT'] || '30');
 
+    // ── Vercel AI SDK: wrap the exporter in OpenInference span processors ──────
+    // These processors enrich spans emitted by Vercel AI SDK's experimental_telemetry
+    // with OpenInference semantic conventions (model name, token counts, IO, etc.)
+    // before they reach the OTLP exporter. All other SDK spans pass through unchanged.
     const innerProcessor = options.disableBatch
-      ? new SimpleSpanProcessor(exporter)
-      : new BatchSpanProcessor(exporter, {
-          scheduledDelayMillis: flushIntervalSec * 1000,
-          maxExportBatchSize: flushAt,
-          exportTimeoutMillis: timeoutSec * 1000,
+      ? new OpenInferenceSimpleSpanProcessor({ exporter })
+      : new OpenInferenceBatchSpanProcessor({
+          exporter,
+          config: {
+            scheduledDelayMillis: flushIntervalSec * 1000,
+            maxExportBatchSize: flushAt,
+            exportTimeoutMillis: timeoutSec * 1000,
+          },
         });
 
     _provider = new NodeTracerProvider();
@@ -113,8 +123,6 @@ export class TraceRoot {
     wireInstrumentations(options.instrumentModules);
 
     _isInitialized = true;
-    // forceFlush() is async and keeps the event loop alive via its HTTP export request,
-    // so beforeExit + forceFlush() is sufficient — no keepAlive timer needed.
     process.once('beforeExit', () => {
       void _provider?.forceFlush();
     });

--- a/packages/traceroot/src/traceroot.ts
+++ b/packages/traceroot/src/traceroot.ts
@@ -8,7 +8,6 @@ import {
   trace,
 } from '@opentelemetry/api';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
-import { BatchSpanProcessor, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import {
   OpenInferenceBatchSpanProcessor,

--- a/packages/traceroot/tests/initialize.test.ts
+++ b/packages/traceroot/tests/initialize.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { ROOT_CONTEXT } from '@opentelemetry/api';
 import { TraceRoot, _resetForTesting } from '../src/traceroot';
 import { TraceRootSpanProcessor } from '../src/processor';
 
@@ -108,7 +109,9 @@ function makeProcessorFixture() {
     forceFlush: () => Promise.resolve(),
     shutdown: () => Promise.resolve(),
   } as unknown as import('@opentelemetry/sdk-trace-base').SimpleSpanProcessor;
-  const ctx = {} as import('@opentelemetry/api').Context;
+  // Use the real ROOT_CONTEXT so getAttributesFromContext() (called inside
+  // TraceRootSpanProcessor.onStart for the OI #2651 fix) has a working .getValue().
+  const ctx = ROOT_CONTEXT;
   return { span, inner, attributes, ctx };
 }
 

--- a/packages/traceroot/tests/vercel-ai.test.ts
+++ b/packages/traceroot/tests/vercel-ai.test.ts
@@ -1,0 +1,512 @@
+// Vercel AI SDK integration tests.
+//
+// These exercise the production stack:
+//   TraceRootSpanProcessor → OpenInferenceSimpleSpanProcessor → InMemorySpanExporter
+//
+// Real Vercel AI SDK calls go through @arizeai/openinference-vercel, which mutates
+// span attributes onEnd to OpenInference semantic conventions. The assertions are
+// on the post-mapping attribute names (input.value, output.value, llm.model_name,
+// llm.token_count.*, openinference.span.kind, tool_call.*) so the suite catches
+// regressions in either layer.
+
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { InMemorySpanExporter, ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { context, propagation, SpanStatusCode, trace } from '@opentelemetry/api';
+import { OpenInferenceSimpleSpanProcessor } from '@arizeai/openinference-vercel';
+
+import { generateText, streamText, tool } from 'ai';
+import { MockLanguageModelV3, simulateReadableStream } from 'ai/test';
+import { z } from 'zod';
+
+import { TraceRootSpanProcessor } from '../src/processor';
+import { observe, _resetObserveState } from '../src/observe';
+import { usingAttributes } from '../src/usingAttributes';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test infrastructure
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface TestRig {
+  exporter: InMemorySpanExporter;
+  provider: NodeTracerProvider;
+}
+
+function makeRig(
+  opts: {
+    environment?: string;
+    gitRepo?: string;
+    gitRef?: string;
+  } = {},
+): TestRig {
+  const exporter = new InMemorySpanExporter();
+  const oi = new OpenInferenceSimpleSpanProcessor({ exporter });
+  const provider = new NodeTracerProvider();
+  provider.addSpanProcessor(new TraceRootSpanProcessor(oi, opts));
+  provider.register();
+  return { exporter, provider };
+}
+
+async function teardownRig(rig: TestRig): Promise<void> {
+  await rig.provider.shutdown();
+  rig.exporter.reset();
+  trace.disable();
+  context.disable();
+  propagation.disable();
+  // observe.ts caches a tracer at module level; clear it so the next test's
+  // freshly-registered TracerProvider is picked up.
+  _resetObserveState();
+}
+
+function findSpan(spans: ReadableSpan[], name: string): ReadableSpan {
+  const found = spans.find((s) => s.name === name);
+  assert.ok(found, `expected a span named "${name}", got [${spans.map((s) => s.name).join(', ')}]`);
+  return found;
+}
+
+function findSpans(spans: ReadableSpan[], name: string): ReadableSpan[] {
+  return spans.filter((s) => s.name === name);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock builders for MockLanguageModelV3
+// ─────────────────────────────────────────────────────────────────────────────
+
+// LanguageModelV3Usage shape — nested objects, not flat numbers.
+const STD_USAGE = {
+  inputTokens: { total: 11, noCache: 11, cacheRead: undefined, cacheWrite: undefined },
+  outputTokens: { total: 7, text: 7, reasoning: undefined },
+};
+
+function staticTextModel(text: string) {
+  return new MockLanguageModelV3({
+    modelId: 'mock-static',
+    provider: 'mock-provider',
+    doGenerate: async () => ({
+      content: [{ type: 'text', text }],
+      finishReason: 'stop',
+      usage: STD_USAGE,
+      warnings: [],
+    }),
+  });
+}
+
+function streamingTextModel(deltas: string[]) {
+  return new MockLanguageModelV3({
+    modelId: 'mock-stream',
+    provider: 'mock-provider',
+    doStream: async () => ({
+      stream: simulateReadableStream({
+        chunks: [
+          { type: 'stream-start' as const, warnings: [] },
+          { type: 'text-start' as const, id: 'tx1' },
+          ...deltas.map((delta) => ({ type: 'text-delta' as const, id: 'tx1', delta })),
+          { type: 'text-end' as const, id: 'tx1' },
+          {
+            type: 'finish' as const,
+            finishReason: 'stop' as const,
+            usage: STD_USAGE,
+          },
+        ],
+      }),
+    }),
+  });
+}
+
+function throwingModel(message: string) {
+  return new MockLanguageModelV3({
+    modelId: 'mock-throw',
+    provider: 'mock-provider',
+    doGenerate: async () => {
+      throw new Error(message);
+    },
+  });
+}
+
+function streamThatErrorsAfter(deltas: string[], errorMessage: string) {
+  return new MockLanguageModelV3({
+    modelId: 'mock-stream-err',
+    provider: 'mock-provider',
+    doStream: async () => ({
+      stream: simulateReadableStream({
+        chunks: [
+          { type: 'stream-start' as const, warnings: [] },
+          { type: 'text-start' as const, id: 'tx1' },
+          ...deltas.map((delta) => ({ type: 'text-delta' as const, id: 'tx1', delta })),
+          { type: 'error' as const, error: new Error(errorMessage) },
+        ],
+      }),
+    }),
+  });
+}
+
+// Two-call mock: first call returns a tool-call, second call returns a final text.
+function toolCallingModel(toolName: string, toolInput: object, finalText: string) {
+  let call = 0;
+  return new MockLanguageModelV3({
+    modelId: 'mock-tools',
+    provider: 'mock-provider',
+    doGenerate: async () => {
+      call++;
+      if (call === 1) {
+        return {
+          content: [
+            {
+              type: 'tool-call' as const,
+              toolCallId: 't1',
+              toolName,
+              input: JSON.stringify(toolInput),
+            },
+          ],
+          finishReason: 'tool-calls',
+          usage: STD_USAGE,
+          warnings: [],
+        };
+      }
+      return {
+        content: [{ type: 'text', text: finalText }],
+        finishReason: 'stop',
+        usage: STD_USAGE,
+        warnings: [],
+      };
+    },
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Suite
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Vercel AI SDK integration via OpenInference', () => {
+  let rig: TestRig;
+
+  beforeEach(() => {
+    rig = makeRig();
+  });
+
+  afterEach(async () => {
+    await teardownRig(rig);
+  });
+
+  // ── 1. Non-streaming generateText ─────────────────────────────────────────
+  describe('non-streaming generateText', () => {
+    it('produces a parent ai.generateText span and a doGenerate child with mapped attributes', async () => {
+      const result = await generateText({
+        model: staticTextModel('hello world'),
+        prompt: 'say hi',
+        experimental_telemetry: { isEnabled: true },
+      });
+      assert.equal(result.text, 'hello world');
+
+      await rig.provider.forceFlush();
+      const spans = rig.exporter.getFinishedSpans();
+
+      const wrapper = findSpan(spans, 'ai.generateText');
+      const inner = findSpan(spans, 'ai.generateText.doGenerate');
+      assert.equal(
+        spans.length,
+        2,
+        `expected exactly 2 spans, got ${spans.length}: [${spans.map((s) => s.name).join(', ')}]`,
+      );
+
+      // Per OI's VercelSDKFunctionNameToSpanKindMap:
+      //   ai.generateText             → AGENT (the orchestrating wrapper)
+      //   ai.generateText.doGenerate  → LLM   (the actual provider call)
+      assert.equal(wrapper.attributes['openinference.span.kind'], 'AGENT');
+      assert.equal(inner.attributes['openinference.span.kind'], 'LLM');
+
+      // Input/output mapped from ai.prompt / ai.response.text
+      assert.ok(wrapper.attributes['input.value'], 'wrapper input.value should be set');
+      assert.ok(
+        String(wrapper.attributes['input.value']).includes('say hi'),
+        `wrapper input.value should contain prompt; got: ${wrapper.attributes['input.value']}`,
+      );
+      assert.equal(wrapper.attributes['output.value'], 'hello world');
+
+      // Model metadata: model_name lives on both spans; the OI mapping only
+      // emits llm.token_count.* on LLM-kind spans, so it lands on the inner
+      // doGenerate. The AGENT wrapper carries the raw ai.usage.* aggregates.
+      assert.equal(inner.attributes['llm.model_name'], 'mock-static');
+      assert.equal(inner.attributes['llm.token_count.prompt'], 11);
+      assert.equal(inner.attributes['llm.token_count.completion'], 7);
+      assert.equal(wrapper.attributes['ai.usage.inputTokens'], 11);
+      assert.equal(wrapper.attributes['ai.usage.outputTokens'], 7);
+
+      // Parent / child relationship preserved through the OI processor
+      assert.equal(
+        inner.parentSpanId,
+        wrapper.spanContext().spanId,
+        'doGenerate must be a child of generateText',
+      );
+
+      // Status: not ERROR on success (AI SDK may set OK explicitly).
+      assert.notEqual(wrapper.status.code, SpanStatusCode.ERROR);
+
+      // TraceRootSpanProcessor still injects SDK metadata after the swap
+      assert.equal(wrapper.attributes['traceroot.sdk.name'], 'traceroot-ts');
+      assert.ok(wrapper.attributes['traceroot.sdk.version']);
+    });
+  });
+
+  // ── 2. Streaming streamText ───────────────────────────────────────────────
+  describe('streaming streamText', () => {
+    it('keeps the wrapper span open until the stream is consumed and lands usage on close', async () => {
+      const result = streamText({
+        model: streamingTextModel(['hel', 'lo']),
+        prompt: 'go',
+        experimental_telemetry: { isEnabled: true },
+      });
+
+      let collected = '';
+      for await (const chunk of result.textStream) collected += chunk;
+      assert.equal(collected, 'hello');
+
+      await rig.provider.forceFlush();
+      const spans = rig.exporter.getFinishedSpans();
+
+      const wrapper = findSpan(spans, 'ai.streamText');
+      const inner = findSpan(spans, 'ai.streamText.doStream');
+
+      assert.equal(findSpans(spans, 'ai.streamText').length, 1);
+      assert.equal(findSpans(spans, 'ai.streamText.doStream').length, 1);
+
+      // Token usage on the final LLM span (per OI: llm.token_count.* only on LLM-kind spans).
+      // The AGENT-kind wrapper still carries the raw ai.usage.* aggregates.
+      assert.equal(inner.attributes['llm.token_count.prompt'], 11);
+      assert.equal(inner.attributes['llm.token_count.completion'], 7);
+      assert.equal(wrapper.attributes['ai.usage.inputTokens'], 11);
+      assert.equal(wrapper.attributes['ai.usage.outputTokens'], 7);
+
+      // Output text reconstructed on both wrapper and inner
+      assert.equal(wrapper.attributes['output.value'], 'hello');
+      assert.equal(inner.attributes['output.value'], 'hello');
+
+      assert.notEqual(wrapper.status.code, SpanStatusCode.ERROR);
+      assert.ok(wrapper.endTime[0] >= wrapper.startTime[0], 'wrapper.endTime must be set');
+    });
+  });
+
+  // ── 3. Tool calling ───────────────────────────────────────────────────────
+  describe('tool calling', () => {
+    it('emits an ai.toolCall span with TOOL kind and tool input/output', async () => {
+      const result = await generateText({
+        model: toolCallingModel('add', { a: 2, b: 3 }, 'sum is 5'),
+        prompt: 'compute',
+        tools: {
+          add: tool({
+            description: 'add two numbers',
+            inputSchema: z.object({ a: z.number(), b: z.number() }),
+            execute: async ({ a, b }) => a + b,
+          }),
+        },
+        stopWhen: ({ steps }) => steps.length >= 2,
+        experimental_telemetry: { isEnabled: true },
+      });
+      assert.equal(result.text, 'sum is 5');
+
+      await rig.provider.forceFlush();
+      const spans = rig.exporter.getFinishedSpans();
+
+      const toolSpan = findSpan(spans, 'ai.toolCall');
+      assert.equal(toolSpan.attributes['openinference.span.kind'], 'TOOL');
+      assert.equal(toolSpan.attributes['tool.name'], 'add');
+
+      const argsAttr = toolSpan.attributes['tool.parameters'] ?? toolSpan.attributes['input.value'];
+      assert.ok(
+        argsAttr,
+        `tool args should be on the span; saw keys: ${Object.keys(toolSpan.attributes).join(', ')}`,
+      );
+      assert.ok(
+        String(argsAttr).includes('"a":2') && String(argsAttr).includes('"b":3'),
+        `tool args should contain a:2 b:3; got: ${argsAttr}`,
+      );
+
+      const resultAttr = toolSpan.attributes['output.value'];
+      assert.ok(resultAttr, 'tool result should be on the span');
+      assert.ok(
+        String(resultAttr).includes('5'),
+        `tool result should contain 5; got: ${resultAttr}`,
+      );
+
+      // Parent of the tool span is the generateText wrapper
+      const wrapper = findSpan(spans, 'ai.generateText');
+      assert.equal(toolSpan.parentSpanId, wrapper.spanContext().spanId);
+    });
+  });
+
+  // ── 4. Error paths ────────────────────────────────────────────────────────
+  describe('error paths', () => {
+    it('marks spans ERROR when the provider throws and leaves no leaks', async () => {
+      await assert.rejects(
+        () =>
+          generateText({
+            model: throwingModel('boom'),
+            prompt: 'go',
+            experimental_telemetry: { isEnabled: true },
+          }),
+        /boom/,
+      );
+
+      await rig.provider.forceFlush();
+      const spans = rig.exporter.getFinishedSpans();
+
+      const wrapper = findSpan(spans, 'ai.generateText');
+      const inner = findSpan(spans, 'ai.generateText.doGenerate');
+      assert.equal(spans.length, 2, 'no leaked or extra spans on error path');
+      assert.equal(wrapper.status.code, SpanStatusCode.ERROR);
+      assert.equal(inner.status.code, SpanStatusCode.ERROR);
+      assert.ok(
+        wrapper.events.some((e) => e.name === 'exception'),
+        'wrapper should record exception event',
+      );
+    });
+
+    it('marks the streaming wrapper ERROR when the stream emits a fatal error', async () => {
+      const stream = streamText({
+        model: streamThatErrorsAfter(['par'], 'stream-failed'),
+        prompt: 'go',
+        experimental_telemetry: { isEnabled: true },
+        onError: () => {
+          // suppress unhandled — we want to assert on spans, not throw out of consumer
+        },
+      });
+      let collected = '';
+      try {
+        for await (const chunk of stream.textStream) collected += chunk;
+      } catch {
+        // expected
+      }
+
+      await rig.provider.forceFlush();
+      const spans = rig.exporter.getFinishedSpans();
+
+      const wrapper = findSpan(spans, 'ai.streamText');
+      assert.equal(wrapper.status.code, SpanStatusCode.ERROR, 'wrapper status should be ERROR');
+      assert.equal(findSpans(spans, 'ai.streamText').length, 1, 'no leaked wrapper spans');
+      assert.equal(
+        findSpans(spans, 'ai.streamText.doStream').length,
+        1,
+        'no leaked doStream spans',
+      );
+    });
+  });
+
+  // ── 5. Nested call: Vercel inside an observe()-wrapped function ───────────
+  describe('nested call', () => {
+    it('preserves parent/child when generateText runs inside an observe() span', async () => {
+      const _result = await observe({ name: 'outer-fn', type: 'span' }, async () =>
+        generateText({
+          model: staticTextModel('inside'),
+          prompt: 'p',
+          experimental_telemetry: { isEnabled: true },
+        }),
+      );
+
+      await rig.provider.forceFlush();
+      const spans = rig.exporter.getFinishedSpans();
+
+      const outer = findSpan(spans, 'outer-fn');
+      const wrapper = findSpan(spans, 'ai.generateText');
+
+      assert.equal(
+        wrapper.parentSpanId,
+        outer.spanContext().spanId,
+        'ai.generateText must be a direct child of the observe() span',
+      );
+      assert.equal(wrapper.spanContext().traceId, outer.spanContext().traceId);
+    });
+  });
+
+  // ── 6. Pass-through: non-Vercel spans must come through untouched ─────────
+  describe('non-Vercel pass-through', () => {
+    it('does not mutate manual spans that were never produced by the AI SDK', async () => {
+      const tracer = trace.getTracer('manual-test');
+      await new Promise<void>((resolve) => {
+        tracer.startActiveSpan('manual.work', (span) => {
+          span.setAttribute('foo', 'bar');
+          span.setAttribute('input.value', 'preserved-input');
+          span.end();
+          resolve();
+        });
+      });
+
+      await rig.provider.forceFlush();
+      const spans = rig.exporter.getFinishedSpans();
+
+      const manual = findSpan(spans, 'manual.work');
+      assert.equal(spans.length, 1);
+      assert.equal(manual.attributes['foo'], 'bar', 'arbitrary attrs preserved');
+      assert.equal(
+        manual.attributes['input.value'],
+        'preserved-input',
+        'OI processor must not overwrite existing input.value on a non-Vercel span',
+      );
+      assert.equal(manual.attributes['llm.model_name'], undefined);
+      assert.equal(manual.attributes['llm.token_count.prompt'], undefined);
+      assert.equal(manual.attributes['openinference.span.kind'], undefined);
+
+      assert.equal(manual.attributes['traceroot.sdk.name'], 'traceroot-ts');
+    });
+  });
+
+  // ── 7. TraceRootSpanProcessor injection survives the processor swap ───────
+  describe('TraceRootSpanProcessor injection', () => {
+    it('applies traceroot.git.* / deployment.environment to AI SDK spans', async () => {
+      await teardownRig(rig);
+      rig = makeRig({ environment: 'staging', gitRepo: 'org/repo', gitRef: 'abc123' });
+
+      await generateText({
+        model: staticTextModel('ok'),
+        prompt: 'p',
+        experimental_telemetry: { isEnabled: true },
+      });
+
+      await rig.provider.forceFlush();
+      const wrapper = findSpan(rig.exporter.getFinishedSpans(), 'ai.generateText');
+
+      assert.equal(wrapper.attributes['deployment.environment'], 'staging');
+      assert.equal(wrapper.attributes['traceroot.git.repo'], 'org/repo');
+      assert.equal(wrapper.attributes['traceroot.git.ref'], 'abc123');
+      assert.equal(wrapper.attributes['traceroot.sdk.name'], 'traceroot-ts');
+    });
+  });
+
+  // ── 8. Session/user context propagation (the #2651 fix) ───────────────────
+  describe('session/user context propagation', () => {
+    it('lifts session.id and user.id from usingAttributes() onto Vercel AI SDK spans', async () => {
+      await usingAttributes(
+        {
+          sessionId: 'sess-42',
+          userId: 'u-7',
+          tags: ['prod', 'beta'],
+          metadata: { feature: 'chat' },
+        },
+        async () => {
+          await generateText({
+            model: staticTextModel('hi'),
+            prompt: 'p',
+            experimental_telemetry: { isEnabled: true },
+          });
+        },
+      );
+
+      await rig.provider.forceFlush();
+      const wrapper = findSpan(rig.exporter.getFinishedSpans(), 'ai.generateText');
+
+      assert.equal(
+        wrapper.attributes['session.id'],
+        'sess-42',
+        'session.id must propagate from usingAttributes() to ai.generateText (the #2651 case)',
+      );
+      assert.equal(wrapper.attributes['user.id'], 'u-7');
+      const tagsAttr = wrapper.attributes['tag.tags'];
+      assert.ok(tagsAttr, 'tag.tags must be set');
+      assert.ok(
+        String(tagsAttr).includes('prod') && String(tagsAttr).includes('beta'),
+        `tag.tags should contain prod and beta; got: ${tagsAttr}`,
+      );
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       '@arizeai/openinference-semantic-conventions':
         specifier: ^2.1.7
         version: 2.1.7
+      '@arizeai/openinference-vercel':
+        specifier: ^2.7.2
+        version: 2.7.2(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.40.0)
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -200,6 +203,15 @@ packages:
   '@arizeai/openinference-core@2.0.5':
     resolution: {integrity: sha512-BnufYaFqmG9twkz/9DHX9WTcOs7YvVAYaufau5tdjOT1c0Y8niJwmNWzV36phNPg3c7SmdD5OYLuzeAUN0T3pQ==}
 
+  '@arizeai/openinference-core@2.0.6':
+    resolution: {integrity: sha512-hsMax4Yq9x0S+F6QJYcdzKWiKI5OpIeYqLl5TptS4MUDwyfgwz7pOmmy3wiewEktcxB8NY5S/T32S01naAgLxA==}
+
+  '@arizeai/openinference-genai@0.1.7':
+    resolution: {integrity: sha512-w1sevI+y1tFusyzlLkuI7mdT87IsvO9cBGljxB0cd/tM9/TWV5/A0m9fZd/hys/jgMRRQCU+AW4tGBWcCZ/WCQ==}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0'
+      '@opentelemetry/semantic-conventions': '>=1.37.0'
+
   '@arizeai/openinference-instrumentation-anthropic@0.1.7':
     resolution: {integrity: sha512-TaxOkNLQftIgqvtT5R64FaRPGGf6E0nm6+8J3g7JF4A6lPYnLLquc/HyMN+ttckqavXcIfLYn7qKa4AfZm4kuA==}
 
@@ -223,6 +235,14 @@ packages:
 
   '@arizeai/openinference-semantic-conventions@2.1.7':
     resolution: {integrity: sha512-KyBfwxkSusPvxHBaW/TJ0japEbXCNziW9o6/IRKiPu+gp5TMKIagV2NKvt47rWYa4Jc0Nl+SvAPm+yxkdJqVbg==}
+
+  '@arizeai/openinference-semantic-conventions@2.2.0':
+    resolution: {integrity: sha512-jyVeggDSuVFyOXWXqShKsRxHc5RrE7jRN2D0LGMGYDbo4oHeCJCgUezHQITT7t7FPNQxj5O+NcqERhznnDx6UQ==}
+
+  '@arizeai/openinference-vercel@2.7.2':
+    resolution: {integrity: sha512-hr8ccq8Hm/kR8yYi/u6h/05jIp3ndxM4DdRjj0kjyt6sUCpXLTK+vgIsJY73Ruc+cWqOJhSvl0A/Myi3dsbQaw==}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.7.0 <2.0.0'
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -2640,6 +2660,18 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
 
+  '@arizeai/openinference-core@2.0.6':
+    dependencies:
+      '@arizeai/openinference-semantic-conventions': 2.2.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@arizeai/openinference-genai@0.1.7(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@arizeai/openinference-semantic-conventions': 2.2.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+
   '@arizeai/openinference-instrumentation-anthropic@0.1.7':
     dependencies:
       '@arizeai/openinference-core': 2.0.5
@@ -2694,6 +2726,18 @@ snapshots:
       - supports-color
 
   '@arizeai/openinference-semantic-conventions@2.1.7': {}
+
+  '@arizeai/openinference-semantic-conventions@2.2.0': {}
+
+  '@arizeai/openinference-vercel@2.7.2(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@arizeai/openinference-core': 2.0.6
+      '@arizeai/openinference-genai': 0.1.7(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.40.0)
+      '@arizeai/openinference-semantic-conventions': 2.2.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - '@opentelemetry/semantic-conventions'
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,10 +27,10 @@ importers:
     dependencies:
       '@mastra/core':
         specifier: '>=1.0.0-0 <2.0.0-0'
-        version: 1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6)
+        version: 1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.4.3)
       '@mastra/observability':
         specifier: '>=1.0.0-0 <2.0.0-0'
-        version: 1.7.2(@mastra/core@1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6))
+        version: 1.7.2(@mastra/core@1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.4.3))
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -85,10 +85,10 @@ importers:
         version: 0.2.0
       '@arizeai/openinference-instrumentation-langchain':
         specifier: ^4.0.6
-        version: 4.0.6(@langchain/core@1.1.39(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
+        version: 4.0.6(@langchain/core@1.1.39(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
       '@arizeai/openinference-instrumentation-openai':
         specifier: ^4.0.5
-        version: 4.0.5(openai@6.33.0(ws@8.20.0)(zod@4.3.6))
+        version: 4.0.5(openai@6.33.0(ws@8.20.0)(zod@4.4.3))
       '@arizeai/openinference-semantic-conventions':
         specifier: ^2.1.7
         version: 2.1.7
@@ -122,10 +122,13 @@ importers:
         version: 9.39.4
       '@langchain/core':
         specifier: ^1.1.39
-        version: 1.1.39(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+        version: 1.1.39(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.37
+      ai:
+        specifier: ^6.0.175
+        version: 6.0.175(zod@4.4.3)
       anthropic:
         specifier: ^0.0.0
         version: 0.0.0
@@ -134,7 +137,7 @@ importers:
         version: 9.39.4
       openai:
         specifier: ^6.33.0
-        version: 6.33.0(ws@8.20.0)(zod@4.3.6)
+        version: 6.33.0(ws@8.20.0)(zod@4.4.3)
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
@@ -144,12 +147,21 @@ importers:
       typescript-eslint:
         specifier: ^8.0.0
         version: 8.58.0(eslint@9.39.4)(typescript@5.9.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
 packages:
 
   '@a2a-js/sdk@0.2.5':
     resolution: {integrity: sha512-VTDuRS5V0ATbJ/LkaQlisMnTAeYKXAK6scMguVBstf+KIBQ7HIuKhiXLv+G/hvejkV+THoXzoNifInAkU81P1g==}
     engines: {node: '>=18'}
+
+  '@ai-sdk/gateway@3.0.110':
+    resolution: {integrity: sha512-sbv8+1L9/BRKydn8dMNwoMQKupA4iLJ9N+yvxgW6wMQ/94UepDf3FeYWMj/dLdzolAHZ6izRUP4s5WqQkmJ2Zg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   '@ai-sdk/provider-utils@2.2.8':
     resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
@@ -169,6 +181,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.26':
+    resolution: {integrity: sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@1.1.3':
     resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
     engines: {node: '>=18'}
@@ -179,6 +197,10 @@ packages:
 
   '@ai-sdk/provider@3.0.0':
     resolution: {integrity: sha512-m9ka3ptkPQbaHHZHqDXDF9C9B5/Mav0KTdky1k2HZ3/nrW2t1AgObxIVPyGDWQNS9FXT/FS6PIoSjpcP/No8rQ==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.10':
+    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.5':
@@ -647,6 +669,10 @@ packages:
   '@opentelemetry/api-logs@0.57.2':
     resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
     engines: {node: '>=14'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
@@ -1154,6 +1180,10 @@ packages:
     resolution: {integrity: sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@workflow/serde@4.1.0-beta.2':
     resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
 
@@ -1180,6 +1210,12 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  ai@6.0.175:
+    resolution: {integrity: sha512-6fFFHzbh6FIZnYc31V6osOxq25ABJYCShfG0O6ajHiA4FB/DgnPi1mP8cO5aAU3HNSbQHiMazdlh9bIsp97mVA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -1512,6 +1548,10 @@ packages:
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
@@ -2511,6 +2551,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -2588,6 +2629,9 @@ packages:
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -2604,26 +2648,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ai-sdk/provider-utils@2.2.8(zod@4.3.6)':
+  '@ai-sdk/gateway@3.0.110(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.26(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@2.2.8(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
-      zod: 4.3.6
+      zod: 4.4.3
 
-  '@ai-sdk/provider-utils@3.0.20(zod@4.3.6)':
+  '@ai-sdk/provider-utils@3.0.20(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
-      zod: 4.3.6
+      zod: 4.4.3
 
-  '@ai-sdk/provider-utils@4.0.0(zod@4.3.6)':
+  '@ai-sdk/provider-utils@4.0.0(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.0
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
-      zod: 4.3.6
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@4.0.26(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.4.3
 
   '@ai-sdk/provider@1.1.3':
     dependencies:
@@ -2637,16 +2695,20 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
+  '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
   '@ai-sdk/provider@3.0.5':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/ui-utils@1.2.11(zod@4.3.6)':
+  '@ai-sdk/ui-utils@1.2.11(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
 
   '@anthropic-ai/sdk@0.81.0(zod@4.3.6)':
     dependencies:
@@ -2703,25 +2765,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@arizeai/openinference-instrumentation-langchain@4.0.6(@langchain/core@1.1.39(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
+  '@arizeai/openinference-instrumentation-langchain@4.0.6(@langchain/core@1.1.39(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
     dependencies:
       '@arizeai/openinference-core': 2.0.5
       '@arizeai/openinference-semantic-conventions': 2.1.7
-      '@langchain/core': 1.1.39(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 1.1.39(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.46.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@arizeai/openinference-instrumentation-openai@4.0.5(openai@6.33.0(ws@8.20.0)(zod@4.3.6))':
+  '@arizeai/openinference-instrumentation-openai@4.0.5(openai@6.33.0(ws@8.20.0)(zod@4.4.3))':
     dependencies:
       '@arizeai/openinference-core': 2.0.5
       '@arizeai/openinference-semantic-conventions': 2.1.7
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.46.0(@opentelemetry/api@1.9.1)
-      openai: 6.33.0(ws@8.20.0)(zod@4.3.6)
+      openai: 6.33.0(ws@8.20.0)(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -3260,7 +3322,7 @@ snapshots:
 
   '@isaacs/ttlcache@2.1.4': {}
 
-  '@langchain/core@1.1.39(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)':
+  '@langchain/core@1.1.39(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@standard-schema/spec': 1.1.0
@@ -3268,11 +3330,11 @@ snapshots:
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.5.16(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      langsmith: 0.5.16(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       mustache: 4.2.0
       p-queue: 6.6.2
       uuid: 11.1.0
-      zod: 3.25.76
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -3286,18 +3348,18 @@ snapshots:
     dependencies:
       '@lukeed/csprng': 1.1.0
 
-  '@mastra/core@1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6)':
+  '@mastra/core@1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.4.3)':
     dependencies:
       '@a2a-js/sdk': 0.2.5
-      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@3.0.20(zod@4.3.6)'
-      '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.0(zod@4.3.6)'
+      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@3.0.20(zod@4.4.3)'
+      '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.0(zod@4.4.3)'
       '@ai-sdk/provider-v5': '@ai-sdk/provider@2.0.1'
       '@ai-sdk/provider-v6': '@ai-sdk/provider@3.0.5'
-      '@ai-sdk/ui-utils-v5': '@ai-sdk/ui-utils@1.2.11(zod@4.3.6)'
+      '@ai-sdk/ui-utils-v5': '@ai-sdk/ui-utils@1.2.11(zod@4.4.3)'
       '@isaacs/ttlcache': 2.1.4
       '@lukeed/uuid': 2.0.1
-      '@mastra/schema-compat': 1.2.7(zod@4.3.6)
-      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@mastra/schema-compat': 1.2.7(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       '@sindresorhus/slugify': 2.2.1
       '@standard-schema/spec': 1.1.0
       ajv: 8.18.0
@@ -3306,7 +3368,7 @@ snapshots:
       execa: 9.6.1
       gray-matter: 4.0.3
       hono: 4.12.10
-      hono-openapi: 1.3.0(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(hono@4.12.10)(openapi-types@12.1.3)
+      hono-openapi: 1.3.0(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(hono@4.12.10)(openapi-types@12.1.3)
       ignore: 7.0.5
       js-tiktoken: 1.0.21
       json-schema: 0.4.0
@@ -3318,7 +3380,7 @@ snapshots:
       tokenx: 1.3.0
       ws: 8.20.0
       xxhash-wasm: 1.1.0
-      zod: 4.3.6
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - '@hono/standard-validator'
@@ -3330,19 +3392,19 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@mastra/observability@1.7.2(@mastra/core@1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6))':
+  '@mastra/observability@1.7.2(@mastra/core@1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.4.3))':
     dependencies:
-      '@mastra/core': 1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6)
+      '@mastra/core': 1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.4.3)
 
-  '@mastra/schema-compat@1.2.7(zod@4.3.6)':
+  '@mastra/schema-compat@1.2.7(zod@4.4.3)':
     dependencies:
       json-schema-to-zod: 2.8.1
-      zod: 4.3.6
+      zod: 4.4.3
       zod-from-json-schema: 0.5.2
       zod-from-json-schema-v3: zod-from-json-schema@0.0.5
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
 
-  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.12(hono@4.12.10)
       ajv: 8.18.0
@@ -3359,8 +3421,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     optionalDependencies:
       '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
@@ -3369,6 +3431,8 @@ snapshots:
   '@opentelemetry/api-logs@0.57.2':
     dependencies:
       '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.0': {}
 
   '@opentelemetry/api@1.9.1': {}
 
@@ -3803,22 +3867,22 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)':
+  '@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/json-schema': 7.0.15
       quansync: 0.2.11
     optionalDependencies:
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
 
-  '@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6)':
+  '@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3)':
     dependencies:
-      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)
+      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
       '@standard-schema/spec': 1.1.0
       openapi-types: 12.1.3
     optionalDependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -3985,6 +4049,8 @@ snapshots:
       '@typescript-eslint/types': 8.58.0
       eslint-visitor-keys: 5.0.1
 
+  '@vercel/oidc@3.2.0': {}
+
   '@workflow/serde@4.1.0-beta.2': {}
 
   accepts@1.3.8:
@@ -4006,6 +4072,14 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  ai@6.0.175(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.110(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.26(zod@4.4.3)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.4.3
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
@@ -4353,6 +4427,8 @@ snapshots:
 
   eventsource-parser@3.0.6: {}
 
+  eventsource-parser@3.0.8: {}
+
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.0.6
@@ -4580,10 +4656,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono-openapi@1.3.0(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(hono@4.12.10)(openapi-types@12.1.3):
+  hono-openapi@1.3.0(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(hono@4.12.10)(openapi-types@12.1.3):
     dependencies:
-      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)
-      '@standard-community/standard-openapi': 0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6)
+      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
+      '@standard-community/standard-openapi': 0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3)
       '@types/json-schema': 7.0.15
       openapi-types: 12.1.3
     optionalDependencies:
@@ -4703,7 +4779,7 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  langsmith@0.5.16(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0):
+  langsmith@0.5.16(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0):
     dependencies:
       chalk: 5.6.2
       console-table-printer: 2.15.0
@@ -4714,7 +4790,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/exporter-trace-otlp-proto': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
-      openai: 6.33.0(ws@8.20.0)(zod@4.3.6)
+      openai: 6.33.0(ws@8.20.0)(zod@4.4.3)
       ws: 8.20.0
 
   levn@0.4.1:
@@ -5128,10 +5204,10 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  openai@6.33.0(ws@8.20.0)(zod@4.3.6):
+  openai@6.33.0(ws@8.20.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.20.0
-      zod: 4.3.6
+      zod: 4.4.3
 
   openapi-types@12.1.3: {}
 
@@ -5615,12 +5691,14 @@ snapshots:
     dependencies:
       zod: 4.3.6
 
-  zod-to-json-schema@3.25.2(zod@4.3.6):
+  zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
   zod@3.25.76: {}
 
   zod@4.3.6: {}
+
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
Bundled and verified version of #66. Picks up @Fizza-Mukhtar's two commits unchanged, adds two more on top:

1. **fix(processor): propagate `session.id` / `user.id` from Context to all spans** (resolves Arize-ai/openinference#2651 in our pipeline).
2. **test(traceroot): 8-scenario Vercel AI SDK integration suite** with concrete attribute / parent-id / status assertions — no "span exists" smoke checks.

Closes #66.

## Why this is a replacement instead of pushed onto #66

The processor swap sits in the default export path for **every** TraceRoot user, not behind an `instrumentModules` flag, so the blast radius is bigger than e.g. #78. #66 shipped without tests and without an answer on whether OI #2651 affects us. Both gaps are addressed here.

## Session/user context — definitive answer

**Yes, OI #2651 affects us.** Code path: `usingAttributes(...)` calls `setSession`/`setUser`/`setTags`/`setMetadata` from `@arizeai/openinference-core` to attach attributes to the OTel `Context` (`packages/traceroot/src/usingAttributes.ts:39-50`). `observe()` lifts those back via `getAttributesFromContext(context.active())` (`packages/traceroot/src/observe.ts:215-219`). But Vercel AI SDK spans are created outside `observe()` — directly via `tracer.startSpan` inside the SDK's `recordSpan` calls. `@arizeai/openinference-vercel`'s span processor doesn't lift OI Context attributes onto the span (issue #2651). Without a fix, a `usingAttributes({ sessionId })` wrapper around `generateText` produces a span with no `session.id`.

The fix is one block in `TraceRootSpanProcessor.onStart` that calls `getAttributesFromContext(parentContext)` and applies the result. Idempotent for the `observe()` path (same keys, same values). Closes the gap for *every* span TraceRoot processes, not just AI SDK ones — including any future provider-emitted spans we don't wrap with `observe()`.

## Tests (8 scenarios, all in the production stack)

Stack under test: `TraceRootSpanProcessor` wrapping `OpenInferenceSimpleSpanProcessor` over `InMemorySpanExporter`. Real Vercel AI SDK calls via `MockLanguageModelV3` (`ai/test`) — no network, no LLM costs. Each scenario asserts on real attribute names, span kinds, parent IDs, and status codes:

1. **Non-streaming `generateText`** — AGENT wrapper + LLM doGenerate child, mapped attrs (`input.value`, `output.value`, `llm.model_name`, `llm.token_count.{prompt,completion}`), `inner.parentSpanId === wrapper.spanId`, status not ERROR, `traceroot.sdk.name` still injected.
2. **Streaming `streamText`** — wrapper opens until consumption; output text reconstructed; usage on the LLM-kind doStream span; no leaks.
3. **Tool calling** — `ai.toolCall` span has TOOL kind with `tool.name`, args, result, parent equals the wrapper.
4. **Provider-throws error** — both spans ERROR, exception event recorded, no leaks.
5. **Stream-aborts error** — wrapper ERROR, no leaks.
6. **Nested call** — `generateText` inside `observe()`, Vercel wrapper's parent equals the observe() span, same trace.
7. **Pass-through** — a manual span with arbitrary attrs survives the OI processor unchanged (no `llm.*`/`span-kind` invented).
8. **Session/user propagation (the #2651 fix)** — `usingAttributes` around a `generateText` call produces a wrapper with `session.id`, `user.id`, `tag.tags` set.

Existing fixture in `tests/initialize.test.ts` updated to pass `ROOT_CONTEXT` instead of `{} as Context` (the new code path needs `Context.getValue()`).

## Mutation results (suite is 'real')

Each mutation applied to the production code, suite re-run, then reverted:

| # | Mutation | Caught by |
|---|---|---|
| A | Remove the `getAttributesFromContext` block in `TraceRootSpanProcessor.onStart` | 1 unit test (session/user propagation) |
| B | Drop `traceroot.sdk.name` / `traceroot.sdk.version` injection | 6 tests across 3 suites |
| C | Replace `OpenInference{Batch,Simple}SpanProcessor` with plain SDK ones in `traceroot.ts` | TypeScript compile error (constructor shape mismatch) |

Final: `# tests 92, # pass 92, # fail 0`.

## Live E2E (mock LLM, real OTLP transport, real backend)

Driver registered the production-wired TraceRoot tracer (`TraceRoot.initialize({ apiKey, environment, gitRepo, gitRef })`) against a local TraceRoot stack (rest on `:8000`, ClickHouse on `:8123`) and ran all 5 scenarios. ClickHouse query showed every expected span — 13 total — with the right OI mappings normalized into the collector's columns:

| trace | spans | tokens (in/out) | status | parent chain |
|---|---|---|---|---|
| non-stream | `ai.generateText` (AGENT, root) → `ai.generateText.doGenerate` (LLM) | 11/7 on LLM | OK | ✓ |
| stream | `ai.streamText` (AGENT, root) → `ai.streamText.doStream` (LLM) | 11/7 on LLM | OK | ✓ |
| tool | wrapper (AGENT, root) → 2× `doGenerate` (LLM) + `ai.toolCall` (TOOL) | 11/7 each | OK | tool parent = wrapper ✓ |
| error | wrapper (AGENT) → `doGenerate` (LLM) | 18/0 | **ERROR on both** | ✓ |
| nested | `e2e-outer` (CHAIN, root) → `ai.generateText` (AGENT) → `doGenerate` (LLM) | 11/7 on LLM | OK | wrapper parent = outer ✓ |

Trace-level proof of the #2651 fix: the nested run wrapped in `usingAttributes({ sessionId: 'e2e-sess', userId: 'e2e-user', tags: ['e2e'] })` lands in the `traces` table with `session_id="e2e-sess"`, `user_id="e2e-user"`, `tag.tags=["e2e"]` propagated through `ai.generateText` and `ai.generateText.doGenerate`. Without the fix, those columns are `NULL`.

## Type of Change

- [x] feat
- [x] fix (#2651 propagation)
- [x] test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Vercel AI SDK tracing via OpenInference in `TraceRoot`, enriching spans with model/usage and IO. Also propagates `session.id`/`user.id` (plus tags/metadata) from context to all spans, fixing missing context on Vercel-emitted spans (OpenInference issue #2651).

- **New Features**
  - Wire `OpenInferenceSimpleSpanProcessor`/`OpenInferenceBatchSpanProcessor` from `@arizeai/openinference-vercel` to enrich Vercel AI SDK spans before export.
  - Apply `usingAttributes` context to every span at start, including Vercel spans, while keeping `traceroot.sdk.*` and git/environment attributes.
  - Add an 8-scenario integration test suite for `generateText`, `streamText`, tool calls, errors, nesting, and pass-through spans.

- **Dependencies**
  - Add `@arizeai/openinference-vercel`.
  - Dev: add `ai` and `zod`.

<sup>Written for commit e79a63744a98018cd6f90d801f7e866aa3c10559. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

