### PR TITLE
refactor: centralize telemetry attribute constants

### DIFF
--- a/packages/mastra/src/exporter.ts
+++ b/packages/mastra/src/exporter.ts
@@ -31,39 +31,43 @@ import {
   ATTR_TELEMETRY_SDK_VERSION,
 } from '@opentelemetry/semantic-conventions';
 
-// Span path attribute keys — must match TraceRootSpanProcessor (packages/traceroot/src/processor.ts)
-const TR_SPAN_PATH = 'traceroot.span.path';
-const TR_SPAN_IDS_PATH = 'traceroot.span.ids_path';
-
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { version: SDK_VERSION } = require('../package.json') as { version: string };
 const SDK_NAME = 'traceroot-mastra';
 
 const DEFAULT_BASE_URL = 'https://app.traceroot.ai';
 
+const TR_ATTRIBUTES = {
+  // Span path keys must match TraceRootSpanProcessor (packages/traceroot/src/processor.ts).
+  SPAN_PATH: 'traceroot.span.path',
+  SPAN_IDS_PATH: 'traceroot.span.ids_path',
+  SDK_NAME: 'traceroot.sdk.name',
+  SDK_VERSION: 'traceroot.sdk.version',
+  METADATA_PREFIX: 'traceroot.metadata',
+} as const;
+
 // OpenInference semconv keys — internal only, not exposed in public API.
-const OI_SPAN_KIND = 'openinference.span.kind';
-const OI_INPUT_VALUE = 'input.value';
-const OI_OUTPUT_VALUE = 'output.value';
-const OI_SESSION_ID = 'session.id';
-const OI_USER_ID = 'user.id';
+const OI_ATTRIBUTES = {
+  SPAN_KIND: 'openinference.span.kind',
+  INPUT_VALUE: 'input.value',
+  OUTPUT_VALUE: 'output.value',
+  SESSION_ID: 'session.id',
+  USER_ID: 'user.id',
+} as const;
 
 // OpenInference span kind values
 type OISpanKind = 'AGENT' | 'LLM' | 'TOOL' | 'CHAIN';
 
 // gen_ai semconv (standard, used by multiple platforms)
-const GEN_AI_SYSTEM = 'gen_ai.system';
-const GEN_AI_REQUEST_MODEL = 'gen_ai.request.model';
-const GEN_AI_RESPONSE_MODEL = 'gen_ai.response.model';
-const GEN_AI_USAGE_INPUT_TOKENS = 'gen_ai.usage.input_tokens';
-const GEN_AI_USAGE_OUTPUT_TOKENS = 'gen_ai.usage.output_tokens';
-const GEN_AI_CACHE_WRITE_INPUT_TOKENS = 'gen_ai.usage.cache_creation_input_tokens';
-const GEN_AI_CACHE_READ_INPUT_TOKENS = 'gen_ai.usage.cache_read_input_tokens';
-
-// TraceRoot-specific keys
-const TR_SDK_NAME = 'traceroot.sdk.name';
-const TR_SDK_VERSION = 'traceroot.sdk.version';
-const TR_METADATA_PREFIX = 'traceroot.metadata';
+const GEN_AI_ATTRIBUTES = {
+  SYSTEM: 'gen_ai.system',
+  REQUEST_MODEL: 'gen_ai.request.model',
+  RESPONSE_MODEL: 'gen_ai.response.model',
+  USAGE_INPUT_TOKENS: 'gen_ai.usage.input_tokens',
+  USAGE_OUTPUT_TOKENS: 'gen_ai.usage.output_tokens',
+  CACHE_WRITE_INPUT_TOKENS: 'gen_ai.usage.cache_creation_input_tokens',
+  CACHE_READ_INPUT_TOKENS: 'gen_ai.usage.cache_read_input_tokens',
+} as const;
 
 type TraceState = {
   activeSpanIds: Set<string>;
@@ -433,29 +437,29 @@ function buildTraceRootAttributes(
   const attrs: Attributes = {};
 
   // SDK identity (always present)
-  attrs[TR_SDK_NAME] = SDK_NAME;
-  attrs[TR_SDK_VERSION] = SDK_VERSION;
+  attrs[TR_ATTRIBUTES.SDK_NAME] = SDK_NAME;
+  attrs[TR_ATTRIBUTES.SDK_VERSION] = SDK_VERSION;
 
   // Span kind → openinference.span.kind (drives icons in TraceRoot UI)
-  attrs[OI_SPAN_KIND] = mapToOISpanKind(span.type);
+  attrs[OI_ATTRIBUTES.SPAN_KIND] = mapToOISpanKind(span.type);
 
   // Input / output
   if (span.input !== undefined) {
-    attrs[OI_INPUT_VALUE] = serialize(extractInput(span));
+    attrs[OI_ATTRIBUTES.INPUT_VALUE] = serialize(extractInput(span));
   }
   if (span.output !== undefined) {
-    attrs[OI_OUTPUT_VALUE] = serialize(span.output);
+    attrs[OI_ATTRIBUTES.OUTPUT_VALUE] = serialize(span.output);
   }
 
   // Session / user identity
   const sessionId = span.metadata?.sessionId;
   if (typeof sessionId === 'string' && sessionId) {
-    attrs[OI_SESSION_ID] = sessionId;
+    attrs[OI_ATTRIBUTES.SESSION_ID] = sessionId;
   }
 
   const userId = span.metadata?.userId;
   if (typeof userId === 'string' && userId) {
-    attrs[OI_USER_ID] = userId;
+    attrs[OI_ATTRIBUTES.USER_ID] = userId;
   }
 
   // Remaining metadata as traceroot.metadata.* (excludes sessionId/userId)
@@ -463,23 +467,25 @@ function buildTraceRootAttributes(
     for (const [key, value] of Object.entries(span.metadata)) {
       if (key === 'sessionId' || key === 'userId' || value == null) continue;
       const v = toAttributeValue(value);
-      if (v !== undefined) attrs[`${TR_METADATA_PREFIX}.${key}`] = v;
+      if (v !== undefined) attrs[`${TR_ATTRIBUTES.METADATA_PREFIX}.${key}`] = v;
     }
   }
 
   // LLM-specific attributes (only for MODEL_GENERATION spans)
   if (span.type === SpanType.MODEL_GENERATION) {
     const modelAttrs = (span.attributes ?? {}) as ModelGenerationAttributes;
-    if (modelAttrs.provider) attrs[GEN_AI_SYSTEM] = normalizeProvider(modelAttrs.provider);
-    if (modelAttrs.model) attrs[GEN_AI_REQUEST_MODEL] = modelAttrs.model;
-    if (modelAttrs.responseModel) attrs[GEN_AI_RESPONSE_MODEL] = modelAttrs.responseModel;
+    if (modelAttrs.provider)
+      attrs[GEN_AI_ATTRIBUTES.SYSTEM] = normalizeProvider(modelAttrs.provider);
+    if (modelAttrs.model) attrs[GEN_AI_ATTRIBUTES.REQUEST_MODEL] = modelAttrs.model;
+    if (modelAttrs.responseModel)
+      attrs[GEN_AI_ATTRIBUTES.RESPONSE_MODEL] = modelAttrs.responseModel;
     Object.assign(attrs, buildUsageAttributes(modelAttrs.usage));
   }
 
   // Live tracing — span ancestry for real-time UI streaming.
   // Mirrors the Map-based path propagation in TraceRootSpanProcessor (PR #71).
-  if (namePath !== undefined) attrs[TR_SPAN_PATH] = namePath;
-  if (idsPath !== undefined) attrs[TR_SPAN_IDS_PATH] = idsPath;
+  if (namePath !== undefined) attrs[TR_ATTRIBUTES.SPAN_PATH] = namePath;
+  if (idsPath !== undefined) attrs[TR_ATTRIBUTES.SPAN_IDS_PATH] = idsPath;
 
   return attrs;
 }
@@ -522,13 +528,15 @@ function extractInput(span: AnyExportedSpan): unknown {
 function buildUsageAttributes(usage?: UsageStats): Attributes {
   if (!usage) return {};
   const out: Attributes = {};
-  if (usage.inputTokens !== undefined) out[GEN_AI_USAGE_INPUT_TOKENS] = usage.inputTokens;
-  if (usage.outputTokens !== undefined) out[GEN_AI_USAGE_OUTPUT_TOKENS] = usage.outputTokens;
+  if (usage.inputTokens !== undefined)
+    out[GEN_AI_ATTRIBUTES.USAGE_INPUT_TOKENS] = usage.inputTokens;
+  if (usage.outputTokens !== undefined)
+    out[GEN_AI_ATTRIBUTES.USAGE_OUTPUT_TOKENS] = usage.outputTokens;
   if (usage.inputDetails?.cacheWrite !== undefined) {
-    out[GEN_AI_CACHE_WRITE_INPUT_TOKENS] = usage.inputDetails.cacheWrite;
+    out[GEN_AI_ATTRIBUTES.CACHE_WRITE_INPUT_TOKENS] = usage.inputDetails.cacheWrite;
   }
   if (usage.inputDetails?.cacheRead !== undefined) {
-    out[GEN_AI_CACHE_READ_INPUT_TOKENS] = usage.inputDetails.cacheRead;
+    out[GEN_AI_ATTRIBUTES.CACHE_READ_INPUT_TOKENS] = usage.inputDetails.cacheRead;
   }
   return out;
 }

--- a/packages/traceroot/src/constants.ts
+++ b/packages/traceroot/src/constants.ts
@@ -6,16 +6,26 @@ export const DEFAULT_FLUSH_AT = 100; // BatchSpanProcessor maxExportBatchSize
 export const DEFAULT_TIMEOUT_SEC = 30; // seconds → BatchSpanProcessor exportTimeoutMillis (×1000)
 
 // Span-level
+export const OI_SPAN_KIND = 'openinference.span.kind';
+export const OI_INPUT_VALUE = 'input.value';
+export const OI_OUTPUT_VALUE = 'output.value';
 export const SPAN_METADATA = 'traceroot.span.metadata';
 export const SPAN_TAGS = 'traceroot.span.tags';
+export const AGENT_NAME = 'agent.name';
+export const TOOL_NAME = 'tool.name';
 
 // LLM-specific
+export const OI_LLM_MODEL_NAME = 'llm.model_name';
+export const OI_LLM_TOKEN_COUNT_PROMPT = 'llm.token_count.prompt';
+export const OI_LLM_TOKEN_COUNT_COMPLETION = 'llm.token_count.completion';
 export const LLM_MODEL = 'traceroot.llm.model';
 export const LLM_MODEL_PARAMETERS = 'traceroot.llm.model_parameters';
 export const LLM_USAGE = 'traceroot.llm.usage';
 export const LLM_PROMPT = 'traceroot.llm.prompt';
 
 // Trace-level
+export const OI_TRACE_USER_ID = 'user.id';
+export const OI_TRACE_SESSION_ID = 'session.id';
 export const TRACE_METADATA = 'traceroot.trace.metadata';
 export const TRACE_TAGS = 'traceroot.trace.tags';
 
@@ -30,8 +40,8 @@ export const TRACE_TAGS = 'traceroot.trace.tags';
 export const SpanAttributes = {
   // Span-level
   SPAN_TYPE: 'traceroot.span.type',
-  SPAN_INPUT: 'input.value', // OpenInference
-  SPAN_OUTPUT: 'output.value', // OpenInference
+  SPAN_INPUT: OI_INPUT_VALUE, // OpenInference
+  SPAN_OUTPUT: OI_OUTPUT_VALUE, // OpenInference
   SPAN_METADATA,
   SPAN_TAGS,
 
@@ -42,8 +52,8 @@ export const SpanAttributes = {
   LLM_PROMPT,
 
   // Trace-level
-  TRACE_USER_ID: 'user.id', // OpenInference
-  TRACE_SESSION_ID: 'session.id', // OpenInference
+  TRACE_USER_ID: OI_TRACE_USER_ID, // OpenInference
+  TRACE_SESSION_ID: OI_TRACE_SESSION_ID, // OpenInference
   TRACE_METADATA,
   TRACE_TAGS,
 

--- a/packages/traceroot/src/openai-agents.ts
+++ b/packages/traceroot/src/openai-agents.ts
@@ -1,6 +1,17 @@
 import { context, SpanStatusCode, trace } from '@opentelemetry/api';
 import type { Context, Span as OTelSpan } from '@opentelemetry/api';
 import type { SpanData } from '@openai/agents';
+import {
+  AGENT_NAME,
+  OI_INPUT_VALUE,
+  OI_LLM_MODEL_NAME,
+  OI_LLM_TOKEN_COUNT_COMPLETION,
+  OI_LLM_TOKEN_COUNT_PROMPT,
+  OI_OUTPUT_VALUE,
+  OI_SPAN_KIND,
+  SPAN_METADATA,
+  TOOL_NAME,
+} from './constants';
 
 // Structural mirrors of the public read-surface of @openai/agents `Span` and `Trace`.
 // We can't use the SDK class types directly because they hold their state in
@@ -67,64 +78,63 @@ export function getSpanName(data: SpanData): string {
 
 export function getSpanAttributes(data: SpanData): Record<string, string | number | boolean> {
   const attrs: Record<string, string | number | boolean> = {
-    'openinference.span.kind': SPAN_KIND[data.type],
+    [OI_SPAN_KIND]: SPAN_KIND[data.type],
   };
   switch (data.type) {
     case 'agent':
-      attrs['agent.name'] = data.name;
-      if (data.tools?.length) attrs['input.value'] = JSON.stringify({ tools: data.tools });
+      attrs[AGENT_NAME] = data.name;
+      if (data.tools?.length) attrs[OI_INPUT_VALUE] = JSON.stringify({ tools: data.tools });
       break;
     case 'function':
-      attrs['tool.name'] = data.name;
-      if (data.input != null) attrs['input.value'] = data.input;
-      if (data.output != null) attrs['output.value'] = data.output;
+      attrs[TOOL_NAME] = data.name;
+      if (data.input != null) attrs[OI_INPUT_VALUE] = data.input;
+      if (data.output != null) attrs[OI_OUTPUT_VALUE] = data.output;
       break;
     case 'generation':
-      if (data.model) attrs['llm.model_name'] = data.model;
-      if (data.input != null) attrs['input.value'] = JSON.stringify(data.input);
-      if (data.output != null) attrs['output.value'] = JSON.stringify(data.output);
+      if (data.model) attrs[OI_LLM_MODEL_NAME] = data.model;
+      if (data.input != null) attrs[OI_INPUT_VALUE] = JSON.stringify(data.input);
+      if (data.output != null) attrs[OI_OUTPUT_VALUE] = JSON.stringify(data.output);
       if (data.usage?.input_tokens != null)
-        attrs['llm.token_count.prompt'] = data.usage.input_tokens;
+        attrs[OI_LLM_TOKEN_COUNT_PROMPT] = data.usage.input_tokens;
       if (data.usage?.output_tokens != null)
-        attrs['llm.token_count.completion'] = data.usage.output_tokens;
+        attrs[OI_LLM_TOKEN_COUNT_COMPLETION] = data.usage.output_tokens;
       break;
     case 'response': {
       const r = data._response as Record<string, unknown> | undefined;
-      if (r?.model) attrs['llm.model_name'] = r.model as string;
+      if (r?.model) attrs[OI_LLM_MODEL_NAME] = r.model as string;
       const usage = r?.usage as Record<string, number> | undefined;
-      if (usage?.input_tokens != null) attrs['llm.token_count.prompt'] = usage.input_tokens;
-      if (usage?.output_tokens != null) attrs['llm.token_count.completion'] = usage.output_tokens;
+      if (usage?.input_tokens != null) attrs[OI_LLM_TOKEN_COUNT_PROMPT] = usage.input_tokens;
+      if (usage?.output_tokens != null) attrs[OI_LLM_TOKEN_COUNT_COMPLETION] = usage.output_tokens;
       if (data._input != null)
-        attrs['input.value'] =
+        attrs[OI_INPUT_VALUE] =
           typeof data._input === 'string' ? data._input : JSON.stringify(data._input);
-      if (r?.output != null) attrs['output.value'] = JSON.stringify(r.output);
+      if (r?.output != null) attrs[OI_OUTPUT_VALUE] = JSON.stringify(r.output);
       break;
     }
     case 'handoff':
-      if (data.from_agent) attrs['agent.name'] = data.from_agent;
-      if (data.to_agent)
-        attrs['traceroot.span.metadata'] = JSON.stringify({ to_agent: data.to_agent });
+      if (data.from_agent) attrs[AGENT_NAME] = data.from_agent;
+      if (data.to_agent) attrs[SPAN_METADATA] = JSON.stringify({ to_agent: data.to_agent });
       break;
     case 'custom':
-      if (data.data) attrs['input.value'] = JSON.stringify(data.data);
+      if (data.data) attrs[OI_INPUT_VALUE] = JSON.stringify(data.data);
       break;
     case 'guardrail':
-      attrs['traceroot.span.metadata'] = JSON.stringify({ triggered: data.triggered });
+      attrs[SPAN_METADATA] = JSON.stringify({ triggered: data.triggered });
       break;
     case 'transcription':
-      if (data.model) attrs['llm.model_name'] = data.model;
-      if (data.output) attrs['output.value'] = data.output;
+      if (data.model) attrs[OI_LLM_MODEL_NAME] = data.model;
+      if (data.output) attrs[OI_OUTPUT_VALUE] = data.output;
       break;
     case 'speech':
-      if (data.model) attrs['llm.model_name'] = data.model;
-      if (data.input) attrs['input.value'] = data.input;
+      if (data.model) attrs[OI_LLM_MODEL_NAME] = data.model;
+      if (data.input) attrs[OI_INPUT_VALUE] = data.input;
       break;
     case 'speech_group':
-      if (data.input) attrs['input.value'] = data.input;
+      if (data.input) attrs[OI_INPUT_VALUE] = data.input;
       break;
     case 'mcp_tools':
-      if (data.server) attrs['tool.name'] = data.server;
-      if (data.result) attrs['output.value'] = JSON.stringify(data.result);
+      if (data.server) attrs[TOOL_NAME] = data.server;
+      if (data.result) attrs[OI_OUTPUT_VALUE] = JSON.stringify(data.result);
       break;
   }
   return attrs;
@@ -137,7 +147,7 @@ export class OpenAIAgentsProcessor {
 
   async onTraceStart(t: OpenAIAgentsTrace): Promise<void> {
     const span = this.tracer.startSpan(t.name ?? 'Agent workflow', {
-      attributes: { 'openinference.span.kind': 'CHAIN' },
+      attributes: { [OI_SPAN_KIND]: 'CHAIN' },
     });
     this.spanMap.set(t.traceId, span);
     this.ctxMap.set(t.traceId, trace.setSpan(context.active(), span));


### PR DESCRIPTION
## Summary
- add shared OpenInference-style attribute constants in the TraceRoot package
- use those constants in OpenAI Agents span attribute construction
- group Mastra exporter TraceRoot/OpenInference/gen_ai attribute keys into local constant objects

## Testing
- pnpm --filter @traceroot-ai/traceroot test -- span-attributes openai-agents
- pnpm --filter @traceroot-ai/traceroot build
- pnpm --filter @traceroot-ai/mastra test
- pnpm --filter @traceroot-ai/mastra build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized telemetry attribute constants across TraceRoot and Mastra to align with OpenInference and gen_ai conventions. This removes string literals, reduces typos, and keeps span attributes consistent.

- **Refactors**
  - Added shared OpenInference-style constants in `@traceroot-ai/traceroot` for span kind, input/output, LLM fields, agent/tool names, and user/session.
  - Updated OpenAI Agents attribute construction to use these constants and keep JSON serialization for inputs/outputs and token counts.
  - Grouped Mastra exporter keys into local `TR_ATTRIBUTES`, `OI_ATTRIBUTES`, and `GEN_AI_ATTRIBUTES` and used them for SDK identity, metadata prefix, span paths, models, and usage.

<sup>Written for commit ec61fc1655b2b2b43261b2e4545996608c049659. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot-ts/pull/96?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

