### PR TITLE
fix: lazy-load OpenInference instrumentations to avoid peer dep crashes

### DIFF
--- a/packages/traceroot/src/instrumentation.ts
+++ b/packages/traceroot/src/instrumentation.ts
@@ -1,12 +1,30 @@
 // src/instrumentation.ts
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
-import { AnthropicInstrumentation } from '@arizeai/openinference-instrumentation-anthropic';
-import { BedrockInstrumentation } from '@arizeai/openinference-instrumentation-bedrock';
-import { ClaudeAgentSDKInstrumentation } from '@arizeai/openinference-instrumentation-claude-agent-sdk';
-import { LangChainInstrumentation } from '@arizeai/openinference-instrumentation-langchain';
-import { OpenAIInstrumentation } from '@arizeai/openinference-instrumentation-openai';
 import { InitializeOptions } from './types';
 import { wireOpenAIAgentsProcessor } from './openai-agents';
+
+/**
+ * Lazily loads a module export. Returns the constructor or null if the
+ * module (or its peer dependencies) cannot be resolved. This prevents
+ * TraceRoot.initialize() from crashing when a project doesn't depend on
+ * every peer dep of every instrumentation package.
+ *
+ * @example
+ *   const OpenAICtor = safeRequire(
+ *     '@arizeai/openinference-instrumentation-openai',
+ *     'OpenAIInstrumentation',
+ *   );
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function safeRequire(pkg: string, exportName: string): any | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require(pkg);
+    return mod[exportName] || null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Wires OpenInference instrumentations based on the instrumentModules option:
@@ -16,6 +34,11 @@ import { wireOpenAIAgentsProcessor } from './openai-agents';
  * - { openAI } → manual patch only the provided module refs
  *
  * Called once by TraceRoot.initialize().
+ *
+ * All OpenInference instrumentations are lazy-loaded via require() so that
+ * missing peer dependencies (e.g. `openai`, `@anthropic-ai/sdk`, `bedrock`)
+ * don't crash initialization. An instrumentation is silently skipped when
+ * its module can't be resolved.
  */
 export function wireInstrumentations(
   instrumentModules: InitializeOptions['instrumentModules'],
@@ -23,51 +46,101 @@ export function wireInstrumentations(
   if (instrumentModules === undefined) {
     // Auto-instrumentation via require-in-the-middle (CJS only).
     // ESM users must pass explicit module refs.
-    registerInstrumentations({
-      instrumentations: [
-        new OpenAIInstrumentation(),
-        new AnthropicInstrumentation(),
-        new LangChainInstrumentation(),
-        new ClaudeAgentSDKInstrumentation(),
-        new BedrockInstrumentation(),
-      ],
-    });
+    const instrs: any[] = [];
+
+    const OpenAIInstrumentation = safeRequire(
+      '@arizeai/openinference-instrumentation-openai',
+      'OpenAIInstrumentation',
+    );
+    if (OpenAIInstrumentation) instrs.push(new OpenAIInstrumentation());
+
+    const AnthropicInstrumentation = safeRequire(
+      '@arizeai/openinference-instrumentation-anthropic',
+      'AnthropicInstrumentation',
+    );
+    if (AnthropicInstrumentation) instrs.push(new AnthropicInstrumentation());
+
+    const LangChainInstrumentation = safeRequire(
+      '@arizeai/openinference-instrumentation-langchain',
+      'LangChainInstrumentation',
+    );
+    if (LangChainInstrumentation) instrs.push(new LangChainInstrumentation());
+
+    const ClaudeAgentSDKInstrumentation = safeRequire(
+      '@arizeai/openinference-instrumentation-claude-agent-sdk',
+      'ClaudeAgentSDKInstrumentation',
+    );
+    if (ClaudeAgentSDKInstrumentation)
+      instrs.push(new ClaudeAgentSDKInstrumentation());
+
+    const BedrockInstrumentation = safeRequire(
+      '@arizeai/openinference-instrumentation-bedrock',
+      'BedrockInstrumentation',
+    );
+    if (BedrockInstrumentation) instrs.push(new BedrockInstrumentation());
+
+    if (instrs.length > 0) {
+      registerInstrumentations({ instrumentations: instrs });
+    }
     return;
   }
 
-  const instrs: InstanceType<
-    | typeof OpenAIInstrumentation
-    | typeof AnthropicInstrumentation
-    | typeof LangChainInstrumentation
-    | typeof ClaudeAgentSDKInstrumentation
-    | typeof BedrockInstrumentation
-  >[] = [];
+  const instrs: any[] = [];
 
   if (instrumentModules.openAI) {
-    const instr = new OpenAIInstrumentation();
-    instrs.push(instr);
-    instr.manuallyInstrument(instrumentModules.openAI as any);
+    const OpenAIInstrumentation = safeRequire(
+      '@arizeai/openinference-instrumentation-openai',
+      'OpenAIInstrumentation',
+    );
+    if (OpenAIInstrumentation) {
+      const instr = new OpenAIInstrumentation();
+      instrs.push(instr);
+      instr.manuallyInstrument(instrumentModules.openAI as any);
+    }
   }
   if (instrumentModules.anthropic) {
-    const instr = new AnthropicInstrumentation();
-    instrs.push(instr);
-    instr.manuallyInstrument(instrumentModules.anthropic as any);
+    const AnthropicInstrumentation = safeRequire(
+      '@arizeai/openinference-instrumentation-anthropic',
+      'AnthropicInstrumentation',
+    );
+    if (AnthropicInstrumentation) {
+      const instr = new AnthropicInstrumentation();
+      instrs.push(instr);
+      instr.manuallyInstrument(instrumentModules.anthropic as any);
+    }
   }
   if (instrumentModules.langchain) {
-    // langchain must be: import * as lcCallbackManager from '@langchain/core/callbacks/manager'
-    const instr = new LangChainInstrumentation();
-    instrs.push(instr);
-    instr.manuallyInstrument(instrumentModules.langchain as any);
+    const LangChainInstrumentation = safeRequire(
+      '@arizeai/openinference-instrumentation-langchain',
+      'LangChainInstrumentation',
+    );
+    if (LangChainInstrumentation) {
+      const instr = new LangChainInstrumentation();
+      instrs.push(instr);
+      instr.manuallyInstrument(instrumentModules.langchain as any);
+    }
   }
   if (instrumentModules.claudeAgentSDK) {
-    const instr = new ClaudeAgentSDKInstrumentation();
-    instrs.push(instr);
-    instr.manuallyInstrument(instrumentModules.claudeAgentSDK as any);
+    const ClaudeAgentSDKInstrumentation = safeRequire(
+      '@arizeai/openinference-instrumentation-claude-agent-sdk',
+      'ClaudeAgentSDKInstrumentation',
+    );
+    if (ClaudeAgentSDKInstrumentation) {
+      const instr = new ClaudeAgentSDKInstrumentation();
+      instrs.push(instr);
+      instr.manuallyInstrument(instrumentModules.claudeAgentSDK as any);
+    }
   }
   if (instrumentModules.bedrock) {
-    const instr = new BedrockInstrumentation();
-    instrs.push(instr);
-    instr.manuallyInstrument(instrumentModules.bedrock as any);
+    const BedrockInstrumentation = safeRequire(
+      '@arizeai/openinference-instrumentation-bedrock',
+      'BedrockInstrumentation',
+    );
+    if (BedrockInstrumentation) {
+      const instr = new BedrockInstrumentation();
+      instrs.push(instr);
+      instr.manuallyInstrument(instrumentModules.bedrock as any);
+    }
   }
   if (instrumentModules.openaiAgents) {
     wireOpenAIAgentsProcessor(instrumentModules.openaiAgents);


### PR DESCRIPTION
## Summary

Fixes traceroot-ai/traceroot#862 — lazy-load all OpenInference instrumentations so `TraceRoot.initialize()` no longer crashes when a project is missing peer dependencies of uninstrumented packages.

## Root Cause

`packages/traceroot/src/instrumentation.ts` had five static top-level imports:

```ts
import { OpenAIInstrumentation } from '@arizeai/openinference-instrumentation-openai';
import { AnthropicInstrumentation } from '@arizeai/openinference-instrumentation-anthropic';
import { LangChainInstrumentation } from '@arizeai/openinference-instrumentation-langchain';
import { ClaudeAgentSDKInstrumentation } from '@arizeai/openinference-instrumentation-claude-agent-sdk';
import { BedrockInstrumentation } from '@arizeai/openinference-instrumentation-bedrock';
```

These are evaluated at module-parse time — before `wireInstrumentations()` even runs. Each instrumentation package declares peer deps (e.g. `openai`, `@anthropic-ai/sdk`, `bedrock`). When a project doesn't install the peer dep for an instrumentation it never intends to use, the entire `TraceRoot.initialize()` call crashes with `Cannot find module`.

## Fix

- Removed the five static imports
- Added a `safeRequire()` helper that wraps `require()` in try-catch — returns `null` when the module can't be resolved
- Each instrumentation is now loaded lazily inside `wireInstrumentations()` only when needed (either via RITM auto-instrumentation or explicit `instrumentModules` config)
- An instrumentation that can't be resolved is silently skipped instead of crashing

## Changes

| File | Change |
|------|--------|
| `packages/traceroot/src/instrumentation.ts` | +110 / -37 |

## Testing

- ✅ Existing tests pass (no functional change when all peer deps are present)
- ✅ Manual verification: `safeRequire()` returns `null` for unresolvable packages instead of throwing
- ✅ All five instrumentations follow the same lazy-load pattern
- ✅ `instrumentModules: undefined` (RITM path) and explicit module paths both use lazy loading

## Verification

To verify the fix resolves the original issue, run the `examples/typescript/anthropic` example against this branch without `openai` installed — it should no longer crash on initialization.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazy-load OpenInference instrumentations to prevent `TraceRoot.initialize()` from crashing when peer dependencies of unused packages are missing. Startup now succeeds even if `openai`, `@anthropic-ai/sdk`, or `bedrock` aren’t installed.

- Bug Fixes
  - Removed top-level imports of `@arizeai/openinference-instrumentation-openai`, `@arizeai/openinference-instrumentation-anthropic`, `@arizeai/openinference-instrumentation-langchain`, `@arizeai/openinference-instrumentation-claude-agent-sdk`, and `@arizeai/openinference-instrumentation-bedrock`.
  - Added `safeRequire()` to lazily load modules and return `null` when unresolved instead of throwing.
  - Moved instantiation into `wireInstrumentations()`; unresolved instrumentations are skipped silently.
  - Works for both RITM auto-instrumentation and explicit `instrumentModules`; no behavior change when all peer deps are present.

<sup>Written for commit 5e20bcdd1e401d7911db1c55bd7929d02890a198. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot-ts/pull/93?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

