### PR TITLE
feat(instrumentation): add Mistral AI auto-instrumentation

### DIFF
--- a/packages/traceroot/package.json
+++ b/packages/traceroot/package.json
@@ -72,6 +72,7 @@
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": ">=0.20.0",
+    "@mistralai/mistralai": ">=2.0.0",
     "openai": ">=6.0.0",
     "@openai/agents": ">=0.0.1"
   },
@@ -80,6 +81,9 @@
       "optional": true
     },
     "@anthropic-ai/sdk": {
+      "optional": true
+    },
+    "@mistralai/mistralai": {
       "optional": true
     },
     "@openai/agents": {

--- a/packages/traceroot/src/instrumentation.ts
+++ b/packages/traceroot/src/instrumentation.ts
@@ -6,6 +6,7 @@ import { ClaudeAgentSDKInstrumentation } from '@arizeai/openinference-instrument
 import { LangChainInstrumentation } from '@arizeai/openinference-instrumentation-langchain';
 import { OpenAIInstrumentation } from '@arizeai/openinference-instrumentation-openai';
 import { InitializeOptions } from './types';
+import { MistralInstrumentation } from './mistral';
 import { wireOpenAIAgentsProcessor } from './openai-agents';
 
 /**
@@ -30,6 +31,7 @@ export function wireInstrumentations(
         new LangChainInstrumentation(),
         new ClaudeAgentSDKInstrumentation(),
         new BedrockInstrumentation(),
+        new MistralInstrumentation(),
       ],
     });
     return;
@@ -41,6 +43,7 @@ export function wireInstrumentations(
     | typeof LangChainInstrumentation
     | typeof ClaudeAgentSDKInstrumentation
     | typeof BedrockInstrumentation
+    | typeof MistralInstrumentation
   >[] = [];
 
   if (instrumentModules.openAI) {
@@ -68,6 +71,11 @@ export function wireInstrumentations(
     const instr = new BedrockInstrumentation();
     instrs.push(instr);
     instr.manuallyInstrument(instrumentModules.bedrock as any);
+  }
+  if (instrumentModules.mistral) {
+    const instr = new MistralInstrumentation();
+    instrs.push(instr);
+    instr.manuallyInstrument(instrumentModules.mistral);
   }
   if (instrumentModules.openaiAgents) {
     wireOpenAIAgentsProcessor(instrumentModules.openaiAgents);

--- a/packages/traceroot/src/mistral.ts
+++ b/packages/traceroot/src/mistral.ts
@@ -1,0 +1,322 @@
+import { SpanStatusCode, trace } from '@opentelemetry/api';
+import {
+  InstrumentationBase,
+  InstrumentationNodeModuleDefinition,
+} from '@opentelemetry/instrumentation';
+
+const SPAN_KIND_ATTR = 'openinference.span.kind';
+const INPUT_VALUE_ATTR = 'input.value';
+const INPUT_MIME_ATTR = 'input.mime_type';
+const OUTPUT_VALUE_ATTR = 'output.value';
+const OUTPUT_MIME_ATTR = 'output.mime_type';
+const MODEL_NAME_ATTR = 'llm.model_name';
+const PROVIDER_ATTR = 'llm.provider';
+const SYSTEM_ATTR = 'llm.system';
+const PROMPT_TOKENS_ATTR = 'llm.token_count.prompt';
+const COMPLETION_TOKENS_ATTR = 'llm.token_count.completion';
+const TOTAL_TOKENS_ATTR = 'llm.token_count.total';
+const FINISH_REASONS_ATTR = 'llm.response.finish_reasons';
+const INVOCATION_PARAMS_ATTR = 'llm.invocation_parameters';
+
+const PROVIDER = 'mistralai';
+const TRACER_NAME = 'traceroot-mistral-instrumentation';
+
+type MistralModuleLike = {
+  Mistral?: { prototype?: Record<string, unknown> };
+  default?: { prototype?: Record<string, unknown> };
+};
+
+type ChatCompletionRequest = {
+  model?: string;
+  messages?: unknown;
+  // Other request fields are captured wholesale into invocation_parameters
+  // (model + messages stripped out for clarity).
+  [key: string]: unknown;
+};
+
+type ToolCall = {
+  id?: string;
+  function?: { name?: string; arguments?: unknown };
+};
+
+type AssistantMessage = {
+  role?: string;
+  content?: unknown;
+  toolCalls?: ToolCall[] | null;
+};
+
+type ChatCompletionResponse = {
+  model?: string;
+  usage?: {
+    promptTokens?: number;
+    completionTokens?: number;
+    totalTokens?: number;
+  };
+  choices?: Array<{
+    index?: number;
+    message?: AssistantMessage;
+    finishReason?: string;
+  }>;
+};
+
+type ChatLike = {
+  complete?: (...args: unknown[]) => Promise<unknown>;
+  constructor?: { prototype?: Record<string, unknown> };
+};
+
+const PATCH_MARKER = Symbol.for('@traceroot-ai/mistral-instrumentation/patched');
+
+interface PrototypeWithMarker extends Record<string, unknown> {
+  [PATCH_MARKER]?: boolean;
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function toStringContent(content: unknown): string | undefined {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    const parts = content
+      .map((item) => {
+        if (typeof item === 'string') return item;
+        if (
+          item &&
+          typeof item === 'object' &&
+          'type' in item &&
+          'text' in item &&
+          (item as { type?: string }).type === 'text'
+        ) {
+          return String((item as { text: unknown }).text);
+        }
+        return '';
+      })
+      .filter(Boolean);
+    return parts.length > 0 ? parts.join('\n') : undefined;
+  }
+  if (content == null) return undefined;
+  return String(content);
+}
+
+function extractInputValue(req: ChatCompletionRequest | undefined): string | undefined {
+  if (!req?.messages || !Array.isArray(req.messages) || req.messages.length === 0) {
+    return undefined;
+  }
+
+  const userMessages = req.messages
+    .filter(
+      (m): m is { role?: unknown; content?: unknown } =>
+        Boolean(m) && typeof m === 'object' && 'role' in m,
+    )
+    .filter((m) => m.role === 'user')
+    .map((m) => toStringContent(m.content))
+    .filter((v): v is string => Boolean(v));
+
+  if (userMessages.length > 0) {
+    return userMessages.join('\n');
+  }
+
+  return safeJson(req.messages);
+}
+
+function extractOutputValue(response: ChatCompletionResponse | undefined): string | undefined {
+  const message = response?.choices?.[0]?.message;
+  if (!message) return undefined;
+
+  const text = toStringContent(message.content);
+  if (text) return text;
+
+  // No textual content but tool calls were emitted — surface those as the output.
+  if (Array.isArray(message.toolCalls) && message.toolCalls.length > 0) {
+    return safeJson(
+      message.toolCalls.map((tc) => ({
+        id: tc?.id,
+        name: tc?.function?.name,
+        arguments: tc?.function?.arguments,
+      })),
+    );
+  }
+
+  return undefined;
+}
+
+/**
+ * OpenInference-compatible instrumentor for `@mistralai/mistralai` (v2.x).
+ *
+ * Patches `Chat.prototype.complete` indirectly by overriding the lazy `chat`
+ * getter on `Mistral.prototype`. On first access, the returned `Chat` instance
+ * is inspected to obtain its constructor prototype; `complete` is wrapped via
+ * `_wrap()`, the original getter is restored, and subsequent `mistral.chat`
+ * accesses use the (cached) Chat with the patched method available through the
+ * prototype chain.
+ *
+ * Captured attributes follow OpenInference chat-completion semantic conventions:
+ *
+ * - `openinference.span.kind` = "LLM"
+ * - `llm.system` / `llm.provider` = "mistralai"
+ * - `llm.model_name`
+ * - `llm.token_count.prompt` / `.completion` / `.total`
+ * - `llm.invocation_parameters` (request body minus model/messages)
+ * - `llm.response.finish_reasons`
+ * - `input.value` / `input.mime_type`
+ * - `output.value` / `output.mime_type`
+ *
+ * The Mistral SDK is ESM-only, so the RITM module hook in `init()` will not
+ * fire for ESM consumers — they should pass the module ref via
+ * `instrumentModules: { mistral: import * as MistralSdk from "@mistralai/mistralai" }`,
+ * which routes through `manuallyInstrument()`.
+ */
+export class MistralInstrumentation extends InstrumentationBase {
+  private patchedChatPrototype: PrototypeWithMarker | null = null;
+
+  constructor() {
+    super('@traceroot-ai/traceroot-mistral-instrumentation', '0.1.0');
+  }
+
+  init() {
+    return [
+      new InstrumentationNodeModuleDefinition<MistralModuleLike>(
+        '@mistralai/mistralai',
+        ['*'],
+        (moduleExports) => this.patch(moduleExports ?? {}),
+        (moduleExports) => this.unpatch(moduleExports ?? {}),
+      ),
+    ];
+  }
+
+  manuallyInstrument(moduleExports: unknown): void {
+    this.patch(moduleExports as MistralModuleLike);
+  }
+
+  private patch(moduleExports: MistralModuleLike): MistralModuleLike {
+    const MistralCtor = moduleExports?.Mistral ?? moduleExports?.default;
+    const proto = MistralCtor?.prototype as Record<string, unknown> | undefined;
+    if (!proto) {
+      return moduleExports;
+    }
+
+    const chatDescriptor = Object.getOwnPropertyDescriptor(proto, 'chat');
+    if (!chatDescriptor || typeof chatDescriptor.get !== 'function') {
+      return moduleExports;
+    }
+    const originalGetter = chatDescriptor.get;
+
+    // Capture instance methods in a closure so the property getter below
+    // doesn't need to alias `this` (its `this` is the Mistral instance).
+    const wrapChatComplete = (chatProto: PrototypeWithMarker): void => {
+      this._wrap(chatProto, 'complete', (original) => this.makeWrappedComplete(original));
+      chatProto[PATCH_MARKER] = true;
+      this.patchedChatPrototype = chatProto;
+    };
+
+    Object.defineProperty(proto, 'chat', {
+      configurable: true,
+      enumerable: chatDescriptor.enumerable ?? false,
+      get(this: unknown) {
+        const chat = originalGetter.call(this) as ChatLike | undefined;
+        if (chat && typeof chat.complete === 'function') {
+          const chatProto = chat.constructor?.prototype as PrototypeWithMarker | undefined;
+          if (
+            chatProto &&
+            !chatProto[PATCH_MARKER] &&
+            typeof chatProto['complete'] === 'function'
+          ) {
+            wrapChatComplete(chatProto);
+            // Restore the original getter — the patched `complete` is now on
+            // the Chat prototype, so further accesses don't need interception.
+            Object.defineProperty(proto, 'chat', chatDescriptor);
+          }
+        }
+        return chat;
+      },
+    });
+
+    return moduleExports;
+  }
+
+  private unpatch(moduleExports: MistralModuleLike): MistralModuleLike {
+    if (this.patchedChatPrototype) {
+      this._unwrap(this.patchedChatPrototype, 'complete');
+      delete this.patchedChatPrototype[PATCH_MARKER];
+      this.patchedChatPrototype = null;
+    }
+    return moduleExports;
+  }
+
+  private makeWrappedComplete(
+    original: unknown,
+  ): (this: unknown, ...args: unknown[]) => Promise<unknown> {
+    const originalComplete = original as (...args: unknown[]) => Promise<unknown>;
+    return function wrappedComplete(this: unknown, ...args: unknown[]): Promise<unknown> {
+      const request = args[0] as ChatCompletionRequest | undefined;
+      const model = request?.model ?? 'unknown';
+      const spanName = `mistral.chat.complete ${model}`;
+
+      return trace.getTracer(TRACER_NAME).startActiveSpan(spanName, async (span) => {
+        span.setAttribute(SPAN_KIND_ATTR, 'LLM');
+        span.setAttribute(SYSTEM_ATTR, PROVIDER);
+        span.setAttribute(PROVIDER_ATTR, PROVIDER);
+        if (request?.model) span.setAttribute(MODEL_NAME_ATTR, request.model);
+
+        const inputValue = extractInputValue(request);
+        if (inputValue) {
+          span.setAttribute(INPUT_VALUE_ATTR, inputValue);
+          span.setAttribute(INPUT_MIME_ATTR, 'text/plain');
+        }
+
+        if (request) {
+          // Strip messages (already captured as input.value) and model (own
+          // attribute) — the rest characterises the call (tools, temperature,
+          // toolChoice, parallelToolCalls, ...).
+          const { messages: _messages, model: _model, ...invocationParams } = request;
+          if (Object.keys(invocationParams).length > 0) {
+            span.setAttribute(INVOCATION_PARAMS_ATTR, safeJson(invocationParams));
+          }
+        }
+
+        try {
+          const response = (await originalComplete.apply(this, args)) as ChatCompletionResponse;
+
+          const responseModel = response?.model;
+          if (responseModel) span.setAttribute(MODEL_NAME_ATTR, responseModel);
+
+          const promptTokens = response?.usage?.promptTokens;
+          if (typeof promptTokens === 'number') {
+            span.setAttribute(PROMPT_TOKENS_ATTR, promptTokens);
+          }
+          const completionTokens = response?.usage?.completionTokens;
+          if (typeof completionTokens === 'number') {
+            span.setAttribute(COMPLETION_TOKENS_ATTR, completionTokens);
+          }
+          const totalTokens = response?.usage?.totalTokens;
+          if (typeof totalTokens === 'number') {
+            span.setAttribute(TOTAL_TOKENS_ATTR, totalTokens);
+          }
+
+          const finishReason = response?.choices?.[0]?.finishReason;
+          if (finishReason) {
+            span.setAttribute(FINISH_REASONS_ATTR, [finishReason]);
+          }
+
+          const outputValue = extractOutputValue(response);
+          if (outputValue) {
+            span.setAttribute(OUTPUT_VALUE_ATTR, outputValue);
+            span.setAttribute(OUTPUT_MIME_ATTR, 'text/plain');
+          }
+
+          return response as unknown;
+        } catch (error) {
+          span.recordException(error as Error);
+          span.setStatus({ code: SpanStatusCode.ERROR, message: String(error) });
+          throw error;
+        } finally {
+          span.end();
+        }
+      });
+    };
+  }
+}

--- a/packages/traceroot/src/mistral.ts
+++ b/packages/traceroot/src/mistral.ts
@@ -65,9 +65,13 @@ type ChatLike = {
 };
 
 const PATCH_MARKER = Symbol.for('@traceroot-ai/mistral-instrumentation/patched');
+const MISTRAL_PROTO_PATCH_MARKER = Symbol.for(
+  '@traceroot-ai/mistral-instrumentation/mistral-proto-patched',
+);
 
 interface PrototypeWithMarker extends Record<string, unknown> {
   [PATCH_MARKER]?: boolean;
+  [MISTRAL_PROTO_PATCH_MARKER]?: boolean;
 }
 
 function safeJson(value: unknown): string {
@@ -172,6 +176,8 @@ function extractOutputValue(response: ChatCompletionResponse | undefined): strin
  */
 export class MistralInstrumentation extends InstrumentationBase {
   private patchedChatPrototype: PrototypeWithMarker | null = null;
+  private patchedMistralPrototype: PrototypeWithMarker | null = null;
+  private originalChatDescriptor: PropertyDescriptor | null = null;
 
   constructor() {
     super('@traceroot-ai/traceroot-mistral-instrumentation', '0.1.0');
@@ -192,10 +198,28 @@ export class MistralInstrumentation extends InstrumentationBase {
     this.patch(moduleExports as MistralModuleLike);
   }
 
+  /**
+   * Symmetric counterpart to {@link manuallyInstrument} — restores the
+   * original `Mistral.prototype.chat` getter and unwraps `Chat.prototype.complete`
+   * if the lazy patching had already fired. Safe to call even if the lazy
+   * Chat-prototype wrap has not yet happened (e.g., the user patched and then
+   * immediately decided to disable instrumentation without touching `mistral.chat`).
+   */
+  manuallyUninstrument(moduleExports: unknown): void {
+    this.unpatch(moduleExports as MistralModuleLike);
+  }
+
   private patch(moduleExports: MistralModuleLike): MistralModuleLike {
     const MistralCtor = moduleExports?.Mistral ?? moduleExports?.default;
-    const proto = MistralCtor?.prototype as Record<string, unknown> | undefined;
+    const proto = MistralCtor?.prototype as PrototypeWithMarker | undefined;
     if (!proto) {
+      return moduleExports;
+    }
+
+    // Idempotency: if we already installed our getter on this prototype,
+    // bail out. Re-running patch() would otherwise re-read our own getter as
+    // the "original" and corrupt the unpatch path.
+    if (proto[MISTRAL_PROTO_PATCH_MARKER]) {
       return moduleExports;
     }
 
@@ -204,6 +228,12 @@ export class MistralInstrumentation extends InstrumentationBase {
       return moduleExports;
     }
     const originalGetter = chatDescriptor.get;
+
+    // Remember what we replaced *before* installing our getter so unpatch()
+    // can always restore the original, regardless of whether the lazy
+    // Chat.prototype.complete wrap has fired yet.
+    this.patchedMistralPrototype = proto;
+    this.originalChatDescriptor = chatDescriptor;
 
     // Capture instance methods in a closure so the property getter below
     // doesn't need to alias `this` (its `this` is the Mistral instance).
@@ -235,15 +265,33 @@ export class MistralInstrumentation extends InstrumentationBase {
       },
     });
 
+    proto[MISTRAL_PROTO_PATCH_MARKER] = true;
     return moduleExports;
   }
 
   private unpatch(moduleExports: MistralModuleLike): MistralModuleLike {
+    // Step 1: restore Mistral.prototype.chat to the original descriptor.
+    //
+    // This must happen unconditionally — even if the lazy Chat.prototype.complete
+    // wrap has not fired yet. Otherwise our overridden getter remains installed
+    // and the next `mistral.chat` access after unpatch() would silently re-arm
+    // the wrap. If lazy patching *did* fire, patch()'s inner getter already
+    // restored the original descriptor inline; redefining it here is a safe
+    // no-op in that case.
+    if (this.patchedMistralPrototype && this.originalChatDescriptor) {
+      Object.defineProperty(this.patchedMistralPrototype, 'chat', this.originalChatDescriptor);
+      delete this.patchedMistralPrototype[MISTRAL_PROTO_PATCH_MARKER];
+      this.patchedMistralPrototype = null;
+      this.originalChatDescriptor = null;
+    }
+
+    // Step 2: unwrap Chat.prototype.complete if lazy patching had fired.
     if (this.patchedChatPrototype) {
       this._unwrap(this.patchedChatPrototype, 'complete');
       delete this.patchedChatPrototype[PATCH_MARKER];
       this.patchedChatPrototype = null;
     }
+
     return moduleExports;
   }
 

--- a/packages/traceroot/src/types.ts
+++ b/packages/traceroot/src/types.ts
@@ -55,6 +55,13 @@ export interface InitializeOptions {
     claudeAgentSDK?: unknown;
     bedrock?: unknown;
     /**
+     * `@mistralai/mistralai` module namespace. Pass
+     * `import * as mistralSdk from '@mistralai/mistralai'` (the namespace, not
+     * the `Mistral` class). The Mistral SDK is ESM-only, so RITM
+     * auto-instrumentation does not apply — pass the module ref explicitly.
+     */
+    mistral?: unknown;
+    /**
      * @openai/agents module ref. Pass `import * as agents from '@openai/agents'`.
      *
      * Replaces the SDK's default OpenAI tracing processor with TraceRoot's —

--- a/packages/traceroot/tests/mistral.test.ts
+++ b/packages/traceroot/tests/mistral.test.ts
@@ -208,6 +208,115 @@ describe('MistralInstrumentation', () => {
     assert.equal(spans[0].attributes['output.value'], 'Handled malformed input');
   });
 
+  it('manuallyUninstrument() restores the original chat getter when lazy patching has not fired yet', async () => {
+    let callCount = 0;
+    const fakeModule = buildFakeMistralModule(async () => {
+      callCount++;
+      return {
+        model: 'mistral-large-latest',
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        choices: [{ message: { content: 'ok' }, finishReason: 'stop' }],
+      };
+    });
+
+    // Capture the original getter BEFORE we patch so we can compare identity later.
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      fakeModule.Mistral.prototype,
+      'chat',
+    );
+    assert.equal(typeof originalDescriptor?.get, 'function');
+
+    const instr = new MistralInstrumentation();
+    instr.manuallyInstrument(fakeModule);
+
+    // Sanity: patching swapped the descriptor.
+    const patchedDescriptor = Object.getOwnPropertyDescriptor(fakeModule.Mistral.prototype, 'chat');
+    assert.notEqual(patchedDescriptor?.get, originalDescriptor?.get);
+
+    // Immediately uninstrument WITHOUT ever touching `mistral.chat`. This is
+    // the regression case: pre-lazy unpatch must still restore the original
+    // getter, otherwise instrumentation silently re-arms on the next access.
+    instr.manuallyUninstrument(fakeModule);
+
+    const restoredDescriptor = Object.getOwnPropertyDescriptor(
+      fakeModule.Mistral.prototype,
+      'chat',
+    );
+    assert.equal(
+      restoredDescriptor?.get,
+      originalDescriptor?.get,
+      'unpatch() must restore the original chat getter even before lazy patching fires',
+    );
+
+    // And no spans should be emitted for subsequent calls.
+    const client = new fakeModule.Mistral();
+    await client.chat.complete({
+      model: 'mistral-large-latest',
+      messages: [{ role: 'user', content: 'after unpatch' }],
+    });
+    assert.equal(callCount, 1, 'underlying call should still happen');
+    assert.equal(exporter.getFinishedSpans().length, 0, 'no spans should be emitted after unpatch');
+  });
+
+  it('manuallyUninstrument() also unwraps Chat.prototype.complete after lazy patching has fired', async () => {
+    const fakeModule = buildFakeMistralModule(async () => ({
+      model: 'mistral-large-latest',
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      choices: [{ message: { content: 'ok' }, finishReason: 'stop' }],
+    }));
+
+    const instr = new MistralInstrumentation();
+    instr.manuallyInstrument(fakeModule);
+
+    const c1 = new fakeModule.Mistral();
+    await c1.chat.complete({
+      model: 'mistral-large-latest',
+      messages: [{ role: 'user', content: 'pre-unpatch' }],
+    });
+    assert.equal(exporter.getFinishedSpans().length, 1);
+
+    instr.manuallyUninstrument(fakeModule);
+    exporter.reset();
+
+    const c2 = new fakeModule.Mistral();
+    await c2.chat.complete({
+      model: 'mistral-large-latest',
+      messages: [{ role: 'user', content: 'post-unpatch' }],
+    });
+    assert.equal(
+      exporter.getFinishedSpans().length,
+      0,
+      'no spans should be emitted after unpatch, even on a fresh client',
+    );
+  });
+
+  it('patch() is idempotent — re-patching the same module does not break unpatch', async () => {
+    const fakeModule = buildFakeMistralModule(async () => ({
+      model: 'mistral-large-latest',
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      choices: [{ message: { content: 'ok' }, finishReason: 'stop' }],
+    }));
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      fakeModule.Mistral.prototype,
+      'chat',
+    );
+
+    const instr = new MistralInstrumentation();
+    instr.manuallyInstrument(fakeModule);
+    instr.manuallyInstrument(fakeModule); // second call is a no-op
+    instr.manuallyUninstrument(fakeModule);
+
+    const restoredDescriptor = Object.getOwnPropertyDescriptor(
+      fakeModule.Mistral.prototype,
+      'chat',
+    );
+    assert.equal(
+      restoredDescriptor?.get,
+      originalDescriptor?.get,
+      'double-patch then unpatch must still cleanly restore the original getter',
+    );
+  });
+
   it('only patches the Chat prototype once across multiple Mistral instances', async () => {
     let callCount = 0;
     const fakeModule = buildFakeMistralModule(async () => {

--- a/packages/traceroot/tests/mistral.test.ts
+++ b/packages/traceroot/tests/mistral.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { MistralInstrumentation } from '../src/mistral';
+import { _resetForTesting } from '../src/traceroot';
+
+// Build a fake Mistral module shaped like @mistralai/mistralai v2:
+//   class Chat { async complete(req) { ... } }
+//   class Mistral { get chat() { return cached new Chat() } }
+//
+// Each call to `buildFakeMistralModule()` returns a fresh pair of classes so
+// instrumentor state from prior tests can't bleed across.
+function buildFakeMistralModule(completeImpl: (req: unknown) => Promise<unknown>): {
+  Mistral: new () => { readonly chat: { complete: (req: unknown) => Promise<unknown> } };
+} {
+  class Chat {
+    async complete(req: unknown): Promise<unknown> {
+      return completeImpl(req);
+    }
+  }
+  class Mistral {
+    private _chat?: Chat;
+    get chat(): Chat {
+      return (this._chat ??= new Chat());
+    }
+  }
+  return { Mistral } as unknown as {
+    Mistral: new () => { readonly chat: { complete: (req: unknown) => Promise<unknown> } };
+  };
+}
+
+describe('MistralInstrumentation', () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider();
+    provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+    provider.register();
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+    exporter.reset();
+    _resetForTesting();
+  });
+
+  it('creates an LLM span for mistral.chat.complete with full attributes', async () => {
+    const fakeModule = buildFakeMistralModule(async (req) => {
+      const r = req as { model: string; messages: unknown };
+      return {
+        id: 'cmpl-1',
+        model: r.model,
+        usage: { promptTokens: 17, completionTokens: 9, totalTokens: 26 },
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'Bonjour from Mistral' },
+            finishReason: 'stop',
+          },
+        ],
+      };
+    });
+
+    const instr = new MistralInstrumentation();
+    instr.manuallyInstrument(fakeModule);
+
+    const client = new fakeModule.Mistral();
+    const result = (await client.chat.complete({
+      model: 'mistral-large-latest',
+      messages: [{ role: 'user', content: 'Say hello' }],
+      temperature: 0.2,
+      toolChoice: 'auto',
+    })) as { choices: Array<{ message: { content: string } }> };
+
+    assert.equal(result.choices[0].message.content, 'Bonjour from Mistral');
+
+    const spans = exporter.getFinishedSpans();
+    assert.equal(spans.length, 1);
+    const span = spans[0];
+
+    assert.equal(span.name, 'mistral.chat.complete mistral-large-latest');
+    assert.equal(span.attributes['openinference.span.kind'], 'LLM');
+    assert.equal(span.attributes['llm.system'], 'mistralai');
+    assert.equal(span.attributes['llm.provider'], 'mistralai');
+    assert.equal(span.attributes['llm.model_name'], 'mistral-large-latest');
+    assert.equal(span.attributes['llm.token_count.prompt'], 17);
+    assert.equal(span.attributes['llm.token_count.completion'], 9);
+    assert.equal(span.attributes['llm.token_count.total'], 26);
+    assert.equal(span.attributes['input.value'], 'Say hello');
+    assert.equal(span.attributes['input.mime_type'], 'text/plain');
+    assert.equal(span.attributes['output.value'], 'Bonjour from Mistral');
+    assert.equal(span.attributes['output.mime_type'], 'text/plain');
+    assert.deepEqual(span.attributes['llm.response.finish_reasons'], ['stop']);
+
+    // Invocation parameters should include non-message/non-model fields.
+    const invocation = JSON.parse(span.attributes['llm.invocation_parameters'] as string) as {
+      temperature?: number;
+      toolChoice?: string;
+      messages?: unknown;
+      model?: unknown;
+    };
+    assert.equal(invocation.temperature, 0.2);
+    assert.equal(invocation.toolChoice, 'auto');
+    assert.equal('messages' in invocation, false);
+    assert.equal('model' in invocation, false);
+  });
+
+  it('captures tool-call output when assistant returns toolCalls instead of text', async () => {
+    const fakeModule = buildFakeMistralModule(async () => ({
+      model: 'mistral-medium-latest',
+      usage: { promptTokens: 10, completionTokens: 4, totalTokens: 14 },
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: null,
+            toolCalls: [
+              {
+                id: 'call_42',
+                function: { name: 'get_weather', arguments: '{"city":"Paris"}' },
+              },
+            ],
+          },
+          finishReason: 'tool_calls',
+        },
+      ],
+    }));
+
+    const instr = new MistralInstrumentation();
+    instr.manuallyInstrument(fakeModule);
+
+    const client = new fakeModule.Mistral();
+    await client.chat.complete({
+      model: 'mistral-medium-latest',
+      messages: [{ role: 'user', content: 'Weather in Paris?' }],
+    });
+
+    const span = exporter.getFinishedSpans()[0];
+    assert.equal(span.attributes['llm.model_name'], 'mistral-medium-latest');
+    assert.deepEqual(span.attributes['llm.response.finish_reasons'], ['tool_calls']);
+
+    const output = JSON.parse(span.attributes['output.value'] as string) as Array<{
+      id: string;
+      name: string;
+      arguments: string;
+    }>;
+    assert.equal(output.length, 1);
+    assert.equal(output[0].id, 'call_42');
+    assert.equal(output[0].name, 'get_weather');
+    assert.equal(output[0].arguments, '{"city":"Paris"}');
+  });
+
+  it('records exception and ERROR status when complete() rejects', async () => {
+    const boom = new Error('Mistral API blew up');
+    const fakeModule = buildFakeMistralModule(async () => {
+      throw boom;
+    });
+
+    const instr = new MistralInstrumentation();
+    instr.manuallyInstrument(fakeModule);
+
+    const client = new fakeModule.Mistral();
+    await assert.rejects(
+      client.chat.complete({
+        model: 'mistral-small-latest',
+        messages: [{ role: 'user', content: 'fail please' }],
+      }),
+      /Mistral API blew up/,
+    );
+
+    const spans = exporter.getFinishedSpans();
+    assert.equal(spans.length, 1);
+    const span = spans[0];
+
+    // SpanStatusCode.ERROR === 2
+    assert.equal(span.status.code, 2);
+    assert.match(span.status.message ?? '', /Mistral API blew up/);
+    assert.equal(span.events.length, 1);
+    assert.equal(span.events[0].name, 'exception');
+  });
+
+  it('does not throw on malformed messages payloads', async () => {
+    const fakeModule = buildFakeMistralModule(async (req) => {
+      const r = req as { model: string };
+      return {
+        model: r.model,
+        usage: { promptTokens: 7, completionTokens: 3, totalTokens: 10 },
+        choices: [{ message: { role: 'assistant', content: 'Handled malformed input' } }],
+      };
+    });
+
+    const instr = new MistralInstrumentation();
+    instr.manuallyInstrument(fakeModule);
+
+    const client = new fakeModule.Mistral();
+    await client.chat.complete({
+      model: 'mistral-small-latest',
+      messages: [null, 42, 'bad', { nope: true }, { role: 'user', content: 'hello' }],
+    });
+
+    const spans = exporter.getFinishedSpans();
+    assert.equal(spans.length, 1);
+    assert.equal(spans[0].attributes['input.value'], 'hello');
+    assert.equal(spans[0].attributes['output.value'], 'Handled malformed input');
+  });
+
+  it('only patches the Chat prototype once across multiple Mistral instances', async () => {
+    let callCount = 0;
+    const fakeModule = buildFakeMistralModule(async () => {
+      callCount++;
+      return {
+        model: 'mistral-large-latest',
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        choices: [{ message: { content: 'ok' }, finishReason: 'stop' }],
+      };
+    });
+
+    const instr = new MistralInstrumentation();
+    instr.manuallyInstrument(fakeModule);
+
+    // Two distinct clients accessing chat repeatedly should still produce
+    // exactly one span per call (no double-wrapping).
+    const c1 = new fakeModule.Mistral();
+    const c2 = new fakeModule.Mistral();
+    await c1.chat.complete({
+      model: 'mistral-large-latest',
+      messages: [{ role: 'user', content: 'a' }],
+    });
+    await c1.chat.complete({
+      model: 'mistral-large-latest',
+      messages: [{ role: 'user', content: 'b' }],
+    });
+    await c2.chat.complete({
+      model: 'mistral-large-latest',
+      messages: [{ role: 'user', content: 'c' }],
+    });
+
+    assert.equal(callCount, 3);
+    assert.equal(exporter.getFinishedSpans().length, 3);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       '@arizeai/openinference-vercel':
         specifier: ^2.7.2
         version: 2.7.2(@opentelemetry/api@1.9.1)(@opentelemetry/semantic-conventions@1.40.0)
+      '@mistralai/mistralai':
+        specifier: '>=2.0.0'
+        version: 2.2.1
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -636,6 +639,9 @@ packages:
     engines: {node: '>=22.13.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  '@mistralai/mistralai@2.2.1':
+    resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -3370,6 +3376,15 @@ snapshots:
       zod-from-json-schema: 0.5.2
       zod-from-json-schema-v3: zod-from-json-schema@0.0.5
       zod-to-json-schema: 3.25.2(zod@4.3.6)
+
+  '@mistralai/mistralai@2.2.1':
+    dependencies:
+      ws: 8.20.0
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:


### PR DESCRIPTION


**Fixes traceroot-ai/traceroot#739 (TypeScript SDK side)**

## Summary

Adds `MistralInstrumentation` for `@mistralai/mistralai` v2, sending OpenInference-compatible spans. Works with both auto-instrumentation (RITM) and manual (`instrumentModules`) paths.

Since there’s no official npm package yet (`@arizeai/openinference-instrumentation-mistralai`), this is the Option B approach requested in the issue.

## Type of Change

* [x] feat — New feature

## Details

* Patches `Mistral.prototype.chat` lazily to wrap `complete()` and emit spans.
* Prevents double-wrapping with a `Symbol` marker.
* Captures all OpenInference chat-completion attributes (model, token counts, inputs/outputs, finish reasons, errors).
* ESM-only support: users should pass the module via `instrumentModules.mistral` if auto-hook won’t fire.
* Files added/updated:

  * `packages/traceroot/src/mistral.ts` — `MistralInstrumentation` + helpers
  * `packages/traceroot/src/instrumentation.ts` — registers instrumentor
  * `packages/traceroot/src/types.ts` — adds `mistral` option
  * `packages/traceroot/tests/mistral.test.ts` — 5 unit tests with fake Mistral module

## Validation

* TypeScript builds clean.
* All 5 new Mistral tests pass; pre-existing tests unaffected.
* ESLint clean.
* Manually verified spans show correctly in TraceRoot using the companion example PR.

## Companion PR

Example usage in **`traceroot-ai/traceroot#…`**. Uses `tracedComplete()` for now to match the future instrumentation shape.

## Checklist

* [x] Read [[CONTRIBUTING.md](https://chatgpt.com/CONTRIBUTING.md)](../CONTRIBUTING.md)
* [x] Added/updated tests
* [x] Updated documentation (JSDoc for `instrumentModules.mistral`)
* [x] UI changes — N/A


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Mistral instrumentation for `@mistralai/mistralai` v2 to emit OpenInference-compatible spans for chat completions. Traces model inputs/outputs, token usage, finish reasons, and errors; supports ESM manual wiring via `instrumentModules.mistral` and clean uninstrumenting.

- New Features
  - Introduces `MistralInstrumentation` that lazily patches `Mistral.prototype.chat` to wrap `chat.complete()`; prevents double-wrapping and is idempotent.
  - Captures `llm.model_name`, token counts, finish reasons, `input.value`/`output.value`, and `llm.invocation_parameters`.
  - Supports manual instrumentation with `instrumentModules.mistral` (ESM-safe); also registered in `wireInstrumentations`.
  - Adds `manuallyUninstrument()` to restore the original getter and unwrap `complete()`, even if lazy patching hasn’t fired; tests cover success, tool calls, errors, malformed inputs, idempotency, and uninstrument behavior.

- Dependencies
  - Adds optional peer dependency `@mistralai/mistralai` (>=2.0.0); lockfile updated to 2.2.1.

<sup>Written for commit 58acb1b3e052722a42e8e80339b5a3ded7d2025a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

