### PR TITLE
fix(sdk): lazy-load openinference instrumentations

### DIFF
--- a/packages/traceroot/src/instrumentation.ts
+++ b/packages/traceroot/src/instrumentation.ts
@@ -1,12 +1,49 @@
 // src/instrumentation.ts
-import { registerInstrumentations } from '@opentelemetry/instrumentation';
-import { AnthropicInstrumentation } from '@arizeai/openinference-instrumentation-anthropic';
-import { BedrockInstrumentation } from '@arizeai/openinference-instrumentation-bedrock';
-import { ClaudeAgentSDKInstrumentation } from '@arizeai/openinference-instrumentation-claude-agent-sdk';
-import { LangChainInstrumentation } from '@arizeai/openinference-instrumentation-langchain';
-import { OpenAIInstrumentation } from '@arizeai/openinference-instrumentation-openai';
-import { InitializeOptions } from './types';
+import { registerInstrumentations, type Instrumentation } from '@opentelemetry/instrumentation';
+import type { InitializeOptions } from './types';
 import { wireOpenAIAgentsProcessor } from './openai-agents';
+
+type ManualInstrumentation = Instrumentation & {
+  manuallyInstrument(moduleRef: unknown): void;
+};
+
+type ManualInstrumentationConstructor = new () => ManualInstrumentation;
+
+function loadInstrumentation(
+  packageName: string,
+  exportName: string,
+): ManualInstrumentationConstructor {
+  const mod = module.require(packageName) as Record<string, unknown>;
+  const ctor = mod[exportName];
+  if (typeof ctor !== 'function') {
+    throw new Error(`[TraceRoot] ${packageName} does not export ${exportName}`);
+  }
+  return ctor as ManualInstrumentationConstructor;
+}
+
+const loadOpenAIInstrumentation = () =>
+  loadInstrumentation('@arizeai/openinference-instrumentation-openai', 'OpenAIInstrumentation');
+
+const loadAnthropicInstrumentation = () =>
+  loadInstrumentation(
+    '@arizeai/openinference-instrumentation-anthropic',
+    'AnthropicInstrumentation',
+  );
+
+const loadLangChainInstrumentation = () =>
+  loadInstrumentation(
+    '@arizeai/openinference-instrumentation-langchain',
+    'LangChainInstrumentation',
+  );
+
+const loadClaudeAgentSDKInstrumentation = () =>
+  loadInstrumentation(
+    '@arizeai/openinference-instrumentation-claude-agent-sdk',
+    'ClaudeAgentSDKInstrumentation',
+  );
+
+const loadBedrockInstrumentation = () =>
+  loadInstrumentation('@arizeai/openinference-instrumentation-bedrock', 'BedrockInstrumentation');
 
 /**
  * Wires OpenInference instrumentations based on the instrumentModules option:
@@ -25,49 +62,43 @@ export function wireInstrumentations(
     // ESM users must pass explicit module refs.
     registerInstrumentations({
       instrumentations: [
-        new OpenAIInstrumentation(),
-        new AnthropicInstrumentation(),
-        new LangChainInstrumentation(),
-        new ClaudeAgentSDKInstrumentation(),
-        new BedrockInstrumentation(),
+        new (loadOpenAIInstrumentation())(),
+        new (loadAnthropicInstrumentation())(),
+        new (loadLangChainInstrumentation())(),
+        new (loadClaudeAgentSDKInstrumentation())(),
+        new (loadBedrockInstrumentation())(),
       ],
     });
     return;
   }
 
-  const instrs: InstanceType<
-    | typeof OpenAIInstrumentation
-    | typeof AnthropicInstrumentation
-    | typeof LangChainInstrumentation
-    | typeof ClaudeAgentSDKInstrumentation
-    | typeof BedrockInstrumentation
-  >[] = [];
+  const instrs: Instrumentation[] = [];
 
   if (instrumentModules.openAI) {
-    const instr = new OpenAIInstrumentation();
+    const instr = new (loadOpenAIInstrumentation())();
     instrs.push(instr);
-    instr.manuallyInstrument(instrumentModules.openAI as any);
+    instr.manuallyInstrument(instrumentModules.openAI);
   }
   if (instrumentModules.anthropic) {
-    const instr = new AnthropicInstrumentation();
+    const instr = new (loadAnthropicInstrumentation())();
     instrs.push(instr);
-    instr.manuallyInstrument(instrumentModules.anthropic as any);
+    instr.manuallyInstrument(instrumentModules.anthropic);
   }
   if (instrumentModules.langchain) {
     // langchain must be: import * as lcCallbackManager from '@langchain/core/callbacks/manager'
-    const instr = new LangChainInstrumentation();
+    const instr = new (loadLangChainInstrumentation())();
     instrs.push(instr);
-    instr.manuallyInstrument(instrumentModules.langchain as any);
+    instr.manuallyInstrument(instrumentModules.langchain);
   }
   if (instrumentModules.claudeAgentSDK) {
-    const instr = new ClaudeAgentSDKInstrumentation();
+    const instr = new (loadClaudeAgentSDKInstrumentation())();
     instrs.push(instr);
-    instr.manuallyInstrument(instrumentModules.claudeAgentSDK as any);
+    instr.manuallyInstrument(instrumentModules.claudeAgentSDK);
   }
   if (instrumentModules.bedrock) {
-    const instr = new BedrockInstrumentation();
+    const instr = new (loadBedrockInstrumentation())();
     instrs.push(instr);
-    instr.manuallyInstrument(instrumentModules.bedrock as any);
+    instr.manuallyInstrument(instrumentModules.bedrock);
   }
   if (instrumentModules.openaiAgents) {
     wireOpenAIAgentsProcessor(instrumentModules.openaiAgents);

--- a/packages/traceroot/tests/instrumentation.test.ts
+++ b/packages/traceroot/tests/instrumentation.test.ts
@@ -1,0 +1,53 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+function runIsolatedInstrumentationScript(script: string) {
+  const tsxLoader = pathToFileURL(
+    path.join(process.cwd(), 'node_modules', 'tsx', 'dist', 'loader.mjs'),
+  ).href;
+  return spawnSync(process.execPath, ['--import', tsxLoader, '-e', script], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  });
+}
+
+describe('wireInstrumentations()', () => {
+  it('does not load OpenAI instrumentation when only Anthropic is requested', () => {
+    const result = runIsolatedInstrumentationScript(`
+      const Module = require('node:module');
+      const originalLoad = Module._load;
+
+      class FakeAnthropicInstrumentation {
+        manuallyInstrument(moduleRef) {
+          if (moduleRef.name !== 'anthropic-module') {
+            throw new Error('unexpected module ref');
+          }
+        }
+      }
+
+      Module._load = function(request, parent, isMain) {
+        if (request === '@opentelemetry/instrumentation') {
+          return { registerInstrumentations: () => {} };
+        }
+        if (request === '@arizeai/openinference-instrumentation-anthropic') {
+          return { AnthropicInstrumentation: FakeAnthropicInstrumentation };
+        }
+        if (request === '@arizeai/openinference-instrumentation-openai') {
+          throw new Error('OpenAI instrumentation should not be loaded');
+        }
+        if (request.startsWith('@arizeai/openinference-instrumentation-')) {
+          throw new Error(request + ' should not be loaded');
+        }
+        return originalLoad.apply(this, arguments);
+      };
+
+      const { wireInstrumentations } = require('./src/instrumentation.ts');
+      wireInstrumentations({ anthropic: { name: 'anthropic-module' } });
+    `);
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes TraceRoot TS SDK module loading so OpenInference instrumentations are no longer imported eagerly when the SDK instrumentation module is loaded.

The SDK now loads each OpenInference instrumentation only when its matching `instrumentModules` option is used. The existing `instrumentModules === undefined` auto-instrumentation path still registers all supported instrumentations.

## Why

The tracking issue reports that projects without all peer dependencies can crash during module evaluation, for example an Anthropic-only project failing because the OpenAI instrumentation is imported at the top level.

## Tests

- `pnpm --filter @traceroot-ai/traceroot typecheck`
- `pnpm --filter @traceroot-ai/traceroot build`
- `pnpm --filter @traceroot-ai/traceroot lint`
- `pnpm --filter @traceroot-ai/traceroot exec tsx --test tests/instrumentation.test.ts`

I also checked the full test command:

- `pnpm --filter @traceroot-ai/traceroot test`

The full suite still has three pre-existing git/source-location failures on this Windows/Node 22 environment. Those same failures were reproduced before this patch; the new instrumentation test passes in the full run.

Refs traceroot-ai/traceroot#862.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazily load OpenInference instrumentations in `@traceroot-ai/traceroot` to prevent crashes when peer dependencies are missing. Instrumentations load only when their matching `instrumentModules` option is used; the default still registers all.

- Bug Fixes
  - Removed top-level imports of `@arizeai/openinference-instrumentation-*`; construct instrumentations only when requested.
  - Preserved auto-instrumentation behavior when `instrumentModules` is `undefined`.
  - Added isolated test ensuring Anthropic-only setup does not load `@arizeai/openinference-instrumentation-openai`.

<sup>Written for commit ec1644b3412da693a0681d131ec1168500f50e49. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

