### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/packages/traceroot/package.json
+++ b/packages/traceroot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traceroot-ai/traceroot",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "TraceRoot TypeScript SDK for AI observability",
   "keywords": [
     "traceroot",


### PR DESCRIPTION
Fixes https://github.com/traceroot-ai/traceroot/issues/865

## Summary
- Bump `@traceroot-ai/traceroot` from `0.1.3` → `0.1.4` in `packages/traceroot/package.json`.
- Once merged, cut a `v0.1.4` GitHub release to trigger `npm-publish.yml`.

## Test plan
- [ ] CI green on this PR (lint + build)
- [ ] After merge: `gh release create v0.1.4 --target main --title "v0.1.4" --generate-notes`
- [ ] `npm-publish.yml` succeeds (tag↔version check, lint, build, test, publish)
- [ ] `npm view @traceroot-ai/traceroot version` reports `0.1.4`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@traceroot-ai/traceroot` from 0.1.3 to 0.1.4 to prepare the next patch release. This will trigger the `npm-publish.yml` workflow to publish the SDK to npm.

<sup>Written for commit 12062bf14b3d639f1b6e04679b41dd67a2445cd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

