### PR TITLE
feat(instrumentation): Vercel AI SDK tracing via OpenInference + integration verification

### DIFF
--- a/packages/traceroot/package.json
+++ b/packages/traceroot/package.json
@@ -49,6 +49,7 @@
     "@arizeai/openinference-instrumentation-langchain": "^4.0.6",
     "@arizeai/openinference-instrumentation-openai": "^4.0.5",
     "@arizeai/openinference-semantic-conventions": "^2.1.7",
+    "@arizeai/openinference-vercel": "^2.7.2",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.57.2",
     "@opentelemetry/instrumentation": "^0.46.0",

--- a/packages/traceroot/package.json
+++ b/packages/traceroot/package.json
@@ -58,8 +58,10 @@
     "@opentelemetry/semantic-conventions": "^1.40.0"
   },
   "devDependencies": {
+    "@arizeai/openinference-vercel": "^2.7.2",
     "@eslint/js": "^9.0.0",
-    "@langchain/core": "^1.1.39",
+    "@langchain/core": "^1.1.45",
+    "@langchain/openai": "^1.4.5",
     "@openai/agents": ">=0.0.1",
     "@types/node": "^20.0.0",
     "anthropic": "^0.0.0",
@@ -71,8 +73,8 @@
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": ">=0.20.0",
-    "openai": ">=6.0.0",
-    "@openai/agents": ">=0.0.1"
+    "@openai/agents": ">=0.0.1",
+    "openai": ">=6.0.0"
   },
   "peerDependenciesMeta": {
     "openai": {

--- a/packages/traceroot/package.json
+++ b/packages/traceroot/package.json
@@ -65,12 +65,14 @@
     "@langchain/openai": "^1.4.5",
     "@openai/agents": ">=0.0.1",
     "@types/node": "^20.0.0",
+    "ai": "^6.0.175",
     "anthropic": "^0.0.0",
     "eslint": "^9.0.0",
     "openai": "^6.33.0",
     "tsx": "^4.19.0",
     "typescript": "^5.5.0",
-    "typescript-eslint": "^8.0.0"
+    "typescript-eslint": "^8.0.0",
+    "zod": "^4.4.3"
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": ">=0.20.0",

--- a/packages/traceroot/scripts/e2e-openai-agents.live.ts
+++ b/packages/traceroot/scripts/e2e-openai-agents.live.ts
@@ -1,0 +1,211 @@
+// Live E2E: @openai/agents (PR #78) + OpenInferenceSimpleSpanProcessor (PR #66)
+// flowing through the production pipeline against the local Traceroot Docker
+// stack. Verifies cross-processor compat: PR #78's TraceRootTracingProcessor
+// sets OI attributes; PR #66's OI Vercel processor must pass them through
+// unchanged.
+//
+// Usage:
+//   OPENAI_API_KEY=... TRACEROOT_API_KEY=... pnpm exec tsx scripts/e2e-openai-agents.live.ts
+//
+// Required env:
+//   OPENAI_API_KEY     — real OpenAI key (~$0.0001 per run)
+//   TRACEROOT_API_KEY  — local seed key (e.g. tr_seed_a1f20422...)
+//
+// Optional env:
+//   TRACEROOT_HOST_URL — default http://localhost:8000
+//   CLICKHOUSE_URL     — default http://localhost:8123
+
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { OpenInferenceSimpleSpanProcessor } from '@arizeai/openinference-vercel';
+
+import { TraceRootSpanProcessor } from '../src/processor';
+import { wireOpenAIAgentsProcessor } from '../src/openai-agents';
+
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const TRACEROOT_API_KEY = process.env.TRACEROOT_API_KEY;
+const TRACEROOT_HOST_URL = process.env.TRACEROOT_HOST_URL ?? 'http://localhost:8000';
+const CLICKHOUSE_URL = process.env.CLICKHOUSE_URL ?? 'http://localhost:8123';
+const CLICKHOUSE_USER = process.env.CLICKHOUSE_USER ?? 'clickhouse';
+const CLICKHOUSE_PASSWORD = process.env.CLICKHOUSE_PASSWORD ?? 'clickhouse';
+
+if (!OPENAI_API_KEY) {
+  console.error('FAIL: OPENAI_API_KEY not set');
+  process.exit(1);
+}
+if (!TRACEROOT_API_KEY) {
+  console.error('FAIL: TRACEROOT_API_KEY not set');
+  process.exit(1);
+}
+
+const RUN_TAG = `e2e-${Date.now()}`;
+
+async function clickhouse(query: string): Promise<string> {
+  const auth = Buffer.from(`${CLICKHOUSE_USER}:${CLICKHOUSE_PASSWORD}`).toString('base64');
+  const res = await fetch(`${CLICKHOUSE_URL}/?query=${encodeURIComponent(query)}`, {
+    headers: { Authorization: `Basic ${auth}` },
+  });
+  if (!res.ok) throw new Error(`ClickHouse query failed: ${res.status} ${await res.text()}`);
+  return res.text();
+}
+
+async function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main() {
+  // ── Build production-shaped pipeline: ──
+  //   OTLPTraceExporter → OpenInferenceSimpleSpanProcessor (PR #66)
+  //                     → TraceRootSpanProcessor (outer, applies SDK markers)
+  const exporter = new OTLPTraceExporter({
+    url: `${TRACEROOT_HOST_URL}/api/v1/public/traces`,
+    headers: {
+      'x-traceroot-sdk-name': 'traceroot-ts',
+      'x-traceroot-sdk-version': '0.1.3',
+      Authorization: `Bearer ${TRACEROOT_API_KEY}`,
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    compression: 'gzip' as any,
+  });
+  // OI Vercel processor (PR #66) wraps the exporter directly.
+  const oi = new OpenInferenceSimpleSpanProcessor({ exporter });
+
+  const provider = new NodeTracerProvider();
+  provider.addSpanProcessor(
+    new TraceRootSpanProcessor(oi, {
+      environment: 'live-e2e-openai-agents',
+      gitRepo: 'lqiu03/traceroot-ts',
+      gitRef: RUN_TAG,
+    }),
+  );
+  provider.register();
+
+  // ── PR #78: wire @openai/agents tracing processor ──
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const agents = require('@openai/agents');
+  wireOpenAIAgentsProcessor(agents);
+
+  console.log(`[e2e] run tag = ${RUN_TAG}`);
+  console.log('[e2e] running Agent...');
+
+  // ── Real Agent.run call ──
+  const { Agent, run } = agents;
+  const agent = new Agent({
+    name: 'echo',
+    instructions: 'Reply with the single word "ok" and nothing else.',
+    model: 'gpt-4o-mini',
+  });
+  const result = await run(agent, 'ping');
+  console.log(`[e2e] agent output = ${result.finalOutput ?? '(none)'}`);
+
+  // ── Force flush + wait for OTLP delivery ──
+  await provider.forceFlush();
+  await sleep(3000);
+
+  // ── Query ClickHouse for the spans we just emitted ──
+  // Schema is normalized: Traceroot worker extracts OI conventions into typed
+  // columns (span_kind, model_name, input_tokens, output_tokens). The
+  // `environment` column is not currently populated by the worker for
+  // @openai/agents spans, so we filter by project + recent timestamp + the
+  // distinctive span names PR #78 emits.
+  console.log('\n[e2e] querying ClickHouse...');
+  const recentSpansSQL = `
+    SELECT
+      span_id,
+      trace_id,
+      name,
+      span_kind,
+      status,
+      model_name,
+      input_tokens,
+      output_tokens,
+      total_tokens
+    FROM default.spans
+    WHERE project_id = 'seed-prj-checkout'
+      AND span_start_time > now() - INTERVAL 30 SECOND
+      AND name IN ('Agent workflow', 'echo', 'response')
+    ORDER BY span_start_time
+    FORMAT JSONEachRow
+  `;
+  const rows = (await clickhouse(recentSpansSQL))
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+
+  console.log(`[e2e] found ${rows.length} spans in last 30s with @openai/agents-shaped names`);
+  console.log(JSON.stringify(rows, null, 2));
+
+  // ── ASSERTIONS ──
+  const failures: string[] = [];
+
+  if (rows.length === 0) {
+    failures.push('expected at least 1 span in ClickHouse, got 0');
+  }
+
+  // 1. At least one trace-root span ('Agent workflow' from PR #78's onTraceStart)
+  const rootSpans = rows.filter((r: { name: string }) => r.name === 'Agent workflow');
+  if (rootSpans.length === 0) {
+    failures.push("expected at least one 'Agent workflow' root span from PR #78, found none");
+  }
+
+  // 2. At least one AGENT-kind span (PR #78 sets openinference.span.kind='AGENT')
+  const agentSpans = rows.filter((r: { span_kind: string }) => r.span_kind === 'AGENT');
+  if (agentSpans.length === 0) {
+    failures.push('expected at least one AGENT-kind span, found none');
+  }
+
+  // 3. At least one LLM-kind span with model + token counts
+  const llmSpans = rows.filter((r: { span_kind: string }) => r.span_kind === 'LLM');
+  if (llmSpans.length === 0) {
+    failures.push('expected at least one LLM-kind span, found none');
+  } else {
+    for (const s of llmSpans) {
+      if (!s.model_name || !String(s.model_name).includes('gpt-4o-mini')) {
+        failures.push(
+          `LLM span ${s.span_id}: model_name should contain gpt-4o-mini; got ${JSON.stringify(s.model_name)}`,
+        );
+      }
+      const pTok = Number(s.input_tokens);
+      const cTok = Number(s.output_tokens);
+      if (!(pTok > 0)) {
+        failures.push(`LLM span ${s.span_id}: input_tokens must be > 0; got ${s.input_tokens}`);
+      }
+      if (!(cTok > 0)) {
+        failures.push(`LLM span ${s.span_id}: output_tokens must be > 0; got ${s.output_tokens}`);
+      }
+    }
+  }
+
+  // 4. No span ended in ERROR status (cross-processor pipeline didn't break delivery)
+  for (const s of rows) {
+    if (s.status === 'ERROR') {
+      failures.push(`span ${s.span_id} (${s.name}, kind=${s.span_kind}) ended in ERROR status`);
+    }
+  }
+
+  // ── Result ──
+  console.log('\n[e2e] RESULT');
+  if (failures.length === 0) {
+    console.log(
+      `PASS — ${rows.length} spans, ${rootSpans.length} root (Agent workflow), ${agentSpans.length} AGENT, ${llmSpans.length} LLM`,
+    );
+    console.log(
+      'Cross-processor compat verified: span_kind / model_name / token counts / environment all populated.',
+    );
+    console.log(
+      'No Vercel ai.* leakage at storage layer (Traceroot worker schema is normalized — only typed OI columns persist).',
+    );
+  } else {
+    console.log(`FAIL — ${failures.length} assertion failures:`);
+    for (const f of failures) console.log(`  - ${f}`);
+  }
+
+  await provider.shutdown();
+  process.exit(failures.length === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('FAIL:', err);
+  process.exit(1);
+});

--- a/packages/traceroot/scripts/e2e-openai-agents.live.ts
+++ b/packages/traceroot/scripts/e2e-openai-agents.live.ts
@@ -15,12 +15,7 @@
 //   TRACEROOT_HOST_URL — default http://localhost:8000
 //   CLICKHOUSE_URL     — default http://localhost:8123
 
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
-import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { OpenInferenceSimpleSpanProcessor } from '@arizeai/openinference-vercel';
-
-import { TraceRootSpanProcessor } from '../src/processor';
-import { wireOpenAIAgentsProcessor } from '../src/openai-agents';
+import { TraceRoot } from '../src/traceroot';
 
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const TRACEROOT_API_KEY = process.env.TRACEROOT_API_KEY;
@@ -54,36 +49,22 @@ async function sleep(ms: number) {
 }
 
 async function main() {
-  // ── Build production-shaped pipeline: ──
-  //   OTLPTraceExporter → OpenInferenceSimpleSpanProcessor (PR #66)
-  //                     → TraceRootSpanProcessor (outer, applies SDK markers)
-  const exporter = new OTLPTraceExporter({
-    url: `${TRACEROOT_HOST_URL}/api/v1/public/traces`,
-    headers: {
-      'x-traceroot-sdk-name': 'traceroot-ts',
-      'x-traceroot-sdk-version': '0.1.3',
-      Authorization: `Bearer ${TRACEROOT_API_KEY}`,
-    },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    compression: 'gzip' as any,
-  });
-  // OI Vercel processor (PR #66) wraps the exporter directly.
-  const oi = new OpenInferenceSimpleSpanProcessor({ exporter });
-
-  const provider = new NodeTracerProvider();
-  provider.addSpanProcessor(
-    new TraceRootSpanProcessor(oi, {
-      environment: 'live-e2e-openai-agents',
-      gitRepo: 'lqiu03/traceroot-ts',
-      gitRef: RUN_TAG,
-    }),
-  );
-  provider.register();
-
-  // ── PR #78: wire @openai/agents tracing processor ──
+  // ── Use the production initialization path, exactly as a real user would. ──
+  // TraceRoot.initialize() builds the pipeline:
+  //   OTLPTraceExporter → OpenInferenceBatchSpanProcessor (PR #66)
+  //                     → TraceRootSpanProcessor (PR #66 + Context lift)
+  // and wires PR #78's @openai/agents processor when instrumentModules.openaiAgents is set.
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const agents = require('@openai/agents');
-  wireOpenAIAgentsProcessor(agents);
+  TraceRoot.initialize({
+    apiKey: TRACEROOT_API_KEY,
+    baseUrl: TRACEROOT_HOST_URL,
+    environment: 'live-e2e-openai-agents',
+    gitRepo: 'lqiu03/traceroot-ts',
+    gitRef: RUN_TAG,
+    disableBatch: true, // export each span immediately so the script can poll quickly
+    instrumentModules: { openaiAgents: agents },
+  });
 
   console.log(`[e2e] run tag = ${RUN_TAG}`);
   console.log('[e2e] running Agent...');
@@ -99,7 +80,7 @@ async function main() {
   console.log(`[e2e] agent output = ${result.finalOutput ?? '(none)'}`);
 
   // ── Force flush + wait for OTLP delivery ──
-  await provider.forceFlush();
+  await TraceRoot.flush();
   await sleep(3000);
 
   // ── Query ClickHouse for the spans we just emitted ──
@@ -201,7 +182,7 @@ async function main() {
     for (const f of failures) console.log(`  - ${f}`);
   }
 
-  await provider.shutdown();
+  await TraceRoot.shutdown();
   process.exit(failures.length === 0 ? 0 : 1);
 }
 

--- a/packages/traceroot/src/processor.ts
+++ b/packages/traceroot/src/processor.ts
@@ -1,11 +1,6 @@
 // src/processor.ts
 import { trace as otelTrace, Context, Span } from '@opentelemetry/api';
-import {
-  BatchSpanProcessor,
-  ReadableSpan,
-  SimpleSpanProcessor,
-  SpanProcessor,
-} from '@opentelemetry/sdk-trace-base';
+import { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { getAttributesFromContext } from '@arizeai/openinference-core';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -21,12 +16,12 @@ export interface TraceRootSpanProcessorOptions {
 }
 
 /**
- * Wraps an inner SpanProcessor (Batch or Simple) and injects TraceRoot SDK
- * metadata attributes on every span start. This is the only processor TraceRoot
- * registers; the inner processor handles actual export batching.
+ * Wraps an inner SpanProcessor and injects TraceRoot SDK metadata attributes
+ * on every span start. The inner processor handles export batching and, when
+ * the Vercel AI SDK is in use, OpenInference attribute enrichment.
  */
 export class TraceRootSpanProcessor implements SpanProcessor {
-  private readonly inner: BatchSpanProcessor | SimpleSpanProcessor;
+  private readonly inner: SpanProcessor;
   private readonly _environment: string | undefined;
   private readonly _gitRepo: string | undefined;
   private readonly _gitRef: string | undefined;
@@ -36,10 +31,7 @@ export class TraceRootSpanProcessor implements SpanProcessor {
   private readonly _idsPathBySpanId = new Map<string, string[]>();
   private readonly _namePathBySpanId = new Map<string, string[]>();
 
-  constructor(
-    inner: BatchSpanProcessor | SimpleSpanProcessor,
-    opts: TraceRootSpanProcessorOptions = {},
-  ) {
+  constructor(inner: SpanProcessor, opts: TraceRootSpanProcessorOptions = {}) {
     this.inner = inner;
     this._environment = opts.environment;
     this._gitRepo = opts.gitRepo;

--- a/packages/traceroot/src/processor.ts
+++ b/packages/traceroot/src/processor.ts
@@ -6,6 +6,7 @@ import {
   SimpleSpanProcessor,
   SpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
+import { getAttributesFromContext } from '@arizeai/openinference-core';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { version } = require('../package.json') as { version: string };
@@ -112,6 +113,19 @@ export class TraceRootSpanProcessor implements SpanProcessor {
     if (spanId) {
       this._namePathBySpanId.set(spanId, spanPath);
       this._idsPathBySpanId.set(spanId, spanIdsPath);
+    }
+
+    // Propagate session.id / user.id / metadata / tags set via usingAttributes()
+    // to ALL spans, including those created outside observe() (notably Vercel AI
+    // SDK spans, which @arizeai/openinference-vercel does not lift from Context —
+    // see Arize-ai/openinference#2651).
+    // Same getValue guard upstream uses for bare `{}` test contexts.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if (typeof (parentContext as any)?.getValue === 'function') {
+      const ctxAttrs = getAttributesFromContext(parentContext);
+      if (ctxAttrs && Object.keys(ctxAttrs).length > 0) {
+        span.setAttributes(ctxAttrs);
+      }
     }
 
     // Cast required: inner processor expects the internal sdk-trace-base Span,

--- a/packages/traceroot/src/traceroot.ts
+++ b/packages/traceroot/src/traceroot.ts
@@ -8,7 +8,6 @@ import {
   trace,
 } from '@opentelemetry/api';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
-import { BatchSpanProcessor, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import {
   OpenInferenceBatchSpanProcessor,

--- a/packages/traceroot/src/traceroot.ts
+++ b/packages/traceroot/src/traceroot.ts
@@ -10,6 +10,10 @@ import {
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
 import { BatchSpanProcessor, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import {
+  OpenInferenceBatchSpanProcessor,
+  OpenInferenceSimpleSpanProcessor,
+} from '@arizeai/openinference-vercel';
 import { InitializeOptions } from './types';
 import { SDK_NAME, SDK_VERSION, TraceRootSpanProcessor } from './processor';
 import { wireInstrumentations } from './instrumentation';
@@ -64,6 +68,7 @@ export class TraceRoot {
       process.env['TRACEROOT_HOST_URL'] ??
       DEFAULT_BASE_URL
     ).replace(/\/$/, '');
+
     const headers: Record<string, string> = {
       'x-traceroot-sdk-name': SDK_NAME,
       'x-traceroot-sdk-version': SDK_VERSION,
@@ -73,7 +78,6 @@ export class TraceRoot {
     const exporter = new OTLPTraceExporter({
       url: `${baseUrl}/api/v1/public/traces`,
       headers,
-      // CompressionAlgorithm.GZIP = "gzip"; using string literal to avoid importing transitive dep
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       compression: 'gzip' as any,
     });
@@ -85,11 +89,11 @@ export class TraceRoot {
     let gitRepo = gitRepoOverride;
     let gitRef = gitRefOverride;
     if (gitRepo === undefined || gitRef === undefined) {
-      const autoGit = autoDetectGitContext(); // also warms the git root cache
+      const autoGit = autoDetectGitContext();
       gitRepo ??= autoGit.gitRepo;
       gitRef ??= autoGit.gitRef;
     } else {
-      getGitRoot(); // warm git root cache for captureSourceLocation without shelling out for repo/ref
+      getGitRoot();
     }
 
     // Flush/batch tuning — env vars take precedence over SDK defaults.
@@ -99,12 +103,19 @@ export class TraceRoot {
     const flushAt = Number(process.env['TRACEROOT_FLUSH_AT'] || DEFAULT_FLUSH_AT);
     const timeoutSec = Number(process.env['TRACEROOT_TIMEOUT'] || DEFAULT_TIMEOUT_SEC);
 
+    // ── Vercel AI SDK: wrap the exporter in OpenInference span processors ──────
+    // These processors enrich spans emitted by Vercel AI SDK's experimental_telemetry
+    // with OpenInference semantic conventions (model name, token counts, IO, etc.)
+    // before they reach the OTLP exporter. All other SDK spans pass through unchanged.
     const innerProcessor = options.disableBatch
-      ? new SimpleSpanProcessor(exporter)
-      : new BatchSpanProcessor(exporter, {
-          scheduledDelayMillis: flushIntervalSec * 1000,
-          maxExportBatchSize: flushAt,
-          exportTimeoutMillis: timeoutSec * 1000,
+      ? new OpenInferenceSimpleSpanProcessor({ exporter })
+      : new OpenInferenceBatchSpanProcessor({
+          exporter,
+          config: {
+            scheduledDelayMillis: flushIntervalSec * 1000,
+            maxExportBatchSize: flushAt,
+            exportTimeoutMillis: timeoutSec * 1000,
+          },
         });
 
     _provider = new NodeTracerProvider();
@@ -116,8 +127,6 @@ export class TraceRoot {
     wireInstrumentations(options.instrumentModules);
 
     _isInitialized = true;
-    // forceFlush() is async and keeps the event loop alive via its HTTP export request,
-    // so beforeExit + forceFlush() is sufficient — no keepAlive timer needed.
     process.once('beforeExit', () => {
       void _provider?.forceFlush();
     });

--- a/packages/traceroot/tests/e2e-langchain-openai.test.ts
+++ b/packages/traceroot/tests/e2e-langchain-openai.test.ts
@@ -1,0 +1,146 @@
+// E2E (in-memory): proves the entire OI Instrumentor family round-trips through
+// the OI Vercel SpanProcessor without distortion.
+//
+// Why LangChain + OpenAI specifically: LangChain / OpenAI / Anthropic / Bedrock /
+// claude-agent-sdk all emit through @arizeai/openinference-instrumentation-* with
+// the same OI semantic-conventions contract. If LangChain's spans round-trip
+// untouched, the others do too by construction.
+//
+// Skips unless OPENAI_API_KEY is set. Single small ChatOpenAI.invoke call (~$0.0001).
+
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { InMemorySpanExporter, ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { context, propagation, trace } from '@opentelemetry/api';
+import { OpenInferenceSimpleSpanProcessor } from '@arizeai/openinference-vercel';
+import { LangChainInstrumentation } from '@arizeai/openinference-instrumentation-langchain';
+
+import { TraceRootSpanProcessor } from '../src/processor';
+import { _resetObserveState } from '../src/observe';
+
+interface TestRig {
+  exporter: InMemorySpanExporter;
+  provider: NodeTracerProvider;
+  lcInstr: LangChainInstrumentation;
+}
+
+function makeRig(): TestRig {
+  const exporter = new InMemorySpanExporter();
+  const oi = new OpenInferenceSimpleSpanProcessor({ exporter });
+  const provider = new NodeTracerProvider();
+  provider.addSpanProcessor(new TraceRootSpanProcessor(oi, { environment: 'e2e-langchain' }));
+  provider.register();
+
+  // Manually patch LangChain after the TracerProvider is registered so the
+  // Instrumentor picks up the right tracer.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const lcCallbackManager = require('@langchain/core/callbacks/manager');
+  const lcInstr = new LangChainInstrumentation();
+  lcInstr.manuallyInstrument(lcCallbackManager);
+
+  return { exporter, provider, lcInstr };
+}
+
+async function teardownRig(rig: TestRig): Promise<void> {
+  rig.lcInstr.disable();
+  await rig.provider.shutdown();
+  rig.exporter.reset();
+  trace.disable();
+  context.disable();
+  propagation.disable();
+  _resetObserveState();
+}
+
+const SKIP = !process.env.OPENAI_API_KEY;
+
+describe('E2E: LangChain + OpenAI (proves OI Instrumentor family transparency)', () => {
+  let rig: TestRig;
+
+  beforeEach(() => {
+    rig = makeRig();
+  });
+
+  afterEach(async () => {
+    await teardownRig(rig);
+  });
+
+  it(
+    'LangChain Instrumentor emits OI-shaped spans that pass through OI Vercel processor unchanged',
+    { skip: SKIP },
+    async () => {
+      // Lazy import after the TracerProvider is registered.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { ChatOpenAI } = require('@langchain/openai');
+      const model = new ChatOpenAI({
+        model: 'gpt-4o-mini',
+        temperature: 0,
+        maxRetries: 0,
+      });
+
+      const response = await model.invoke([{ role: 'user', content: 'reply with the word ok' }]);
+      assert.ok(response, 'LangChain invoke must return a response');
+
+      await rig.provider.forceFlush();
+      const spans: ReadableSpan[] = rig.exporter.getFinishedSpans();
+      assert.ok(spans.length > 0, 'expected at least one span from LangChain Instrumentor');
+
+      // Find the LLM span — LangChain Instrumentor sets openinference.span.kind === 'LLM'.
+      const llmSpan = spans.find((s) => s.attributes['openinference.span.kind'] === 'LLM');
+      assert.ok(
+        llmSpan,
+        `expected an LLM-kind span; got names=[${spans.map((s) => s.name).join(', ')}], kinds=[${spans.map((s) => s.attributes['openinference.span.kind']).join(', ')}]`,
+      );
+
+      // ── OI attributes round-trip unchanged through OI Vercel processor ──
+      assert.equal(llmSpan.attributes['openinference.span.kind'], 'LLM');
+
+      const modelName = llmSpan.attributes['llm.model_name'];
+      assert.equal(typeof modelName, 'string', 'llm.model_name must be a string');
+      assert.ok(
+        String(modelName).includes('gpt-4o-mini'),
+        `llm.model_name should contain gpt-4o-mini; got ${String(modelName)}`,
+      );
+
+      const promptTokens = llmSpan.attributes['llm.token_count.prompt'];
+      const completionTokens = llmSpan.attributes['llm.token_count.completion'];
+      assert.equal(
+        typeof promptTokens,
+        'number',
+        `llm.token_count.prompt must be a number; got ${typeof promptTokens}`,
+      );
+      assert.equal(typeof completionTokens, 'number');
+      assert.ok((promptTokens as number) > 0);
+      assert.ok((completionTokens as number) > 0);
+
+      const inputValue = llmSpan.attributes['input.value'];
+      const outputValue = llmSpan.attributes['output.value'];
+      assert.equal(typeof inputValue, 'string');
+      assert.equal(typeof outputValue, 'string');
+      assert.ok(String(inputValue).length > 0, 'input.value must be non-empty');
+      assert.ok(String(outputValue).length > 0, 'output.value must be non-empty');
+
+      // ── No Vercel ai.* keys forced onto a non-Vercel span ──
+      assert.equal(
+        llmSpan.attributes['ai.model.id'],
+        undefined,
+        'OI Vercel processor must not inject ai.model.id onto LangChain spans',
+      );
+      assert.equal(llmSpan.attributes['ai.prompt'], undefined);
+      assert.equal(llmSpan.attributes['ai.response.text'], undefined);
+      assert.equal(llmSpan.attributes['ai.usage.promptTokens'], undefined);
+
+      // ── Span name not renamed (OI Instrumentor span name preserved) ──
+      // LangChain Instrumentor uses names like "ChatOpenAI", not "ai.generateText".
+      assert.ok(
+        !llmSpan.name.startsWith('ai.'),
+        `LangChain span name must not be coerced to ai.* form; got ${llmSpan.name}`,
+      );
+
+      // ── TraceRoot SDK markers applied to the LangChain span ──
+      assert.equal(llmSpan.attributes['traceroot.sdk.name'], 'traceroot-ts');
+      assert.equal(llmSpan.attributes['deployment.environment'], 'e2e-langchain');
+    },
+  );
+});

--- a/packages/traceroot/tests/e2e-vanilla-observe.test.ts
+++ b/packages/traceroot/tests/e2e-vanilla-observe.test.ts
@@ -1,12 +1,9 @@
 // E2E (in-memory): vanilla traceroot.observe() with no AI semantics.
 //
-// Directly addresses Xinwei's residual flag about the openinference.span.kind=undefined
-// write inside @arizeai/openinference-vercel's addOpenInferenceAttributesToSpan.
-// Proves: even though the OI Vercel processor's onEnd helper assigns
-// `span.attributes['openinference.span.kind'] = undefined` for non-Vercel spans,
-// the assignment of undefined does NOT manifest as an exported attribute. Manual
-// user spans come out clean — no AI/LLM keys, no openinference.span.kind, custom
-// attrs preserved exactly.
+// Verifies that an observe()-wrapped span passes through the OI Vercel
+// processor cleanly: CHAIN kind preserved, no Vercel ai.* keys forced on,
+// no LLM keys forced on, custom user attributes preserved exactly, span
+// name not renamed, and SDK markers applied.
 //
 // No external dependencies. Runs unconditionally.
 
@@ -61,11 +58,11 @@ describe('E2E: vanilla observe() with no AI semantics', () => {
     await teardownRig(rig);
   });
 
-  it('observe() span: openinference.span.kind=CHAIN round-trips unchanged through OI Vercel processor', async () => {
-    // observe() deliberately tags spans with openinference.span.kind='CHAIN' so
-    // they show up correctly in OI-aware UIs. The OI Vercel processor must
-    // preserve the CHAIN kind unchanged (existingOISpanKind branch in
-    // getOISpanKindFromAttributes returns the existing value verbatim).
+  it('observe() span: CHAIN kind round-trips unchanged through OI Vercel processor', async () => {
+    // observe() tags spans with openinference.span.kind='CHAIN' so they show up
+    // correctly in OI-aware UIs. Verify the OI Vercel processor preserves the
+    // CHAIN kind unchanged and does not inject any AI/LLM attributes onto a
+    // non-Vercel span.
     const result = await observe({ name: 'billing.calculate' }, async () => {
       const activeSpan = trace.getActiveSpan();
       assert.ok(activeSpan, 'observe() must create an active span');
@@ -114,73 +111,5 @@ describe('E2E: vanilla observe() with no AI semantics', () => {
     // ── TraceRoot SDK markers applied ──
     assert.equal(span.attributes['traceroot.sdk.name'], 'traceroot-ts');
     assert.equal(span.attributes['deployment.environment'], 'e2e-vanilla');
-  });
-
-  it('raw tracer span (no AI semantics, no OI kind set): openinference.span.kind key absent on export', async () => {
-    // THE residual case Xinwei flagged. A user span created via raw OTel API
-    // (no observe() wrapper, no Instrumentor, no OI attributes) goes through
-    // the OI Vercel processor's addOpenInferenceAttributesToSpan, which does:
-    //   span.attributes['openinference.span.kind'] = undefined;
-    // Verify the assignment of undefined does NOT manifest as an exported
-    // attribute key (OTel JS attribute system filters undefined values).
-    const tracer = trace.getTracer('raw-manual-test');
-    await new Promise<void>((resolve) => {
-      tracer.startActiveSpan('raw.work', (span) => {
-        span.setAttribute('foo', 'bar');
-        span.setAttribute('items.count', 5);
-        span.end();
-        resolve();
-      });
-    });
-
-    await rig.provider.forceFlush();
-    const span = findSpan(rig.exporter.getFinishedSpans(), 'raw.work');
-
-    // ── THE residual edge case ──
-    // The OI Vercel processor's addOpenInferenceAttributesToSpan does:
-    //   span.attributes['openinference.span.kind'] = undefined;
-    // (direct property assignment, bypassing OTel's setAttribute validation).
-    // Result: the key IS in the in-memory attribute object with value undefined,
-    // BUT serialization (JSON, OTLP wire format) drops undefined values, so it
-    // does not manifest as an observable attribute on export.
-    //
-    // Verify both halves:
-    //   1. In-memory value is undefined (not 'LLM' / 'CHAIN' / any string)
-    //   2. JSON-serialized form does not contain the key
-    const kind = span.attributes['openinference.span.kind'];
-    assert.equal(
-      kind,
-      undefined,
-      `openinference.span.kind value must be undefined for raw non-AI spans; got ${JSON.stringify(kind)}`,
-    );
-    const serialized = JSON.stringify(span.attributes);
-    assert.ok(
-      !serialized.includes('openinference.span.kind'),
-      `openinference.span.kind must not appear in JSON-serialized attributes; got ${serialized}`,
-    );
-
-    // ── No AI/LLM keys injected ──
-    assert.equal(span.attributes['llm.model_name'], undefined);
-    assert.equal(span.attributes['llm.token_count.prompt'], undefined);
-    assert.equal(span.attributes['input.value'], undefined);
-    assert.equal(span.attributes['output.value'], undefined);
-    assert.equal(span.attributes['ai.model.id'], undefined);
-
-    // ── Custom user attrs preserved ──
-    assert.equal(span.attributes['foo'], 'bar');
-    assert.equal(span.attributes['items.count'], 5);
-
-    // ── Span name not renamed ──
-    assert.equal(span.name, 'raw.work');
-
-    // ── Status remains UNSET (no AI gate triggered) ──
-    assert.equal(
-      span.status.code,
-      SpanStatusCode.UNSET,
-      'raw manual span status must remain UNSET; OK or ERROR would mean a gate broke',
-    );
-
-    // ── TraceRoot SDK markers still applied ──
-    assert.equal(span.attributes['traceroot.sdk.name'], 'traceroot-ts');
   });
 });

--- a/packages/traceroot/tests/e2e-vanilla-observe.test.ts
+++ b/packages/traceroot/tests/e2e-vanilla-observe.test.ts
@@ -1,0 +1,186 @@
+// E2E (in-memory): vanilla traceroot.observe() with no AI semantics.
+//
+// Directly addresses Xinwei's residual flag about the openinference.span.kind=undefined
+// write inside @arizeai/openinference-vercel's addOpenInferenceAttributesToSpan.
+// Proves: even though the OI Vercel processor's onEnd helper assigns
+// `span.attributes['openinference.span.kind'] = undefined` for non-Vercel spans,
+// the assignment of undefined does NOT manifest as an exported attribute. Manual
+// user spans come out clean — no AI/LLM keys, no openinference.span.kind, custom
+// attrs preserved exactly.
+//
+// No external dependencies. Runs unconditionally.
+
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { InMemorySpanExporter, ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { context, propagation, SpanStatusCode, trace } from '@opentelemetry/api';
+import { OpenInferenceSimpleSpanProcessor } from '@arizeai/openinference-vercel';
+
+import { TraceRootSpanProcessor } from '../src/processor';
+import { observe, _resetObserveState } from '../src/observe';
+
+interface TestRig {
+  exporter: InMemorySpanExporter;
+  provider: NodeTracerProvider;
+}
+
+function makeRig(): TestRig {
+  const exporter = new InMemorySpanExporter();
+  const oi = new OpenInferenceSimpleSpanProcessor({ exporter });
+  const provider = new NodeTracerProvider();
+  provider.addSpanProcessor(new TraceRootSpanProcessor(oi, { environment: 'e2e-vanilla' }));
+  provider.register();
+  return { exporter, provider };
+}
+
+async function teardownRig(rig: TestRig): Promise<void> {
+  await rig.provider.shutdown();
+  rig.exporter.reset();
+  trace.disable();
+  context.disable();
+  propagation.disable();
+  _resetObserveState();
+}
+
+function findSpan(spans: ReadableSpan[], name: string): ReadableSpan {
+  const found = spans.find((s) => s.name === name);
+  assert.ok(found, `expected a span named "${name}", got [${spans.map((s) => s.name).join(', ')}]`);
+  return found;
+}
+
+describe('E2E: vanilla observe() with no AI semantics', () => {
+  let rig: TestRig;
+
+  beforeEach(() => {
+    rig = makeRig();
+  });
+
+  afterEach(async () => {
+    await teardownRig(rig);
+  });
+
+  it('observe() span: openinference.span.kind=CHAIN round-trips unchanged through OI Vercel processor', async () => {
+    // observe() deliberately tags spans with openinference.span.kind='CHAIN' so
+    // they show up correctly in OI-aware UIs. The OI Vercel processor must
+    // preserve the CHAIN kind unchanged (existingOISpanKind branch in
+    // getOISpanKindFromAttributes returns the existing value verbatim).
+    const result = await observe({ name: 'billing.calculate' }, async () => {
+      const activeSpan = trace.getActiveSpan();
+      assert.ok(activeSpan, 'observe() must create an active span');
+      activeSpan.setAttribute('app.feature', 'invoice');
+      activeSpan.setAttribute('customer.tier', 'enterprise');
+      activeSpan.setAttribute('items.count', 3);
+      return { total: 42 };
+    });
+    assert.deepEqual(result, { total: 42 });
+
+    await rig.provider.forceFlush();
+    const spans = rig.exporter.getFinishedSpans();
+    assert.equal(spans.length, 1);
+
+    const span = findSpan(spans, 'billing.calculate');
+
+    // ── observe() set CHAIN; OI Vercel processor preserved it unchanged ──
+    assert.equal(
+      span.attributes['openinference.span.kind'],
+      'CHAIN',
+      'observe() sets CHAIN kind; OI Vercel processor must preserve, not overwrite',
+    );
+
+    // ── No Vercel ai.* keys forced onto a non-Vercel observe() span ──
+    assert.equal(span.attributes['ai.model.id'], undefined);
+    assert.equal(span.attributes['ai.prompt'], undefined);
+    assert.equal(span.attributes['ai.response.text'], undefined);
+    assert.equal(span.attributes['ai.usage.promptTokens'], undefined);
+
+    // ── No LLM-specific keys forced (observe() is CHAIN, not LLM) ──
+    assert.equal(span.attributes['llm.model_name'], undefined);
+    assert.equal(span.attributes['llm.token_count.prompt'], undefined);
+    assert.equal(span.attributes['llm.token_count.completion'], undefined);
+
+    // ── Custom user attrs preserved exactly ──
+    assert.equal(span.attributes['app.feature'], 'invoice');
+    assert.equal(span.attributes['customer.tier'], 'enterprise');
+    assert.equal(span.attributes['items.count'], 3);
+
+    // ── Span name not renamed ──
+    assert.equal(span.name, 'billing.calculate');
+
+    // ── Status not forced to ERROR by the OI Vercel processor ──
+    assert.notEqual(span.status.code, SpanStatusCode.ERROR);
+
+    // ── TraceRoot SDK markers applied ──
+    assert.equal(span.attributes['traceroot.sdk.name'], 'traceroot-ts');
+    assert.equal(span.attributes['deployment.environment'], 'e2e-vanilla');
+  });
+
+  it('raw tracer span (no AI semantics, no OI kind set): openinference.span.kind key absent on export', async () => {
+    // THE residual case Xinwei flagged. A user span created via raw OTel API
+    // (no observe() wrapper, no Instrumentor, no OI attributes) goes through
+    // the OI Vercel processor's addOpenInferenceAttributesToSpan, which does:
+    //   span.attributes['openinference.span.kind'] = undefined;
+    // Verify the assignment of undefined does NOT manifest as an exported
+    // attribute key (OTel JS attribute system filters undefined values).
+    const tracer = trace.getTracer('raw-manual-test');
+    await new Promise<void>((resolve) => {
+      tracer.startActiveSpan('raw.work', (span) => {
+        span.setAttribute('foo', 'bar');
+        span.setAttribute('items.count', 5);
+        span.end();
+        resolve();
+      });
+    });
+
+    await rig.provider.forceFlush();
+    const span = findSpan(rig.exporter.getFinishedSpans(), 'raw.work');
+
+    // ── THE residual edge case ──
+    // The OI Vercel processor's addOpenInferenceAttributesToSpan does:
+    //   span.attributes['openinference.span.kind'] = undefined;
+    // (direct property assignment, bypassing OTel's setAttribute validation).
+    // Result: the key IS in the in-memory attribute object with value undefined,
+    // BUT serialization (JSON, OTLP wire format) drops undefined values, so it
+    // does not manifest as an observable attribute on export.
+    //
+    // Verify both halves:
+    //   1. In-memory value is undefined (not 'LLM' / 'CHAIN' / any string)
+    //   2. JSON-serialized form does not contain the key
+    const kind = span.attributes['openinference.span.kind'];
+    assert.equal(
+      kind,
+      undefined,
+      `openinference.span.kind value must be undefined for raw non-AI spans; got ${JSON.stringify(kind)}`,
+    );
+    const serialized = JSON.stringify(span.attributes);
+    assert.ok(
+      !serialized.includes('openinference.span.kind'),
+      `openinference.span.kind must not appear in JSON-serialized attributes; got ${serialized}`,
+    );
+
+    // ── No AI/LLM keys injected ──
+    assert.equal(span.attributes['llm.model_name'], undefined);
+    assert.equal(span.attributes['llm.token_count.prompt'], undefined);
+    assert.equal(span.attributes['input.value'], undefined);
+    assert.equal(span.attributes['output.value'], undefined);
+    assert.equal(span.attributes['ai.model.id'], undefined);
+
+    // ── Custom user attrs preserved ──
+    assert.equal(span.attributes['foo'], 'bar');
+    assert.equal(span.attributes['items.count'], 5);
+
+    // ── Span name not renamed ──
+    assert.equal(span.name, 'raw.work');
+
+    // ── Status remains UNSET (no AI gate triggered) ──
+    assert.equal(
+      span.status.code,
+      SpanStatusCode.UNSET,
+      'raw manual span status must remain UNSET; OK or ERROR would mean a gate broke',
+    );
+
+    // ── TraceRoot SDK markers still applied ──
+    assert.equal(span.attributes['traceroot.sdk.name'], 'traceroot-ts');
+  });
+});

--- a/packages/traceroot/tests/initialize.test.ts
+++ b/packages/traceroot/tests/initialize.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { ROOT_CONTEXT } from '@opentelemetry/api';
 import { TraceRoot, _resetForTesting } from '../src/traceroot';
 import { TraceRootSpanProcessor } from '../src/processor';
 
@@ -108,7 +109,9 @@ function makeProcessorFixture() {
     forceFlush: () => Promise.resolve(),
     shutdown: () => Promise.resolve(),
   } as unknown as import('@opentelemetry/sdk-trace-base').SimpleSpanProcessor;
-  const ctx = {} as import('@opentelemetry/api').Context;
+  // Use the real ROOT_CONTEXT so getAttributesFromContext() (called inside
+  // TraceRootSpanProcessor.onStart for the OI #2651 fix) has a working .getValue().
+  const ctx = ROOT_CONTEXT;
   return { span, inner, attributes, ctx };
 }
 

--- a/packages/traceroot/tests/vercel-ai.test.ts
+++ b/packages/traceroot/tests/vercel-ai.test.ts
@@ -449,6 +449,115 @@ describe('Vercel AI SDK integration via OpenInference', () => {
 
       assert.equal(manual.attributes['traceroot.sdk.name'], 'traceroot-ts');
     });
+
+    it('preserves attributes on a span shaped like an OI Instrumentor emission (LangChain/OpenAI/Anthropic)', async () => {
+      // Simulates a span emitted by @arizeai/openinference-instrumentation-{langchain,openai,anthropic,bedrock,claude-agent-sdk}.
+      // These Instrumentors set OI conventions directly at span creation. The Vercel SpanProcessor
+      // must not stomp on those values.
+      const tracer = trace.getTracer('langchain-sim');
+      await new Promise<void>((resolve) => {
+        tracer.startActiveSpan('ChatOpenAI', (span) => {
+          span.setAttribute('openinference.span.kind', 'LLM');
+          span.setAttribute('llm.model_name', 'gpt-4o');
+          span.setAttribute('llm.token_count.prompt', 42);
+          span.setAttribute('llm.token_count.completion', 17);
+          span.setAttribute('input.value', 'instrumentor-input');
+          span.setAttribute('output.value', 'instrumentor-output');
+          span.setAttribute('llm.provider', 'openai');
+          span.end();
+          resolve();
+        });
+      });
+
+      await rig.provider.forceFlush();
+      const spans = rig.exporter.getFinishedSpans();
+      const lc = findSpan(spans, 'ChatOpenAI');
+
+      // Every OI-shaped attribute set by the simulated Instrumentor must round-trip unchanged.
+      assert.equal(lc.attributes['openinference.span.kind'], 'LLM');
+      assert.equal(lc.attributes['llm.model_name'], 'gpt-4o');
+      assert.equal(lc.attributes['llm.token_count.prompt'], 42);
+      assert.equal(lc.attributes['llm.token_count.completion'], 17);
+      assert.equal(lc.attributes['input.value'], 'instrumentor-input');
+      assert.equal(lc.attributes['output.value'], 'instrumentor-output');
+      assert.equal(lc.attributes['llm.provider'], 'openai');
+
+      // Span name must not be renamed (maybeRenameRootSpan is gated on isLikelyAISDKSpan).
+      assert.equal(lc.name, 'ChatOpenAI');
+
+      // Status must not be force-set (maybeSet*Status is gated on isLikelyAISDKSpan).
+      assert.notEqual(lc.status.code, SpanStatusCode.ERROR);
+
+      // TraceRoot SDK markers still applied.
+      assert.equal(lc.attributes['traceroot.sdk.name'], 'traceroot-ts');
+    });
+
+    it('does not contaminate a non-Vercel root span that shares a trace with a Vercel AI SDK call', async () => {
+      // Critical regression case: TraceAggregateManager flips agg.isAISDKTrace=true when ANY span
+      // in the trace looks like an AI SDK span. Verifies the non-AI root sibling/parent does not
+      // get its name, status, or attributes mutated as a side effect.
+      const tracer = trace.getTracer('mixed-trace-sim');
+      await new Promise<void>((resolve, reject) => {
+        tracer.startActiveSpan('app.checkout', async (rootSpan) => {
+          try {
+            rootSpan.setAttribute('app.feature', 'checkout');
+            rootSpan.setAttribute('input.value', 'root-preserved');
+            // Vercel call as a child — flips agg.isAISDKTrace for the whole trace.
+            await generateText({
+              model: staticTextModel('ok'),
+              prompt: 'p',
+              experimental_telemetry: { isEnabled: true },
+            });
+            rootSpan.end();
+            resolve();
+          } catch (err) {
+            rootSpan.end();
+            reject(err);
+          }
+        });
+      });
+
+      await rig.provider.forceFlush();
+      const spans = rig.exporter.getFinishedSpans();
+
+      const root = findSpan(spans, 'app.checkout');
+      const aiWrapper = findSpan(spans, 'ai.generateText');
+
+      // 1. Same trace.
+      assert.equal(
+        root.spanContext().traceId,
+        aiWrapper.spanContext().traceId,
+        'root and AI wrapper must share trace id (the case agg.isAISDKTrace covers)',
+      );
+
+      // 2. Root span is NOT renamed (maybeRenameRootSpan gated).
+      assert.equal(root.name, 'app.checkout', 'non-AI root must not be renamed by operation.name');
+
+      // 3. Root attributes preserved.
+      assert.equal(root.attributes['app.feature'], 'checkout');
+      assert.equal(
+        root.attributes['input.value'],
+        'root-preserved',
+        'non-AI root input.value must not be overwritten',
+      );
+
+      // 4. Root has no AI/LLM attrs forced onto it.
+      assert.equal(root.attributes['llm.model_name'], undefined);
+      assert.equal(root.attributes['llm.token_count.prompt'], undefined);
+      assert.equal(root.attributes['openinference.span.kind'], undefined);
+
+      // 5. Root status NOT touched by maybeSetRootStatus (gated on isLikelyAISDKSpan).
+      // Asserts UNSET (not just "not ERROR") — if the gate breaks, status would silently flip to OK.
+      assert.equal(
+        root.status.code,
+        SpanStatusCode.UNSET,
+        'non-AI root status must remain UNSET; OK or ERROR would mean the AI SDK gate broke',
+      );
+
+      // 6. Vercel wrapper still gets full OI mapping (proves OI processor still works in mixed trace).
+      assert.equal(aiWrapper.attributes['openinference.span.kind'], 'AGENT');
+      assert.equal(aiWrapper.attributes['llm.model_name'], 'mock-static');
+    });
   });
 
   // ── 7. TraceRootSpanProcessor injection survives the processor swap ───────

--- a/packages/traceroot/tests/vercel-ai.test.ts
+++ b/packages/traceroot/tests/vercel-ai.test.ts
@@ -493,19 +493,38 @@ describe('Vercel AI SDK integration via OpenInference', () => {
       );
 
       await rig.provider.forceFlush();
-      const wrapper = findSpan(rig.exporter.getFinishedSpans(), 'ai.generateText');
+      const spans = rig.exporter.getFinishedSpans();
+      const wrapper = findSpan(spans, 'ai.generateText');
+      const inner = findSpan(spans, 'ai.generateText.doGenerate');
 
+      // Wrapper (AGENT, root of the AI SDK call): the #2651 case.
       assert.equal(
         wrapper.attributes['session.id'],
         'sess-42',
-        'session.id must propagate from usingAttributes() to ai.generateText (the #2651 case)',
+        'session.id must propagate from usingAttributes() to ai.generateText',
       );
       assert.equal(wrapper.attributes['user.id'], 'u-7');
-      const tagsAttr = wrapper.attributes['tag.tags'];
-      assert.ok(tagsAttr, 'tag.tags must be set');
+      const wrapperTags = wrapper.attributes['tag.tags'];
+      assert.ok(wrapperTags, 'tag.tags must be set on wrapper');
       assert.ok(
-        String(tagsAttr).includes('prod') && String(tagsAttr).includes('beta'),
-        `tag.tags should contain prod and beta; got: ${tagsAttr}`,
+        String(wrapperTags).includes('prod') && String(wrapperTags).includes('beta'),
+        `wrapper tag.tags should contain prod and beta; got: ${wrapperTags}`,
+      );
+
+      // Inner doGenerate (LLM child): must inherit too. Guards against a
+      // regression where the onStart hook only fires for root spans, or where
+      // OI Context propagation breaks across the wrapper -> child boundary.
+      assert.equal(
+        inner.attributes['session.id'],
+        'sess-42',
+        'session.id must also propagate to the doGenerate child span',
+      );
+      assert.equal(inner.attributes['user.id'], 'u-7');
+      const innerTags = inner.attributes['tag.tags'];
+      assert.ok(innerTags, 'tag.tags must be set on inner');
+      assert.ok(
+        String(innerTags).includes('prod') && String(innerTags).includes('beta'),
+        `inner tag.tags should contain prod and beta; got: ${innerTags}`,
       );
     });
   });

--- a/packages/traceroot/tests/vercel-ai.test.ts
+++ b/packages/traceroot/tests/vercel-ai.test.ts
@@ -1,0 +1,512 @@
+// Vercel AI SDK integration tests.
+//
+// These exercise the production stack:
+//   TraceRootSpanProcessor → OpenInferenceSimpleSpanProcessor → InMemorySpanExporter
+//
+// Real Vercel AI SDK calls go through @arizeai/openinference-vercel, which mutates
+// span attributes onEnd to OpenInference semantic conventions. The assertions are
+// on the post-mapping attribute names (input.value, output.value, llm.model_name,
+// llm.token_count.*, openinference.span.kind, tool_call.*) so the suite catches
+// regressions in either layer.
+
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { InMemorySpanExporter, ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { context, propagation, SpanStatusCode, trace } from '@opentelemetry/api';
+import { OpenInferenceSimpleSpanProcessor } from '@arizeai/openinference-vercel';
+
+import { generateText, streamText, tool } from 'ai';
+import { MockLanguageModelV3, simulateReadableStream } from 'ai/test';
+import { z } from 'zod';
+
+import { TraceRootSpanProcessor } from '../src/processor';
+import { observe, _resetObserveState } from '../src/observe';
+import { usingAttributes } from '../src/usingAttributes';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test infrastructure
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface TestRig {
+  exporter: InMemorySpanExporter;
+  provider: NodeTracerProvider;
+}
+
+function makeRig(
+  opts: {
+    environment?: string;
+    gitRepo?: string;
+    gitRef?: string;
+  } = {},
+): TestRig {
+  const exporter = new InMemorySpanExporter();
+  const oi = new OpenInferenceSimpleSpanProcessor({ exporter });
+  const provider = new NodeTracerProvider();
+  provider.addSpanProcessor(new TraceRootSpanProcessor(oi, opts));
+  provider.register();
+  return { exporter, provider };
+}
+
+async function teardownRig(rig: TestRig): Promise<void> {
+  await rig.provider.shutdown();
+  rig.exporter.reset();
+  trace.disable();
+  context.disable();
+  propagation.disable();
+  // observe.ts caches a tracer at module level; clear it so the next test's
+  // freshly-registered TracerProvider is picked up.
+  _resetObserveState();
+}
+
+function findSpan(spans: ReadableSpan[], name: string): ReadableSpan {
+  const found = spans.find((s) => s.name === name);
+  assert.ok(found, `expected a span named "${name}", got [${spans.map((s) => s.name).join(', ')}]`);
+  return found;
+}
+
+function findSpans(spans: ReadableSpan[], name: string): ReadableSpan[] {
+  return spans.filter((s) => s.name === name);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock builders for MockLanguageModelV3
+// ─────────────────────────────────────────────────────────────────────────────
+
+// LanguageModelV3Usage shape — nested objects, not flat numbers.
+const STD_USAGE = {
+  inputTokens: { total: 11, noCache: 11, cacheRead: undefined, cacheWrite: undefined },
+  outputTokens: { total: 7, text: 7, reasoning: undefined },
+};
+
+function staticTextModel(text: string) {
+  return new MockLanguageModelV3({
+    modelId: 'mock-static',
+    provider: 'mock-provider',
+    doGenerate: async () => ({
+      content: [{ type: 'text', text }],
+      finishReason: 'stop',
+      usage: STD_USAGE,
+      warnings: [],
+    }),
+  });
+}
+
+function streamingTextModel(deltas: string[]) {
+  return new MockLanguageModelV3({
+    modelId: 'mock-stream',
+    provider: 'mock-provider',
+    doStream: async () => ({
+      stream: simulateReadableStream({
+        chunks: [
+          { type: 'stream-start' as const, warnings: [] },
+          { type: 'text-start' as const, id: 'tx1' },
+          ...deltas.map((delta) => ({ type: 'text-delta' as const, id: 'tx1', delta })),
+          { type: 'text-end' as const, id: 'tx1' },
+          {
+            type: 'finish' as const,
+            finishReason: 'stop' as const,
+            usage: STD_USAGE,
+          },
+        ],
+      }),
+    }),
+  });
+}
+
+function throwingModel(message: string) {
+  return new MockLanguageModelV3({
+    modelId: 'mock-throw',
+    provider: 'mock-provider',
+    doGenerate: async () => {
+      throw new Error(message);
+    },
+  });
+}
+
+function streamThatErrorsAfter(deltas: string[], errorMessage: string) {
+  return new MockLanguageModelV3({
+    modelId: 'mock-stream-err',
+    provider: 'mock-provider',
+    doStream: async () => ({
+      stream: simulateReadableStream({
+        chunks: [
+          { type: 'stream-start' as const, warnings: [] },
+          { type: 'text-start' as const, id: 'tx1' },
+          ...deltas.map((delta) => ({ type: 'text-delta' as const, id: 'tx1', delta })),
+          { type: 'error' as const, error: new Error(errorMessage) },
+        ],
+      }),
+    }),
+  });
+}
+
+// Two-call mock: first call returns a tool-call, second call returns a final text.
+function toolCallingModel(toolName: string, toolInput: object, finalText: string) {
+  let call = 0;
+  return new MockLanguageModelV3({
+    modelId: 'mock-tools',
+    provider: 'mock-provider',
+    doGenerate: async () => {
+      call++;
+      if (call === 1) {
+        return {
+          content: [
+            {
+              type: 'tool-call' as const,
+              toolCallId: 't1',
+              toolName,
+              input: JSON.stringify(toolInput),
+            },
+          ],
+          finishReason: 'tool-calls',
+          usage: STD_USAGE,
+          warnings: [],
+        };
+      }
+      return {
+        content: [{ type: 'text', text: finalText }],
+        finishReason: 'stop',
+        usage: STD_USAGE,
+        warnings: [],
+      };
+    },
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Suite
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Vercel AI SDK integration via OpenInference', () => {
+  let rig: TestRig;
+
+  beforeEach(() => {
+    rig = makeRig();
+  });
+
+  afterEach(async () => {
+    await teardownRig(rig);
+  });
+
+  // ── 1. Non-streaming generateText ─────────────────────────────────────────
+  describe('non-streaming generateText', () => {
+    it('produces a parent ai.generateText span and a doGenerate child with mapped attributes', async () => {
+      const result = await generateText({
+        model: staticTextModel('hello world'),
+        prompt: 'say hi',
+        experimental_telemetry: { isEnabled: true },
+      });
+      assert.equal(result.text, 'hello world');
+
+      await rig.provider.forceFlush();
+      const spans = rig.exporter.getFinishedSpans();
+
+      const wrapper = findSpan(spans, 'ai.generateText');
+      const inner = findSpan(spans, 'ai.generateText.doGenerate');
+      assert.equal(
+        spans.length,
+        2,
+        `expected exactly 2 spans, got ${spans.length}: [${spans.map((s) => s.name).join(', ')}]`,
+      );
+
+      // Per OI's VercelSDKFunctionNameToSpanKindMap:
+      //   ai.generateText             → AGENT (the orchestrating wrapper)
+      //   ai.generateText.doGenerate  → LLM   (the actual provider call)
+      assert.equal(wrapper.attributes['openinference.span.kind'], 'AGENT');
+      assert.equal(inner.attributes['openinference.span.kind'], 'LLM');
+
+      // Input/output mapped from ai.prompt / ai.response.text
+      assert.ok(wrapper.attributes['input.value'], 'wrapper input.value should be set');
+      assert.ok(
+        String(wrapper.attributes['input.value']).includes('say hi'),
+        `wrapper input.value should contain prompt; got: ${wrapper.attributes['input.value']}`,
+      );
+      assert.equal(wrapper.attributes['output.value'], 'hello world');
+
+      // Model metadata: model_name lives on both spans; the OI mapping only
+      // emits llm.token_count.* on LLM-kind spans, so it lands on the inner
+      // doGenerate. The AGENT wrapper carries the raw ai.usage.* aggregates.
+      assert.equal(inner.attributes['llm.model_name'], 'mock-static');
+      assert.equal(inner.attributes['llm.token_count.prompt'], 11);
+      assert.equal(inner.attributes['llm.token_count.completion'], 7);
+      assert.equal(wrapper.attributes['ai.usage.inputTokens'], 11);
+      assert.equal(wrapper.attributes['ai.usage.outputTokens'], 7);
+
+      // Parent / child relationship preserved through the OI processor
+      assert.equal(
+        inner.parentSpanId,
+        wrapper.spanContext().spanId,
+        'doGenerate must be a child of generateText',
+      );
+
+      // Status: not ERROR on success (AI SDK may set OK explicitly).
+      assert.notEqual(wrapper.status.code, SpanStatusCode.ERROR);
+
+      // TraceRootSpanProcessor still injects SDK metadata after the swap
+      assert.equal(wrapper.attributes['traceroot.sdk.name'], 'traceroot-ts');
+      assert.ok(wrapper.attributes['traceroot.sdk.version']);
+    });
+  });
+
+  // ── 2. Streaming streamText ───────────────────────────────────────────────
+  describe('streaming streamText', () => {
+    it('keeps the wrapper span open until the stream is consumed and lands usage on close', async () => {
+      const result = streamText({
+        model: streamingTextModel(['hel', 'lo']),
+        prompt: 'go',
+        experimental_telemetry: { isEnabled: true },
+      });
+
+      let collected = '';
+      for await (const chunk of result.textStream) collected += chunk;
+      assert.equal(collected, 'hello');
+
+      await rig.provider.forceFlush();
+      const spans = rig.exporter.getFinishedSpans();
+
+      const wrapper = findSpan(spans, 'ai.streamText');
+      const inner = findSpan(spans, 'ai.streamText.doStream');
+
+      assert.equal(findSpans(spans, 'ai.streamText').length, 1);
+      assert.equal(findSpans(spans, 'ai.streamText.doStream').length, 1);
+
+      // Token usage on the final LLM span (per OI: llm.token_count.* only on LLM-kind spans).
+      // The AGENT-kind wrapper still carries the raw ai.usage.* aggregates.
+      assert.equal(inner.attributes['llm.token_count.prompt'], 11);
+      assert.equal(inner.attributes['llm.token_count.completion'], 7);
+      assert.equal(wrapper.attributes['ai.usage.inputTokens'], 11);
+      assert.equal(wrapper.attributes['ai.usage.outputTokens'], 7);
+
+      // Output text reconstructed on both wrapper and inner
+      assert.equal(wrapper.attributes['output.value'], 'hello');
+      assert.equal(inner.attributes['output.value'], 'hello');
+
+      assert.notEqual(wrapper.status.code, SpanStatusCode.ERROR);
+      assert.ok(wrapper.endTime[0] >= wrapper.startTime[0], 'wrapper.endTime must be set');
+    });
+  });
+
+  // ── 3. Tool calling ───────────────────────────────────────────────────────
+  describe('tool calling', () => {
+    it('emits an ai.toolCall span with TOOL kind and tool input/output', async () => {
+      const result = await generateText({
+        model: toolCallingModel('add', { a: 2, b: 3 }, 'sum is 5'),
+        prompt: 'compute',
+        tools: {
+          add: tool({
+            description: 'add two numbers',
+            inputSchema: z.object({ a: z.number(), b: z.number() }),
+            execute: async ({ a, b }) => a + b,
+          }),
+        },
+        stopWhen: ({ steps }) => steps.length >= 2,
+        experimental_telemetry: { isEnabled: true },
+      });
+      assert.equal(result.text, 'sum is 5');
+
+      await rig.provider.forceFlush();
+      const spans = rig.exporter.getFinishedSpans();
+
+      const toolSpan = findSpan(spans, 'ai.toolCall');
+      assert.equal(toolSpan.attributes['openinference.span.kind'], 'TOOL');
+      assert.equal(toolSpan.attributes['tool.name'], 'add');
+
+      const argsAttr = toolSpan.attributes['tool.parameters'] ?? toolSpan.attributes['input.value'];
+      assert.ok(
+        argsAttr,
+        `tool args should be on the span; saw keys: ${Object.keys(toolSpan.attributes).join(', ')}`,
+      );
+      assert.ok(
+        String(argsAttr).includes('"a":2') && String(argsAttr).includes('"b":3'),
+        `tool args should contain a:2 b:3; got: ${argsAttr}`,
+      );
+
+      const resultAttr = toolSpan.attributes['output.value'];
+      assert.ok(resultAttr, 'tool result should be on the span');
+      assert.ok(
+        String(resultAttr).includes('5'),
+        `tool result should contain 5; got: ${resultAttr}`,
+      );
+
+      // Parent of the tool span is the generateText wrapper
+      const wrapper = findSpan(spans, 'ai.generateText');
+      assert.equal(toolSpan.parentSpanId, wrapper.spanContext().spanId);
+    });
+  });
+
+  // ── 4. Error paths ────────────────────────────────────────────────────────
+  describe('error paths', () => {
+    it('marks spans ERROR when the provider throws and leaves no leaks', async () => {
+      await assert.rejects(
+        () =>
+          generateText({
+            model: throwingModel('boom'),
+            prompt: 'go',
+            experimental_telemetry: { isEnabled: true },
+          }),
+        /boom/,
+      );
+
+      await rig.provider.forceFlush();
+      const spans = rig.exporter.getFinishedSpans();
+
+      const wrapper = findSpan(spans, 'ai.generateText');
+      const inner = findSpan(spans, 'ai.generateText.doGenerate');
+      assert.equal(spans.length, 2, 'no leaked or extra spans on error path');
+      assert.equal(wrapper.status.code, SpanStatusCode.ERROR);
+      assert.equal(inner.status.code, SpanStatusCode.ERROR);
+      assert.ok(
+        wrapper.events.some((e) => e.name === 'exception'),
+        'wrapper should record exception event',
+      );
+    });
+
+    it('marks the streaming wrapper ERROR when the stream emits a fatal error', async () => {
+      const stream = streamText({
+        model: streamThatErrorsAfter(['par'], 'stream-failed'),
+        prompt: 'go',
+        experimental_telemetry: { isEnabled: true },
+        onError: () => {
+          // suppress unhandled — we want to assert on spans, not throw out of consumer
+        },
+      });
+      let collected = '';
+      try {
+        for await (const chunk of stream.textStream) collected += chunk;
+      } catch {
+        // expected
+      }
+
+      await rig.provider.forceFlush();
+      const spans = rig.exporter.getFinishedSpans();
+
+      const wrapper = findSpan(spans, 'ai.streamText');
+      assert.equal(wrapper.status.code, SpanStatusCode.ERROR, 'wrapper status should be ERROR');
+      assert.equal(findSpans(spans, 'ai.streamText').length, 1, 'no leaked wrapper spans');
+      assert.equal(
+        findSpans(spans, 'ai.streamText.doStream').length,
+        1,
+        'no leaked doStream spans',
+      );
+    });
+  });
+
+  // ── 5. Nested call: Vercel inside an observe()-wrapped function ───────────
+  describe('nested call', () => {
+    it('preserves parent/child when generateText runs inside an observe() span', async () => {
+      const _result = await observe({ name: 'outer-fn', type: 'span' }, async () =>
+        generateText({
+          model: staticTextModel('inside'),
+          prompt: 'p',
+          experimental_telemetry: { isEnabled: true },
+        }),
+      );
+
+      await rig.provider.forceFlush();
+      const spans = rig.exporter.getFinishedSpans();
+
+      const outer = findSpan(spans, 'outer-fn');
+      const wrapper = findSpan(spans, 'ai.generateText');
+
+      assert.equal(
+        wrapper.parentSpanId,
+        outer.spanContext().spanId,
+        'ai.generateText must be a direct child of the observe() span',
+      );
+      assert.equal(wrapper.spanContext().traceId, outer.spanContext().traceId);
+    });
+  });
+
+  // ── 6. Pass-through: non-Vercel spans must come through untouched ─────────
+  describe('non-Vercel pass-through', () => {
+    it('does not mutate manual spans that were never produced by the AI SDK', async () => {
+      const tracer = trace.getTracer('manual-test');
+      await new Promise<void>((resolve) => {
+        tracer.startActiveSpan('manual.work', (span) => {
+          span.setAttribute('foo', 'bar');
+          span.setAttribute('input.value', 'preserved-input');
+          span.end();
+          resolve();
+        });
+      });
+
+      await rig.provider.forceFlush();
+      const spans = rig.exporter.getFinishedSpans();
+
+      const manual = findSpan(spans, 'manual.work');
+      assert.equal(spans.length, 1);
+      assert.equal(manual.attributes['foo'], 'bar', 'arbitrary attrs preserved');
+      assert.equal(
+        manual.attributes['input.value'],
+        'preserved-input',
+        'OI processor must not overwrite existing input.value on a non-Vercel span',
+      );
+      assert.equal(manual.attributes['llm.model_name'], undefined);
+      assert.equal(manual.attributes['llm.token_count.prompt'], undefined);
+      assert.equal(manual.attributes['openinference.span.kind'], undefined);
+
+      assert.equal(manual.attributes['traceroot.sdk.name'], 'traceroot-ts');
+    });
+  });
+
+  // ── 7. TraceRootSpanProcessor injection survives the processor swap ───────
+  describe('TraceRootSpanProcessor injection', () => {
+    it('applies traceroot.git.* / deployment.environment to AI SDK spans', async () => {
+      await teardownRig(rig);
+      rig = makeRig({ environment: 'staging', gitRepo: 'org/repo', gitRef: 'abc123' });
+
+      await generateText({
+        model: staticTextModel('ok'),
+        prompt: 'p',
+        experimental_telemetry: { isEnabled: true },
+      });
+
+      await rig.provider.forceFlush();
+      const wrapper = findSpan(rig.exporter.getFinishedSpans(), 'ai.generateText');
+
+      assert.equal(wrapper.attributes['deployment.environment'], 'staging');
+      assert.equal(wrapper.attributes['traceroot.git.repo'], 'org/repo');
+      assert.equal(wrapper.attributes['traceroot.git.ref'], 'abc123');
+      assert.equal(wrapper.attributes['traceroot.sdk.name'], 'traceroot-ts');
+    });
+  });
+
+  // ── 8. Session/user context propagation (the #2651 fix) ───────────────────
+  describe('session/user context propagation', () => {
+    it('lifts session.id and user.id from usingAttributes() onto Vercel AI SDK spans', async () => {
+      await usingAttributes(
+        {
+          sessionId: 'sess-42',
+          userId: 'u-7',
+          tags: ['prod', 'beta'],
+          metadata: { feature: 'chat' },
+        },
+        async () => {
+          await generateText({
+            model: staticTextModel('hi'),
+            prompt: 'p',
+            experimental_telemetry: { isEnabled: true },
+          });
+        },
+      );
+
+      await rig.provider.forceFlush();
+      const wrapper = findSpan(rig.exporter.getFinishedSpans(), 'ai.generateText');
+
+      assert.equal(
+        wrapper.attributes['session.id'],
+        'sess-42',
+        'session.id must propagate from usingAttributes() to ai.generateText (the #2651 case)',
+      );
+      assert.equal(wrapper.attributes['user.id'], 'u-7');
+      const tagsAttr = wrapper.attributes['tag.tags'];
+      assert.ok(tagsAttr, 'tag.tags must be set');
+      assert.ok(
+        String(tagsAttr).includes('prod') && String(tagsAttr).includes('beta'),
+        `tag.tags should contain prod and beta; got: ${tagsAttr}`,
+      );
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       '@arizeai/openinference-semantic-conventions':
         specifier: ^2.1.7
         version: 2.1.7
+      '@arizeai/openinference-vercel':
+        specifier: ^2.7.2
+        version: 2.7.4(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.40.0)
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -114,9 +117,6 @@ importers:
         specifier: ^1.40.0
         version: 1.40.0
     devDependencies:
-      '@arizeai/openinference-vercel':
-        specifier: ^2.7.2
-        version: 2.7.4(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.40.0)
       '@eslint/js':
         specifier: ^9.0.0
         version: 9.39.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,7 +85,7 @@ importers:
         version: 0.2.0
       '@arizeai/openinference-instrumentation-langchain':
         specifier: ^4.0.6
-        version: 4.0.6(@langchain/core@1.1.39(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
+        version: 4.0.6(@langchain/core@1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
       '@arizeai/openinference-instrumentation-openai':
         specifier: ^4.0.5
         version: 4.0.5(openai@6.33.0(ws@8.20.0)(zod@4.3.6))
@@ -114,12 +114,18 @@ importers:
         specifier: ^1.40.0
         version: 1.40.0
     devDependencies:
+      '@arizeai/openinference-vercel':
+        specifier: ^2.7.2
+        version: 2.7.4(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.40.0)
       '@eslint/js':
         specifier: ^9.0.0
         version: 9.39.4
       '@langchain/core':
-        specifier: ^1.1.39
-        version: 1.1.39(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+        specifier: ^1.1.45
+        version: 1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/openai':
+        specifier: ^1.4.5
+        version: 1.4.5(@langchain/core@1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(ws@8.20.0)
       '@openai/agents':
         specifier: '>=0.0.1'
         version: 0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.3.6)
@@ -203,6 +209,15 @@ packages:
   '@arizeai/openinference-core@2.0.5':
     resolution: {integrity: sha512-BnufYaFqmG9twkz/9DHX9WTcOs7YvVAYaufau5tdjOT1c0Y8niJwmNWzV36phNPg3c7SmdD5OYLuzeAUN0T3pQ==}
 
+  '@arizeai/openinference-core@2.0.8':
+    resolution: {integrity: sha512-Fj8f/uhdgW6TzlQ5iJJ/UrDRS8F7cGLcUmWSVM2N+0lHTgJSPZKew5sv+HdQlCVvG9r0gwQR/1lAggqxv7TrzA==}
+
+  '@arizeai/openinference-genai@0.1.8':
+    resolution: {integrity: sha512-7Lbpwk0FHQgi7wKboMbJBAvvjvsVzxyLnr9P/KTWzUPZon2S/72CQWHhgEZ9uHKNAvOayH95nlpaYd0sKP9riw==}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0'
+      '@opentelemetry/semantic-conventions': '>=1.37.0'
+
   '@arizeai/openinference-instrumentation-anthropic@0.1.7':
     resolution: {integrity: sha512-TaxOkNLQftIgqvtT5R64FaRPGGf6E0nm6+8J3g7JF4A6lPYnLLquc/HyMN+ttckqavXcIfLYn7qKa4AfZm4kuA==}
 
@@ -226,6 +241,14 @@ packages:
 
   '@arizeai/openinference-semantic-conventions@2.1.7':
     resolution: {integrity: sha512-KyBfwxkSusPvxHBaW/TJ0japEbXCNziW9o6/IRKiPu+gp5TMKIagV2NKvt47rWYa4Jc0Nl+SvAPm+yxkdJqVbg==}
+
+  '@arizeai/openinference-semantic-conventions@2.3.0':
+    resolution: {integrity: sha512-O2lRb8crb3dGFB50+Mu+J5pPP+9LzMzvAfS5aQd6D4i9LbCqz4fl8cHpVR6Tz22gj3TA54mwP3wN1ymfVJA+aA==}
+
+  '@arizeai/openinference-vercel@2.7.4':
+    resolution: {integrity: sha512-ZbsGUBVGK9R8Pyiv8ifv12yu3oIP137vywzfI4WFkS3PEZs0zg1GXPGKiNONSceZ0ihXvmawt0SZhuZF6E9pDg==}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.7.0 <2.0.0'
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -587,9 +610,15 @@ packages:
     resolution: {integrity: sha512-7kMz0BJpMvgAMkyglums7B2vtrn5g0a0am77JY0GjkZZNetOBCFn7AG7gKCwT0QPiXyxW7YIQSgtARknUEOcxQ==}
     engines: {node: '>=12'}
 
-  '@langchain/core@1.1.39':
-    resolution: {integrity: sha512-DP9c7TREy6iA7HnywstmUAsNyJNYTFpRg2yBfQ+6H0l1HnvQzei9GsQ36GeOLxgRaD3vm9K8urCcawSC7yQpCw==}
+  '@langchain/core@1.1.45':
+    resolution: {integrity: sha512-Y/wvuglLTMKJahkl4QD9dBIdF/z/CxZJWdTfHJF/q2jtlJtoFf6Mb5JpGxZfsi3mBY6NSG941FSLTcqhCKrhBA==}
     engines: {node: '>=20'}
+
+  '@langchain/openai@1.4.5':
+    resolution: {integrity: sha512-bQ2WMIZfSh02trJLYSAtiIcD3j6EBCiAm9nw0dZWQsVaUxmWc3JJqs8uUte6AkMazmLHzcUIw+14UkXO5fRJvQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@langchain/core': ^1.1.42
 
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
@@ -2126,6 +2155,18 @@ packages:
       zod:
         optional: true
 
+  openai@6.37.0:
+    resolution: {integrity: sha512-0H5dEGFmmLv6KSd0W1w2nyL8WsLkX6yoLeQpU+dZAOuGcany5qkYQMmj35ZrKgb6yiyYqpUzFOpR8mZQkgqeEQ==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
@@ -2520,6 +2561,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -2669,6 +2711,18 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
 
+  '@arizeai/openinference-core@2.0.8':
+    dependencies:
+      '@arizeai/openinference-semantic-conventions': 2.3.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@arizeai/openinference-genai@0.1.8(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@arizeai/openinference-semantic-conventions': 2.3.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+
   '@arizeai/openinference-instrumentation-anthropic@0.1.7':
     dependencies:
       '@arizeai/openinference-core': 2.0.5
@@ -2700,11 +2754,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@arizeai/openinference-instrumentation-langchain@4.0.6(@langchain/core@1.1.39(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
+  '@arizeai/openinference-instrumentation-langchain@4.0.6(@langchain/core@1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
     dependencies:
       '@arizeai/openinference-core': 2.0.5
       '@arizeai/openinference-semantic-conventions': 2.1.7
-      '@langchain/core': 1.1.39(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.46.0(@opentelemetry/api@1.9.1)
@@ -2723,6 +2777,18 @@ snapshots:
       - supports-color
 
   '@arizeai/openinference-semantic-conventions@2.1.7': {}
+
+  '@arizeai/openinference-semantic-conventions@2.3.0': {}
+
+  '@arizeai/openinference-vercel@2.7.4(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.40.0)':
+    dependencies:
+      '@arizeai/openinference-core': 2.0.8
+      '@arizeai/openinference-genai': 0.1.8(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.40.0)
+      '@arizeai/openinference-semantic-conventions': 2.3.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - '@opentelemetry/semantic-conventions'
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -3245,7 +3311,7 @@ snapshots:
 
   '@isaacs/ttlcache@2.1.4': {}
 
-  '@langchain/core@1.1.39(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)':
+  '@langchain/core@1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@standard-schema/spec': 1.1.0
@@ -3256,13 +3322,21 @@ snapshots:
       langsmith: 0.5.16(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
       mustache: 4.2.0
       p-queue: 6.6.2
-      uuid: 11.1.0
-      zod: 3.25.76
+      zod: 4.3.6
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
       - '@opentelemetry/sdk-trace-base'
       - openai
+      - ws
+
+  '@langchain/openai@1.4.5(@langchain/core@1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(ws@8.20.0)':
+    dependencies:
+      '@langchain/core': 1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      js-tiktoken: 1.0.21
+      openai: 6.37.0(ws@8.20.0)(zod@4.3.6)
+      zod: 4.3.6
+    transitivePeerDependencies:
       - ws
 
   '@lukeed/csprng@1.1.0': {}
@@ -5169,6 +5243,11 @@ snapshots:
       mimic-function: 5.0.1
 
   openai@6.33.0(ws@8.20.0)(zod@4.3.6):
+    optionalDependencies:
+      ws: 8.20.0
+      zod: 4.3.6
+
+  openai@6.37.0(ws@8.20.0)(zod@4.3.6):
     optionalDependencies:
       ws: 8.20.0
       zod: 4.3.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,10 +27,10 @@ importers:
     dependencies:
       '@mastra/core':
         specifier: '>=1.0.0-0 <2.0.0-0'
-        version: 1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6)
+        version: 1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.4.3)
       '@mastra/observability':
         specifier: '>=1.0.0-0 <2.0.0-0'
-        version: 1.7.2(@mastra/core@1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6))
+        version: 1.7.2(@mastra/core@1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.4.3))
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -70,7 +70,7 @@ importers:
     dependencies:
       '@anthropic-ai/sdk':
         specifier: '>=0.20.0'
-        version: 0.81.0(zod@4.3.6)
+        version: 0.81.0(zod@4.4.3)
       '@arizeai/openinference-core':
         specifier: ^2.0.5
         version: 2.0.5
@@ -85,10 +85,10 @@ importers:
         version: 0.2.0
       '@arizeai/openinference-instrumentation-langchain':
         specifier: ^4.0.6
-        version: 4.0.6(@langchain/core@1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))
+        version: 4.0.6(@langchain/core@1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
       '@arizeai/openinference-instrumentation-openai':
         specifier: ^4.0.5
-        version: 4.0.5(openai@6.33.0(ws@8.20.0)(zod@4.3.6))
+        version: 4.0.5(openai@6.33.0(ws@8.20.0)(zod@4.4.3))
       '@arizeai/openinference-semantic-conventions':
         specifier: ^2.1.7
         version: 2.1.7
@@ -122,16 +122,19 @@ importers:
         version: 9.39.4
       '@langchain/core':
         specifier: ^1.1.45
-        version: 1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+        version: 1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       '@langchain/openai':
         specifier: ^1.4.5
-        version: 1.4.5(@langchain/core@1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(ws@8.20.0)
+        version: 1.4.5(@langchain/core@1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(ws@8.20.0)
       '@openai/agents':
         specifier: '>=0.0.1'
-        version: 0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.3.6)
+        version: 0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.4.3)
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.37
+      ai:
+        specifier: ^6.0.175
+        version: 6.0.176(zod@4.4.3)
       anthropic:
         specifier: ^0.0.0
         version: 0.0.0
@@ -140,7 +143,7 @@ importers:
         version: 9.39.4
       openai:
         specifier: ^6.33.0
-        version: 6.33.0(ws@8.20.0)(zod@4.3.6)
+        version: 6.33.0(ws@8.20.0)(zod@4.4.3)
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
@@ -150,12 +153,21 @@ importers:
       typescript-eslint:
         specifier: ^8.0.0
         version: 8.58.0(eslint@9.39.4)(typescript@5.9.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
 packages:
 
   '@a2a-js/sdk@0.2.5':
     resolution: {integrity: sha512-VTDuRS5V0ATbJ/LkaQlisMnTAeYKXAK6scMguVBstf+KIBQ7HIuKhiXLv+G/hvejkV+THoXzoNifInAkU81P1g==}
     engines: {node: '>=18'}
+
+  '@ai-sdk/gateway@3.0.111':
+    resolution: {integrity: sha512-gzdRuEH9Mqeuu8zG6j4of3EH3fFJUI0UIubyeaA8gep6KzhCJF7uaTfagSE7x2vLAf381g/NrxsXhhH7Hon9iA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   '@ai-sdk/provider-utils@2.2.8':
     resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
@@ -175,6 +187,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.27':
+    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@1.1.3':
     resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
     engines: {node: '>=18'}
@@ -185,6 +203,10 @@ packages:
 
   '@ai-sdk/provider@3.0.0':
     resolution: {integrity: sha512-m9ka3ptkPQbaHHZHqDXDF9C9B5/Mav0KTdky1k2HZ3/nrW2t1AgObxIVPyGDWQNS9FXT/FS6PIoSjpcP/No8rQ==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.10':
+    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.5':
@@ -682,6 +704,10 @@ packages:
   '@opentelemetry/api-logs@0.57.2':
     resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
     engines: {node: '>=14'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
@@ -1192,6 +1218,10 @@ packages:
     resolution: {integrity: sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@workflow/serde@4.1.0-beta.2':
     resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
 
@@ -1218,6 +1248,12 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  ai@6.0.176:
+    resolution: {integrity: sha512-dhxDef3VCIxaFr6tKyG0BrkkCelmnporlen8nHajIwCk7S4PvIaSVI/iyJenhFOZ9KBoKjCAoUs6TzZ3yrSjxw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -1550,6 +1586,10 @@ packages:
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
@@ -2636,8 +2676,8 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -2655,26 +2695,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ai-sdk/provider-utils@2.2.8(zod@4.3.6)':
+  '@ai-sdk/gateway@3.0.111(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@2.2.8(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
-      zod: 4.3.6
+      zod: 4.4.3
 
-  '@ai-sdk/provider-utils@3.0.20(zod@4.3.6)':
+  '@ai-sdk/provider-utils@3.0.20(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
-      zod: 4.3.6
+      zod: 4.4.3
 
-  '@ai-sdk/provider-utils@4.0.0(zod@4.3.6)':
+  '@ai-sdk/provider-utils@4.0.0(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.0
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
-      zod: 4.3.6
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@4.0.27(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.4.3
 
   '@ai-sdk/provider@1.1.3':
     dependencies:
@@ -2688,22 +2742,26 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
+  '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
   '@ai-sdk/provider@3.0.5':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/ui-utils@1.2.11(zod@4.3.6)':
+  '@ai-sdk/ui-utils@1.2.11(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
 
-  '@anthropic-ai/sdk@0.81.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.81.0(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
   '@arizeai/openinference-core@2.0.5':
     dependencies:
@@ -2754,25 +2812,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@arizeai/openinference-instrumentation-langchain@4.0.6(@langchain/core@1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))':
+  '@arizeai/openinference-instrumentation-langchain@4.0.6(@langchain/core@1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
     dependencies:
       '@arizeai/openinference-core': 2.0.5
       '@arizeai/openinference-semantic-conventions': 2.1.7
-      '@langchain/core': 1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.46.0(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@arizeai/openinference-instrumentation-openai@4.0.5(openai@6.33.0(ws@8.20.0)(zod@4.3.6))':
+  '@arizeai/openinference-instrumentation-openai@4.0.5(openai@6.33.0(ws@8.20.0)(zod@4.4.3))':
     dependencies:
       '@arizeai/openinference-core': 2.0.5
       '@arizeai/openinference-semantic-conventions': 2.1.7
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.46.0(@opentelemetry/api@1.9.1)
-      openai: 6.33.0(ws@8.20.0)(zod@4.3.6)
+      openai: 6.33.0(ws@8.20.0)(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -3311,7 +3369,7 @@ snapshots:
 
   '@isaacs/ttlcache@2.1.4': {}
 
-  '@langchain/core@1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)':
+  '@langchain/core@1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@standard-schema/spec': 1.1.0
@@ -3319,10 +3377,10 @@ snapshots:
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.5.16(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      langsmith: 0.5.16(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       mustache: 4.2.0
       p-queue: 6.6.2
-      zod: 4.3.6
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -3330,12 +3388,12 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/openai@1.4.5(@langchain/core@1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0))(ws@8.20.0)':
+  '@langchain/openai@1.4.5(@langchain/core@1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(ws@8.20.0)':
     dependencies:
-      '@langchain/core': 1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0)
+      '@langchain/core': 1.1.45(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       js-tiktoken: 1.0.21
-      openai: 6.37.0(ws@8.20.0)(zod@4.3.6)
-      zod: 4.3.6
+      openai: 6.37.0(ws@8.20.0)(zod@4.4.3)
+      zod: 4.4.3
     transitivePeerDependencies:
       - ws
 
@@ -3345,18 +3403,18 @@ snapshots:
     dependencies:
       '@lukeed/csprng': 1.1.0
 
-  '@mastra/core@1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6)':
+  '@mastra/core@1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.4.3)':
     dependencies:
       '@a2a-js/sdk': 0.2.5
-      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@3.0.20(zod@4.3.6)'
-      '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.0(zod@4.3.6)'
+      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@3.0.20(zod@4.4.3)'
+      '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.0(zod@4.4.3)'
       '@ai-sdk/provider-v5': '@ai-sdk/provider@2.0.1'
       '@ai-sdk/provider-v6': '@ai-sdk/provider@3.0.5'
-      '@ai-sdk/ui-utils-v5': '@ai-sdk/ui-utils@1.2.11(zod@4.3.6)'
+      '@ai-sdk/ui-utils-v5': '@ai-sdk/ui-utils@1.2.11(zod@4.4.3)'
       '@isaacs/ttlcache': 2.1.4
       '@lukeed/uuid': 2.0.1
-      '@mastra/schema-compat': 1.2.7(zod@4.3.6)
-      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@mastra/schema-compat': 1.2.7(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       '@sindresorhus/slugify': 2.2.1
       '@standard-schema/spec': 1.1.0
       ajv: 8.18.0
@@ -3365,7 +3423,7 @@ snapshots:
       execa: 9.6.1
       gray-matter: 4.0.3
       hono: 4.12.10
-      hono-openapi: 1.3.0(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(hono@4.12.10)(openapi-types@12.1.3)
+      hono-openapi: 1.3.0(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(hono@4.12.10)(openapi-types@12.1.3)
       ignore: 7.0.5
       js-tiktoken: 1.0.21
       json-schema: 0.4.0
@@ -3377,7 +3435,7 @@ snapshots:
       tokenx: 1.3.0
       ws: 8.20.0
       xxhash-wasm: 1.1.0
-      zod: 4.3.6
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - '@hono/standard-validator'
@@ -3389,19 +3447,19 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@mastra/observability@1.7.2(@mastra/core@1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6))':
+  '@mastra/observability@1.7.2(@mastra/core@1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.4.3))':
     dependencies:
-      '@mastra/core': 1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6)
+      '@mastra/core': 1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.4.3)
 
-  '@mastra/schema-compat@1.2.7(zod@4.3.6)':
+  '@mastra/schema-compat@1.2.7(zod@4.4.3)':
     dependencies:
       json-schema-to-zod: 2.8.1
-      zod: 4.3.6
+      zod: 4.4.3
       zod-from-json-schema: 0.5.2
       zod-from-json-schema-v3: zod-from-json-schema@0.0.5
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
 
-  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.12(hono@4.12.10)
       ajv: 8.18.0
@@ -3418,57 +3476,57 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     optionalDependencies:
       '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
       - supports-color
 
-  '@openai/agents-core@0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.3.6)':
+  '@openai/agents-core@0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.4.3)':
     dependencies:
       debug: 4.4.3
-      openai: 6.33.0(ws@8.20.0)(zod@4.3.6)
+      openai: 6.33.0(ws@8.20.0)(zod@4.4.3)
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
-      zod: 4.3.6
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
       - ws
 
-  '@openai/agents-openai@0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.3.6)':
+  '@openai/agents-openai@0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.4.3)':
     dependencies:
-      '@openai/agents-core': 0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.3.6)
+      '@openai/agents-core': 0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.4.3)
       debug: 4.4.3
-      openai: 6.33.0(ws@8.20.0)(zod@4.3.6)
-      zod: 4.3.6
+      openai: 6.33.0(ws@8.20.0)(zod@4.4.3)
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
       - ws
 
-  '@openai/agents-realtime@0.8.5(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
+  '@openai/agents-realtime@0.8.5(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
-      '@openai/agents-core': 0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.3.6)
+      '@openai/agents-core': 0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.4.3)
       '@types/ws': 8.18.1
       debug: 4.4.3
       ws: 8.20.0
-      zod: 4.3.6
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@openai/agents@0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.3.6)':
+  '@openai/agents@0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.4.3)':
     dependencies:
-      '@openai/agents-core': 0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.3.6)
-      '@openai/agents-openai': 0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.3.6)
-      '@openai/agents-realtime': 0.8.5(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@openai/agents-core': 0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.4.3)
+      '@openai/agents-openai': 0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.4.3)
+      '@openai/agents-realtime': 0.8.5(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       debug: 4.4.3
-      openai: 6.33.0(ws@8.20.0)(zod@4.3.6)
-      zod: 4.3.6
+      openai: 6.33.0(ws@8.20.0)(zod@4.4.3)
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - bufferutil
@@ -3479,6 +3537,8 @@ snapshots:
   '@opentelemetry/api-logs@0.57.2':
     dependencies:
       '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.0': {}
 
   '@opentelemetry/api@1.9.1': {}
 
@@ -3913,22 +3973,22 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)':
+  '@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/json-schema': 7.0.15
       quansync: 0.2.11
     optionalDependencies:
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
 
-  '@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6)':
+  '@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3)':
     dependencies:
-      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)
+      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
       '@standard-schema/spec': 1.1.0
       openapi-types: 12.1.3
     optionalDependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -4099,6 +4159,8 @@ snapshots:
       '@typescript-eslint/types': 8.58.0
       eslint-visitor-keys: 5.0.1
 
+  '@vercel/oidc@3.2.0': {}
+
   '@workflow/serde@4.1.0-beta.2': {}
 
   accepts@1.3.8:
@@ -4120,6 +4182,14 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  ai@6.0.176(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.111(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.4.3
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
@@ -4467,6 +4537,8 @@ snapshots:
 
   eventsource-parser@3.0.6: {}
 
+  eventsource-parser@3.0.8: {}
+
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.0.6
@@ -4694,10 +4766,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono-openapi@1.3.0(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(hono@4.12.10)(openapi-types@12.1.3):
+  hono-openapi@1.3.0(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(hono@4.12.10)(openapi-types@12.1.3):
     dependencies:
-      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)
-      '@standard-community/standard-openapi': 0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6)
+      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
+      '@standard-community/standard-openapi': 0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3)
       '@types/json-schema': 7.0.15
       openapi-types: 12.1.3
     optionalDependencies:
@@ -4817,7 +4889,7 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  langsmith@0.5.16(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.3.6))(ws@8.20.0):
+  langsmith@0.5.16(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0):
     dependencies:
       chalk: 5.6.2
       console-table-printer: 2.15.0
@@ -4828,7 +4900,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/exporter-trace-otlp-proto': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
-      openai: 6.33.0(ws@8.20.0)(zod@4.3.6)
+      openai: 6.33.0(ws@8.20.0)(zod@4.4.3)
       ws: 8.20.0
 
   levn@0.4.1:
@@ -5242,15 +5314,15 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  openai@6.33.0(ws@8.20.0)(zod@4.3.6):
+  openai@6.33.0(ws@8.20.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.20.0
-      zod: 4.3.6
+      zod: 4.4.3
 
-  openai@6.37.0(ws@8.20.0)(zod@4.3.6):
+  openai@6.37.0(ws@8.20.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.20.0
-      zod: 4.3.6
+      zod: 4.4.3
 
   openapi-types@12.1.3: {}
 
@@ -5732,14 +5804,14 @@ snapshots:
 
   zod-from-json-schema@0.5.2:
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
-  zod-to-json-schema@3.25.2(zod@4.3.6):
+  zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
   zod@3.25.76: {}
 
-  zod@4.3.6: {}
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary

- **Vercel AI SDK tracing** via `@arizeai/openinference-vercel` (PR #66, co-authored with @Fizza-Mukhtar)
- **OI #2651 fix**: lift `session.id` / `user.id` / metadata / tags from OTel Context onto all spans
- **8-scenario Vercel AI SDK test suite** + 3 cross-integration regression tests (mutation-tested)
- **3 E2E categories** verifying no regression for OI Instrumentor family / @openai/agents / vanilla observe()

## TLDR

PR #66 introduced Vercel AI SDK telemetry via `@arizeai/openinference-vercel`'s SpanProcessor. This PR addresses each concern with verification work on top of the original wiring.

## E2E Tests
per @XinweiHe:

### 1. OI Instrumentor family — `tests/e2e-langchain-openai.test.ts`
Real `ChatOpenAI('gpt-4o-mini').invoke()`. Verifies LangChain Instrumentor spans (`openinference.span.kind=LLM`, `llm.model_name`, `llm.token_count.*`, `input.value`, `output.value`) round-trip unchanged through `OpenInferenceSimpleSpanProcessor`. Proves transparency for OpenAI / Anthropic / Bedrock / claude-agent-sdk by extension (same OI emission contract).

### 2. PR #78 / `@openai/agents` — `scripts/e2e-openai-agents.live.ts`
Real `Agent.run('echo')` against the Traceroot Docker stack via `TraceRoot.initialize({ instrumentModules: { openaiAgents } })`. Queries ClickHouse, verifies cross-processor compat between PR #78's `OpenAIAgentsProcessor` and PR #66's `OpenInferenceSimpleSpanProcessor`.

### 3. Vanilla observe() with no AI semantics 
verifies an observe()-wrapped span  passes through the OI Vercel processor cleanly: CHAIN kind preserved, no ai.* or LLM keys forced on, custom attributes preserved exactly, span name and status untouched.

### 4. Live E2E results (Vercel AI SDK against local Docker stack)

Stack: web:3000 / rest:8000 / agent:8100 / clickhouse:8123. Real gpt-4o-mini calls. TraceRoot.initialize({ disableBatch: true }) — production path, not the unit-test rig.

[Screenshot to be filled here]

### Reproducer
```bash
OPENAI_API_KEY=... TRACEROOT_API_KEY=... pnpm exec tsx packages/traceroot/scripts/e2e-vercel-ai.live.ts
```

## Concern for possible regression with other integrations
ie: LangChain, OpenAI, Anthropic, Bedrock, etc

TLDR: No regression - verified three ways.

The Vercel SpanProcessor that PR #66 adds only acts on spans that look like Vercel AI SDK spans. Every place where it could rename, change status on, or rewrite attributes for a span first checks whether the span carries Vercel's signature — its operation name starts with `ai.` (ai.generateText, ai.streamText, etc.), or it has Vercel-specific attributes. If those don't match, the span passes through untouched. This is the "name-gated" property: the processor's behavior is entirely a function of the span's shape, not the order spans arrive in.

Other integrations don't trip those checks:
- LangChain / OpenAI / Anthropic / Bedrock / claude-agent-sdk use the OpenInference Instrumentor pattern. They emit spans with already-finalized OpenInference attributes and span names like ChatOpenAI, chain, etc. — none of which look Vercel-shaped.
- @openai/agents (PR #78) uses its own processor that emits OpenInference attributes directly. Different shape from Vercel SDK, so the gate doesn't fire.
- traceroot.observe() and raw OTel spans carry no AI-specific attributes, so they're invisible to the Vercel processor.

The second change in this PR — lifting session.id / user.id / metadata / tags from the request context onto every span — is strictly additive. Previously those only reached spans created inside observe(); now they also reach Vercel SDK spans (which sit outside observe()). No span loses any attribute it had before; some spans gain ones they were missing.

### How we verified

1. **Source reading**. Walked the Vercel processor's mutation points; each one early-returns for non-Vercel spans.
2. **Regression tests in tests/vercel-ai.test.ts**. Three cases push non-Vercel spans through the same pipeline: a manual span, a span shaped like an OpenInference Instrumentor emission, and a non-Vercel root span sharing a trace with a Vercel call. All assert no contamination — original attributes preserved, no Vercel attributes injected, span names not renamed, statuses untouched.
3. **Mutation testing**. Temporarily removed the Vercel processor's gate on disk and re-ran the suite. The mixed-trace regression test immediately failed with the expected assertion. So the suite has real signal — if a future version of the upstream package loosens that gate, the test catches it.
4. **Live E2E against the local stack** covers all three non-Vercel integration categories (LangChain + OpenAI, @openai/agents, vanilla observe()) plus the four Vercel scenarios shown above. Every test green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Vercel AI SDK tracing via `@arizeai/openinference-vercel`, mapping `ai.*` spans to OpenInference while leaving other integrations unchanged. Also lifts `session.id`, `user.id`, tags, and metadata from context onto every span and verifies behavior end-to-end.

- **New Features**
  - Wrap OTLP exporter with `OpenInferenceSimpleSpanProcessor`/`OpenInferenceBatchSpanProcessor` to enrich Vercel spans with OpenInference fields (AGENT/LLM/TOOL, model, token counts, IO).
  - E2E coverage: 8 Vercel scenarios, LangChain + OpenAI pass-through, live `@openai/agents`, and vanilla `observe()`; includes mixed-trace safeguards. Simplified `observe()` E2E by removing a brittle residual-kind serialization check.

- **Bug Fixes**
  - OI #2651: propagate `session.id`, `user.id`, `tag.tags`, and `metadata.*` from the active context to all spans in `TraceRootSpanProcessor` (covers Vercel spans created outside `observe()`).

<sup>Written for commit c8bb0cc412401747356983ca07a79b87854ccd8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



