### PR TITLE
feat: add Claude Agent SDK instrumentation

### DIFF
--- a/packages/traceroot/src/claude-agent-sdk.ts
+++ b/packages/traceroot/src/claude-agent-sdk.ts
@@ -1,0 +1,868 @@
+import { context, SpanStatusCode, trace } from '@opentelemetry/api';
+import type { Context, Span as OTelSpan } from '@opentelemetry/api';
+import {
+  OI_INPUT_VALUE,
+  OI_LLM_MODEL_NAME,
+  OI_LLM_TOKEN_COUNT_COMPLETION,
+  OI_LLM_TOKEN_COUNT_PROMPT,
+  OI_OUTPUT_VALUE,
+  OI_SPAN_KIND,
+  OI_TRACE_SESSION_ID,
+  TOOL_NAME,
+} from './constants';
+
+type ClaudeAgentSDKMessage = {
+  type?: string;
+  subtype?: string;
+  message?: {
+    id?: string;
+    role?: string;
+    content?: unknown;
+    model?: string;
+    usage?: ClaudeUsage;
+  };
+  parent_tool_use_id?: string | null;
+  result?: string;
+  usage?: ClaudeUsage;
+  num_turns?: number;
+  session_id?: string;
+  total_cost_usd?: number;
+  [key: string]: unknown;
+};
+
+type ClaudeUsage = {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
+};
+
+type ClaudeAgentSDKQueryParams = {
+  prompt?: string | AsyncIterable<ClaudeAgentSDKMessage>;
+  options?: ClaudeAgentSDKQueryOptions;
+};
+
+type ClaudeAgentSDKQueryOptions = {
+  model?: string;
+  maxTurns?: number;
+  allowedTools?: string[];
+  disallowedTools?: string[];
+  permissionMode?: string;
+  hooks?: Record<string, HookMatcher[]>;
+  [key: string]: unknown;
+};
+
+type HookMatcher = {
+  matcher?: string;
+  hooks: HookCallback[];
+};
+
+type HookCallback = (
+  input: Record<string, unknown>,
+  toolUseId?: string,
+  options?: { signal: AbortSignal },
+) => Promise<Record<string, unknown>>;
+
+type ClaudeAgentSDKModule = {
+  query?: (params: ClaudeAgentSDKQueryParams) => AsyncIterable<ClaudeAgentSDKMessage>;
+  [key: string]: unknown;
+};
+
+type ToolState = {
+  ctx: Context;
+  hasSubagent: boolean;
+  name: string;
+  span: OTelSpan;
+  toolUseId: string;
+};
+
+type SubagentState = {
+  agentId?: string;
+  ctx: Context;
+  ended?: boolean;
+  span: OTelSpan;
+  toolUseId: string;
+};
+
+type ActiveLLMSpanState = {
+  ctx: Context;
+  span: OTelSpan;
+};
+
+type QueryState = {
+  accumulatedOutputTokens: number;
+  activeLLMSpansByParent: Map<string, ActiveLLMSpanState>;
+  agentIdToToolUseId: Map<string, string>;
+  currentMessageStartTime: Date;
+  currentMessageId?: string;
+  ctx: Context;
+  params: ClaudeAgentSDKQueryParams;
+  pendingAssistantMessages: ClaudeAgentSDKMessage[];
+  querySpan: OTelSpan;
+  rawSubagentToolUseIdToToolUseId: Map<string, string>;
+  subagents: Map<string, SubagentState>;
+  toolUseToParent: Map<string, string | null>;
+  tools: Map<string, ToolState>;
+  tracer: ReturnType<typeof trace.getTracer>;
+};
+
+// Use the global symbol registry so duplicated package copies still avoid double wrapping.
+const WRAPPED = Symbol.for('traceroot.claude_agent_sdk.wrapped');
+const ROOT_LLM_PARENT_KEY = '__root__';
+const LLM_SPAN_NAME = 'anthropic.messages.create';
+const QUERY_SPAN_NAME = 'ClaudeAgent.query';
+
+const OI_SPAN_KIND_VALUE = {
+  AGENT: 'AGENT',
+  LLM: 'LLM',
+  TOOL: 'TOOL',
+} as const;
+
+const LLM_TOKEN_ATTRIBUTES = {
+  TOTAL: 'llm.token_count.total',
+  CACHE_READ: 'llm.token_count.prompt_details.cache_read',
+  CACHE_CREATION: 'llm.token_count.prompt_details.cache_creation',
+} as const;
+
+const GEN_AI_ATTRIBUTES = {
+  RESPONSE_MODEL: 'gen_ai.response.model',
+  TOOL_CALL_ID: 'gen_ai.tool.call.id',
+  TOOL_NAME: 'gen_ai.tool.name',
+} as const;
+
+const CLAUDE_AGENT_ATTRIBUTES = {
+  AGENT_ID: 'claude_agent_sdk.agent_id',
+  AGENT_TYPE: 'claude_agent_sdk.agent_type',
+  CWD: 'claude_agent_sdk.cwd',
+  DURATION_MS: 'claude_agent_sdk.duration_ms',
+  MODEL: 'claude_agent_sdk.model',
+  NUM_TURNS: 'claude_agent_sdk.num_turns',
+  TOOL_USE_COUNT: 'claude_agent_sdk.tool_use_count',
+  TOOL_USE_ID: 'claude_agent_sdk.tool_use_id',
+  TOTAL_COST_USD: 'claude_agent_sdk.total_cost_usd',
+} as const;
+
+function tryStringify(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function setJsonAttribute(span: OTelSpan, key: string, value: unknown): void {
+  const serialized = tryStringify(value);
+  if (serialized !== undefined) span.setAttribute(key, serialized);
+}
+
+function getToolUseId(input: Record<string, unknown>, toolUseId?: string): string | undefined {
+  return toolUseId ?? (typeof input.tool_use_id === 'string' ? input.tool_use_id : undefined);
+}
+
+function getString(input: Record<string, unknown>, key: string): string | undefined {
+  const value = input[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function getNumber(input: Record<string, unknown>, key: string): number | undefined {
+  const value = input[key];
+  return typeof value === 'number' ? value : undefined;
+}
+
+function getUsage(message: ClaudeAgentSDKMessage): ClaudeUsage | undefined {
+  return message.message?.usage ?? message.usage;
+}
+
+function setUsageAttributes(span: OTelSpan, usage: ClaudeUsage | undefined): void {
+  if (!usage) return;
+
+  const cacheRead = usage.cache_read_input_tokens ?? 0;
+  const cacheCreation = usage.cache_creation_input_tokens ?? 0;
+  const prompt = (usage.input_tokens ?? 0) + cacheRead + cacheCreation;
+  const completion = usage.output_tokens ?? 0;
+
+  if (prompt > 0) span.setAttribute(OI_LLM_TOKEN_COUNT_PROMPT, prompt);
+  if (completion > 0) span.setAttribute(OI_LLM_TOKEN_COUNT_COMPLETION, completion);
+  if (prompt > 0 || completion > 0) {
+    span.setAttribute(LLM_TOKEN_ATTRIBUTES.TOTAL, prompt + completion);
+  }
+  if (cacheRead > 0) {
+    span.setAttribute(LLM_TOKEN_ATTRIBUTES.CACHE_READ, cacheRead);
+  }
+  if (cacheCreation > 0) {
+    span.setAttribute(LLM_TOKEN_ATTRIBUTES.CACHE_CREATION, cacheCreation);
+  }
+}
+
+function setCommonModel(span: OTelSpan, model: string | undefined): void {
+  if (!model) return;
+  span.setAttribute(OI_LLM_MODEL_NAME, model);
+  span.setAttribute(GEN_AI_ATTRIBUTES.RESPONSE_MODEL, model);
+}
+
+function getMessageModel(
+  message: ClaudeAgentSDKMessage,
+  options: ClaudeAgentSDKQueryOptions | undefined,
+): string | undefined {
+  return message.message?.model ?? options?.model;
+}
+
+function llmParentKey(parentToolUseId: string | null | undefined): string {
+  return parentToolUseId ?? ROOT_LLM_PARENT_KEY;
+}
+
+function isTaskSiblingTool(toolName: string): boolean {
+  return toolName === 'Agent' || toolName === 'Task' || toolName === 'Bash';
+}
+
+function getParentToolUseIdForTool(
+  state: QueryState,
+  toolUseId: string,
+  input: Record<string, unknown>,
+): string | null {
+  if (state.toolUseToParent.has(toolUseId)) {
+    return state.toolUseToParent.get(toolUseId) ?? null;
+  }
+
+  const agentId = getString(input, 'agent_id');
+  if (!agentId) return null;
+  return state.agentIdToToolUseId.get(agentId) ?? null;
+}
+
+function getToolParentContext(state: QueryState, input: Record<string, unknown>): Context {
+  const agentId = getString(input, 'agent_id');
+  const subagentToolUseId = agentId ? state.agentIdToToolUseId.get(agentId) : undefined;
+  const subagent = subagentToolUseId ? state.subagents.get(subagentToolUseId) : undefined;
+  return subagent?.ctx ?? state.ctx;
+}
+
+function getTaskParentContext(
+  state: QueryState,
+  parentToolUseId: string | null | undefined,
+): Context {
+  if (parentToolUseId) {
+    return state.subagents.get(parentToolUseId)?.ctx ?? state.ctx;
+  }
+  return state.ctx;
+}
+
+function ensureActiveLLMSpan(
+  state: QueryState,
+  parentToolUseId: string | null | undefined,
+  startTime: Date,
+): ActiveLLMSpanState {
+  const parentKey = llmParentKey(parentToolUseId);
+  const existing = state.activeLLMSpansByParent.get(parentKey);
+  if (existing) return existing;
+
+  const parentCtx = getTaskParentContext(state, parentToolUseId);
+  const span = state.tracer.startSpan(
+    LLM_SPAN_NAME,
+    {
+      attributes: {
+        [OI_SPAN_KIND]: OI_SPAN_KIND_VALUE.LLM,
+      },
+      startTime,
+    },
+    parentCtx,
+  );
+  const llm = { ctx: trace.setSpan(parentCtx, span), span };
+  state.activeLLMSpansByParent.set(parentKey, llm);
+  return llm;
+}
+
+function resolveToolParentContext(
+  state: QueryState,
+  toolUseId: string,
+  toolName: string,
+  input: Record<string, unknown>,
+): Context {
+  const parentToolUseId = getParentToolUseIdForTool(state, toolUseId, input);
+  if (isTaskSiblingTool(toolName)) {
+    return getTaskParentContext(state, parentToolUseId);
+  }
+
+  const parentKey = llmParentKey(parentToolUseId);
+  const activeLLM = state.activeLLMSpansByParent.get(parentKey);
+  // Claude hook events can arrive before the assistant message that creates the
+  // LLM turn span. In that case, keep the tool under the task/subagent context.
+  return activeLLM?.ctx ?? getToolParentContext(state, input);
+}
+
+function findActiveAgentToolUseId(state: QueryState): string | undefined {
+  for (const tool of state.tools.values()) {
+    if (tool.name === 'Agent' && !tool.hasSubagent) return tool.toolUseId;
+  }
+  return undefined;
+}
+
+function canonicalSubagentToolUseId(
+  state: QueryState,
+  rawToolUseId: string,
+  input?: Record<string, unknown>,
+): string {
+  const existing = state.rawSubagentToolUseIdToToolUseId.get(rawToolUseId);
+  if (existing) return existing;
+
+  if (state.tools.has(rawToolUseId)) {
+    state.rawSubagentToolUseIdToToolUseId.set(rawToolUseId, rawToolUseId);
+    return rawToolUseId;
+  }
+
+  const agentId = input ? getString(input, 'agent_id') : undefined;
+  const agentToolUseId = agentId ? state.agentIdToToolUseId.get(agentId) : undefined;
+  if (agentToolUseId) {
+    state.rawSubagentToolUseIdToToolUseId.set(rawToolUseId, agentToolUseId);
+    return agentToolUseId;
+  }
+
+  const activeAgentToolUseId = findActiveAgentToolUseId(state);
+  if (activeAgentToolUseId) {
+    state.rawSubagentToolUseIdToToolUseId.set(rawToolUseId, activeAgentToolUseId);
+    return activeAgentToolUseId;
+  }
+
+  state.rawSubagentToolUseIdToToolUseId.set(rawToolUseId, rawToolUseId);
+  return rawToolUseId;
+}
+
+function ensureSubagent(
+  state: QueryState,
+  toolUseId: string,
+  input?: Record<string, unknown>,
+): SubagentState {
+  const existing = state.subagents.get(toolUseId);
+  if (existing) return existing;
+
+  const toolState = state.tools.get(toolUseId);
+  if (toolState) toolState.hasSubagent = true;
+  const parentCtx = toolState?.ctx ?? state.ctx;
+  const span = state.tracer.startSpan(
+    'Subagent',
+    {
+      attributes: {
+        [OI_SPAN_KIND]: OI_SPAN_KIND_VALUE.AGENT,
+        ...(input && getString(input, 'agent_type')
+          ? { [CLAUDE_AGENT_ATTRIBUTES.AGENT_TYPE]: getString(input, 'agent_type')! }
+          : {}),
+        [CLAUDE_AGENT_ATTRIBUTES.TOOL_USE_ID]: toolUseId,
+      },
+    },
+    parentCtx,
+  );
+  const stateEntry = {
+    agentId: input ? getString(input, 'agent_id') : undefined,
+    ctx: trace.setSpan(parentCtx, span),
+    span,
+    toolUseId,
+  };
+  state.subagents.set(toolUseId, stateEntry);
+  if (stateEntry.agentId) state.agentIdToToolUseId.set(stateEntry.agentId, toolUseId);
+  return stateEntry;
+}
+
+function cleanupToolUseMappings(state: QueryState, rawToolUseId: string, toolUseId: string): void {
+  state.toolUseToParent.delete(rawToolUseId);
+  state.toolUseToParent.delete(toolUseId);
+  state.rawSubagentToolUseIdToToolUseId.delete(rawToolUseId);
+}
+
+function cleanupSubagentMappings(state: QueryState, subagent: SubagentState): void {
+  if (subagent.agentId) state.agentIdToToolUseId.delete(subagent.agentId);
+}
+
+function createTracingHooks(state: QueryState): Record<string, HookMatcher[]> {
+  const preToolUse: HookCallback = async (input, toolUseIdArg) => {
+    if (input.hook_event_name !== 'PreToolUse') return {};
+    const now = new Date();
+    const toolUseId = getToolUseId(input, toolUseIdArg);
+    const toolName = getString(input, 'tool_name');
+    if (!toolUseId || !toolName) return {};
+
+    const startTime = now;
+    const parentCtx = resolveToolParentContext(state, toolUseId, toolName, input);
+    const span = state.tracer.startSpan(
+      toolName,
+      {
+        attributes: {
+          [OI_SPAN_KIND]: OI_SPAN_KIND_VALUE.TOOL,
+          [TOOL_NAME]: toolName,
+          [GEN_AI_ATTRIBUTES.TOOL_NAME]: toolName,
+          [GEN_AI_ATTRIBUTES.TOOL_CALL_ID]: toolUseId,
+          ...(getString(input, 'cwd')
+            ? { [CLAUDE_AGENT_ATTRIBUTES.CWD]: getString(input, 'cwd')! }
+            : {}),
+          ...(getString(input, 'session_id')
+            ? { [OI_TRACE_SESSION_ID]: getString(input, 'session_id')! }
+            : {}),
+        },
+        startTime,
+      },
+      parentCtx,
+    );
+    setJsonAttribute(span, OI_INPUT_VALUE, input.tool_input);
+    state.tools.set(toolUseId, {
+      ctx: trace.setSpan(parentCtx, span),
+      hasSubagent: false,
+      name: toolName,
+      span,
+      toolUseId,
+    });
+    return {};
+  };
+
+  const postToolUse: HookCallback = async (input, toolUseIdArg) => {
+    if (input.hook_event_name !== 'PostToolUse') return {};
+    const now = new Date();
+    const rawToolUseId = getToolUseId(input, toolUseIdArg);
+    if (!rawToolUseId) return {};
+    const toolUseId = state.tools.has(rawToolUseId)
+      ? rawToolUseId
+      : canonicalSubagentToolUseId(state, rawToolUseId, input);
+
+    const tool = state.tools.get(toolUseId);
+    if (tool) {
+      setJsonAttribute(tool.span, OI_OUTPUT_VALUE, input.tool_response);
+      tool.span.setStatus({ code: SpanStatusCode.OK });
+      tool.span.end(now);
+      state.tools.delete(toolUseId);
+      cleanupToolUseMappings(state, rawToolUseId, toolUseId);
+    }
+
+    const subagent = state.subagents.get(toolUseId);
+    const response = input.tool_response;
+    if (subagent && !subagent.ended && response && typeof response === 'object') {
+      const record = response as Record<string, unknown>;
+      const agentType = getString(record, 'agentType');
+      if (agentType) subagent.span.setAttribute(CLAUDE_AGENT_ATTRIBUTES.AGENT_TYPE, agentType);
+      const agentId = getString(record, 'agentId');
+      if (agentId) subagent.span.setAttribute(CLAUDE_AGENT_ATTRIBUTES.AGENT_ID, agentId);
+      const durationMs = getNumber(record, 'totalDurationMs');
+      if (durationMs !== undefined)
+        subagent.span.setAttribute(CLAUDE_AGENT_ATTRIBUTES.DURATION_MS, durationMs);
+      const toolUseCount = getNumber(record, 'totalToolUseCount');
+      if (toolUseCount !== undefined) {
+        subagent.span.setAttribute(CLAUDE_AGENT_ATTRIBUTES.TOOL_USE_COUNT, toolUseCount);
+      }
+      setJsonAttribute(subagent.span, OI_OUTPUT_VALUE, record.content);
+      subagent.span.setStatus({ code: SpanStatusCode.OK });
+      subagent.span.end(now);
+      subagent.ended = true;
+      cleanupSubagentMappings(state, subagent);
+    }
+
+    return {};
+  };
+
+  const postToolUseFailure: HookCallback = async (input, toolUseIdArg) => {
+    if (input.hook_event_name !== 'PostToolUseFailure') return {};
+    const now = new Date();
+    const rawToolUseId = getToolUseId(input, toolUseIdArg);
+    if (!rawToolUseId) return {};
+    const toolUseId = state.tools.has(rawToolUseId)
+      ? rawToolUseId
+      : canonicalSubagentToolUseId(state, rawToolUseId, input);
+    const error = getString(input, 'error') ?? 'Tool failed';
+
+    const tool = state.tools.get(toolUseId);
+    if (tool) {
+      tool.span.setStatus({ code: SpanStatusCode.ERROR, message: error });
+      tool.span.recordException(new Error(error));
+      tool.span.end(now);
+      state.tools.delete(toolUseId);
+      cleanupToolUseMappings(state, rawToolUseId, toolUseId);
+    }
+
+    const subagent = state.subagents.get(toolUseId);
+    if (subagent && !subagent.ended) {
+      subagent.span.setStatus({ code: SpanStatusCode.ERROR, message: error });
+      subagent.span.recordException(new Error(error));
+      subagent.span.end(now);
+      subagent.ended = true;
+      cleanupSubagentMappings(state, subagent);
+    }
+    return {};
+  };
+
+  const subagentStart: HookCallback = async (input, toolUseIdArg) => {
+    if (input.hook_event_name !== 'SubagentStart') return {};
+    const rawToolUseId = getToolUseId(input, toolUseIdArg);
+    if (!rawToolUseId) return {};
+    const toolUseId = canonicalSubagentToolUseId(state, rawToolUseId, input);
+    const subagent = ensureSubagent(state, toolUseId, input);
+    const agentId = getString(input, 'agent_id');
+    if (agentId) {
+      subagent.agentId = agentId;
+      state.agentIdToToolUseId.set(agentId, toolUseId);
+      subagent.span.setAttribute(CLAUDE_AGENT_ATTRIBUTES.AGENT_ID, agentId);
+    }
+    const agentType = getString(input, 'agent_type');
+    if (agentType) subagent.span.setAttribute(CLAUDE_AGENT_ATTRIBUTES.AGENT_TYPE, agentType);
+    return {};
+  };
+
+  const subagentStop: HookCallback = async (input, toolUseIdArg) => {
+    if (input.hook_event_name !== 'SubagentStop') return {};
+    const now = new Date();
+    const rawToolUseId = getToolUseId(input, toolUseIdArg);
+    if (!rawToolUseId) return {};
+    const toolUseId = canonicalSubagentToolUseId(state, rawToolUseId, input);
+    const subagent = state.subagents.get(toolUseId);
+    if (!subagent || subagent.ended) return {};
+    const output = input.last_assistant_message;
+    if (output !== undefined) setJsonAttribute(subagent.span, OI_OUTPUT_VALUE, output);
+    subagent.span.setStatus({ code: SpanStatusCode.OK });
+    subagent.span.end(now);
+    subagent.ended = true;
+    cleanupSubagentMappings(state, subagent);
+    return {};
+  };
+
+  return {
+    PostToolUse: [{ hooks: [postToolUse] }],
+    PostToolUseFailure: [{ hooks: [postToolUseFailure] }],
+    PreToolUse: [{ hooks: [preToolUse] }],
+    SubagentStart: [{ hooks: [subagentStart] }],
+    SubagentStop: [{ hooks: [subagentStop] }],
+  };
+}
+
+function mergeHooks(
+  options: ClaudeAgentSDKQueryOptions | undefined,
+  hooks: Record<string, HookMatcher[]>,
+): ClaudeAgentSDKQueryOptions {
+  const existing = options?.hooks ?? {};
+  const merged: Record<string, HookMatcher[]> = { ...existing };
+  for (const [event, matchers] of Object.entries(hooks)) {
+    merged[event] = [...(existing[event] ?? []), ...matchers];
+  }
+  return { ...(options ?? {}), hooks: merged };
+}
+
+function trackToolUseContext(state: QueryState, message: ClaudeAgentSDKMessage): void {
+  if (message.type !== 'assistant' || !Array.isArray(message.message?.content)) return;
+
+  const parentToolUseId = message.parent_tool_use_id ?? null;
+  for (const block of message.message.content) {
+    if (!block || typeof block !== 'object') continue;
+    const record = block as Record<string, unknown>;
+    if (record.type !== 'tool_use' || typeof record.id !== 'string') continue;
+    state.toolUseToParent.set(record.id, parentToolUseId);
+  }
+}
+
+function emitLLMSpan(state: QueryState, messages: ClaudeAgentSDKMessage[], endTime: Date): void {
+  if (messages.length === 0) return;
+  const firstMessage = messages[0];
+  const lastMessage = messages[messages.length - 1];
+  if (firstMessage.type !== 'assistant' || !lastMessage.message) return;
+
+  const parentToolUseId = firstMessage.parent_tool_use_id ?? null;
+  const parentKey = llmParentKey(parentToolUseId);
+  const activeLLM = ensureActiveLLMSpan(state, parentToolUseId, state.currentMessageStartTime);
+  const model = getMessageModel(lastMessage, state.params.options);
+  const span = activeLLM.span;
+  setCommonModel(span, model);
+  setUsageAttributes(span, getUsage(lastMessage));
+  if (!firstMessage.parent_tool_use_id) {
+    if (typeof state.params.prompt === 'string') {
+      setJsonAttribute(span, OI_INPUT_VALUE, [{ role: 'user', content: state.params.prompt }]);
+    }
+  }
+  const output = messages
+    .map((message) =>
+      message.message?.content !== undefined || message.message?.role !== undefined
+        ? {
+            role: message.message?.role ?? 'assistant',
+            content: message.message?.content,
+          }
+        : undefined,
+    )
+    .filter((message): message is { role: string; content: unknown } => message !== undefined);
+  if (output.length > 0) {
+    setJsonAttribute(span, OI_OUTPUT_VALUE, output);
+  }
+  span.setStatus({ code: SpanStatusCode.OK });
+  span.end(endTime);
+  state.activeLLMSpansByParent.delete(parentKey);
+  state.accumulatedOutputTokens += getUsage(lastMessage)?.output_tokens ?? 0;
+  state.currentMessageStartTime = endTime;
+}
+
+function flushPendingLLMSpan(state: QueryState, endTime = new Date()): void {
+  if (state.pendingAssistantMessages.length === 0) return;
+  emitLLMSpan(state, state.pendingAssistantMessages, endTime);
+  state.pendingAssistantMessages = [];
+}
+
+function shouldFlushBeforeAssistantMessage(
+  state: QueryState,
+  message: ClaudeAgentSDKMessage,
+): boolean {
+  const pending = state.pendingAssistantMessages;
+  if (pending.length === 0) return false;
+  const first = pending[0];
+  const nextMessageId = message.message?.id;
+  if (nextMessageId && nextMessageId !== state.currentMessageId) return true;
+  return (
+    first.parent_tool_use_id !== message.parent_tool_use_id ||
+    getMessageModel(first, state.params.options) !== getMessageModel(message, state.params.options)
+  );
+}
+
+function updateCurrentMessageId(state: QueryState, message: ClaudeAgentSDKMessage): void {
+  const messageId = message.message?.id;
+  if (messageId) state.currentMessageId = messageId;
+}
+
+function adjustPendingAssistantUsageFromResult(
+  state: QueryState,
+  resultMessage: ClaudeAgentSDKMessage,
+): void {
+  if (state.pendingAssistantMessages.length === 0) return;
+
+  const finalUsage = getUsage(resultMessage);
+  if (!finalUsage) return;
+  const finalOutputTokens = finalUsage?.output_tokens;
+  if (finalOutputTokens === undefined) return;
+
+  const lastMessage = state.pendingAssistantMessages[state.pendingAssistantMessages.length - 1];
+  const lastUsage = lastMessage?.message?.usage;
+  if (!lastUsage) return;
+
+  const remainingOutputTokens = finalOutputTokens - state.accumulatedOutputTokens;
+  if (remainingOutputTokens >= 0) {
+    lastUsage.output_tokens = remainingOutputTokens;
+  }
+
+  if (finalUsage.cache_read_input_tokens !== undefined) {
+    lastUsage.cache_read_input_tokens = finalUsage.cache_read_input_tokens;
+  }
+  if (finalUsage.cache_creation_input_tokens !== undefined) {
+    lastUsage.cache_creation_input_tokens = finalUsage.cache_creation_input_tokens;
+  }
+}
+
+function processMessage(
+  state: QueryState,
+  message: ClaudeAgentSDKMessage,
+  params: ClaudeAgentSDKQueryParams,
+): void {
+  trackToolUseContext(state, message);
+
+  if (message.type === 'system' && message.subtype === 'init') {
+    const model = typeof message.model === 'string' ? message.model : params.options?.model;
+    if (model) state.querySpan.setAttribute(CLAUDE_AGENT_ATTRIBUTES.MODEL, model);
+    if (typeof message.session_id === 'string') {
+      state.querySpan.setAttribute(OI_TRACE_SESSION_ID, message.session_id);
+    }
+    return;
+  }
+
+  if (message.type === 'assistant') {
+    const now = new Date();
+    const messageId = message.message?.id;
+    if (messageId && messageId !== state.currentMessageId) {
+      flushPendingLLMSpan(state, now);
+      state.currentMessageId = messageId;
+      state.currentMessageStartTime = now;
+    } else if (shouldFlushBeforeAssistantMessage(state, message)) {
+      flushPendingLLMSpan(state, now);
+      updateCurrentMessageId(state, message);
+    } else {
+      updateCurrentMessageId(state, message);
+    }
+    if (message.message?.usage) {
+      ensureActiveLLMSpan(state, message.parent_tool_use_id ?? null, state.currentMessageStartTime);
+    }
+    state.pendingAssistantMessages.push(message);
+    return;
+  }
+
+  if (message.type === 'result') {
+    const now = new Date();
+    adjustPendingAssistantUsageFromResult(state, message);
+    flushPendingLLMSpan(state, now);
+    if (typeof message.result === 'string') {
+      state.querySpan.setAttribute(OI_OUTPUT_VALUE, message.result);
+    }
+    if (typeof message.session_id === 'string') {
+      state.querySpan.setAttribute(OI_TRACE_SESSION_ID, message.session_id);
+    }
+    if (typeof message.num_turns === 'number') {
+      state.querySpan.setAttribute(CLAUDE_AGENT_ATTRIBUTES.NUM_TURNS, message.num_turns);
+    }
+    if (typeof message.total_cost_usd === 'number') {
+      state.querySpan.setAttribute(CLAUDE_AGENT_ATTRIBUTES.TOTAL_COST_USD, message.total_cost_usd);
+    }
+  }
+}
+
+function endInFlight(state: QueryState, status?: { code: SpanStatusCode; message?: string }): void {
+  const now = new Date();
+  flushPendingLLMSpan(state, now);
+
+  for (const tool of state.tools.values()) {
+    if (status) tool.span.setStatus(status);
+    tool.span.end(now);
+  }
+  state.tools.clear();
+
+  for (const subagent of state.subagents.values()) {
+    if (!subagent.ended) {
+      if (status) subagent.span.setStatus(status);
+      subagent.span.end(now);
+      subagent.ended = true;
+    }
+  }
+  state.subagents.clear();
+  state.activeLLMSpansByParent.clear();
+  state.agentIdToToolUseId.clear();
+  state.rawSubagentToolUseIdToToolUseId.clear();
+  state.toolUseToParent.clear();
+}
+
+function wrapQuery(
+  original: NonNullable<ClaudeAgentSDKModule['query']>,
+): NonNullable<ClaudeAgentSDKModule['query']> {
+  const tracer = trace.getTracer('@traceroot-ai/claude-agent-sdk');
+
+  return function wrappedQuery(
+    params: ClaudeAgentSDKQueryParams,
+  ): AsyncIterable<ClaudeAgentSDKMessage> {
+    const parentCtx = context.active();
+
+    return {
+      [Symbol.asyncIterator]() {
+        const querySpan = tracer.startSpan(
+          QUERY_SPAN_NAME,
+          {
+            attributes: {
+              [OI_SPAN_KIND]: OI_SPAN_KIND_VALUE.AGENT,
+              ...(params.options?.model
+                ? { [CLAUDE_AGENT_ATTRIBUTES.MODEL]: params.options.model }
+                : {}),
+            },
+          },
+          parentCtx,
+        );
+        if (typeof params.prompt === 'string')
+          querySpan.setAttribute(OI_INPUT_VALUE, params.prompt);
+
+        const state: QueryState = {
+          accumulatedOutputTokens: 0,
+          activeLLMSpansByParent: new Map(),
+          agentIdToToolUseId: new Map(),
+          currentMessageStartTime: new Date(),
+          ctx: trace.setSpan(parentCtx, querySpan),
+          params,
+          pendingAssistantMessages: [],
+          querySpan,
+          rawSubagentToolUseIdToToolUseId: new Map(),
+          subagents: new Map(),
+          toolUseToParent: new Map(),
+          tools: new Map(),
+          tracer,
+        };
+
+        const modifiedParams = {
+          ...params,
+          options: mergeHooks(params.options, createTracingHooks(state)),
+        };
+
+        let finished = false;
+        const finish = (
+          status: { code: SpanStatusCode; message?: string } = { code: SpanStatusCode.OK },
+          error?: unknown,
+        ): void => {
+          if (finished) return;
+          finished = true;
+          endInFlight(state, status);
+          if (error !== undefined) {
+            querySpan.recordException(error instanceof Error ? error : new Error(String(error)));
+          }
+          querySpan.setStatus(status);
+          querySpan.end();
+        };
+
+        let inner: AsyncIterator<ClaudeAgentSDKMessage>;
+        try {
+          inner = original(modifiedParams)[Symbol.asyncIterator]();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          finish({ code: SpanStatusCode.ERROR, message }, error);
+          throw error;
+        }
+
+        return {
+          async next() {
+            try {
+              const result = await context.with(state.ctx, () => inner.next());
+              if (!result.done) {
+                processMessage(state, result.value, params);
+              } else {
+                finish();
+              }
+              return result;
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error);
+              finish({ code: SpanStatusCode.ERROR, message }, error);
+              throw error;
+            }
+          },
+          async return(value?: unknown) {
+            if (finished) return { done: true as const, value: undefined };
+            try {
+              const result = inner.return
+                ? await inner.return(value as ClaudeAgentSDKMessage)
+                : { done: true as const, value: undefined };
+              finish();
+              return result;
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error);
+              finish({ code: SpanStatusCode.ERROR, message }, error);
+              throw error;
+            }
+          },
+          async throw(error?: unknown) {
+            const message = error instanceof Error ? error.message : String(error);
+            if (finished) throw error;
+            try {
+              if (inner.throw) {
+                const result = await inner.throw(error);
+                finish({ code: SpanStatusCode.ERROR, message }, error);
+                return result;
+              }
+              finish({ code: SpanStatusCode.ERROR, message }, error);
+              throw error;
+            } catch (thrown) {
+              const thrownMessage = thrown instanceof Error ? thrown.message : String(thrown);
+              finish({ code: SpanStatusCode.ERROR, message: thrownMessage }, thrown);
+              throw thrown;
+            }
+          },
+        };
+      },
+    };
+  };
+}
+
+export function wireClaudeAgentSDKInstrumentation(mod: unknown): void {
+  const sdk = mod as ClaudeAgentSDKModule & { [WRAPPED]?: boolean };
+  if (!sdk || typeof sdk !== 'object' || typeof sdk.query !== 'function') {
+    throw new Error(
+      '[TraceRoot] instrumentModules.claudeAgentSDK does not expose query. ' +
+        'Pass a mutable module namespace, e.g. `{ ...claudeAgentSDK }`.',
+    );
+  }
+  if (sdk[WRAPPED]) return;
+
+  sdk.query = wrapQuery(sdk.query);
+  Object.defineProperty(sdk, WRAPPED, {
+    configurable: false,
+    enumerable: false,
+    value: true,
+  });
+}

--- a/packages/traceroot/src/instrumentation.ts
+++ b/packages/traceroot/src/instrumentation.ts
@@ -2,11 +2,11 @@
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { AnthropicInstrumentation } from '@arizeai/openinference-instrumentation-anthropic';
 import { BedrockInstrumentation } from '@arizeai/openinference-instrumentation-bedrock';
-import { ClaudeAgentSDKInstrumentation } from '@arizeai/openinference-instrumentation-claude-agent-sdk';
 import { LangChainInstrumentation } from '@arizeai/openinference-instrumentation-langchain';
 import { OpenAIInstrumentation } from '@arizeai/openinference-instrumentation-openai';
 import { InitializeOptions } from './types';
 import { wireOpenAIAgentsProcessor } from './openai-agents';
+import { wireClaudeAgentSDKInstrumentation } from './claude-agent-sdk';
 
 /**
  * Wires OpenInference instrumentations based on the instrumentModules option:
@@ -28,7 +28,6 @@ export function wireInstrumentations(
         new OpenAIInstrumentation(),
         new AnthropicInstrumentation(),
         new LangChainInstrumentation(),
-        new ClaudeAgentSDKInstrumentation(),
         new BedrockInstrumentation(),
       ],
     });
@@ -39,7 +38,6 @@ export function wireInstrumentations(
     | typeof OpenAIInstrumentation
     | typeof AnthropicInstrumentation
     | typeof LangChainInstrumentation
-    | typeof ClaudeAgentSDKInstrumentation
     | typeof BedrockInstrumentation
   >[] = [];
 
@@ -60,9 +58,9 @@ export function wireInstrumentations(
     instr.manuallyInstrument(instrumentModules.langchain as any);
   }
   if (instrumentModules.claudeAgentSDK) {
-    const instr = new ClaudeAgentSDKInstrumentation();
-    instrs.push(instr);
-    instr.manuallyInstrument(instrumentModules.claudeAgentSDK as any);
+    // Claude Agent SDK uses TraceRoot's in-house wrapper for stable agent/tool/LLM structure.
+    // Auto RITM is intentionally not enabled for it until this wrapper has its own loader hook.
+    wireClaudeAgentSDKInstrumentation(instrumentModules.claudeAgentSDK);
   }
   if (instrumentModules.bedrock) {
     const instr = new BedrockInstrumentation();

--- a/packages/traceroot/tests/claude-agent-sdk.test.ts
+++ b/packages/traceroot/tests/claude-agent-sdk.test.ts
@@ -1,0 +1,770 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { context, propagation, trace } from '@opentelemetry/api';
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { wireClaudeAgentSDKInstrumentation } from '../src/claude-agent-sdk';
+
+type HookInput = Record<string, unknown>;
+type HookCallback = (input: HookInput, toolUseId?: string) => Promise<Record<string, unknown>>;
+type QueryParams = {
+  prompt?: string;
+  options?: {
+    model?: string;
+    hooks?: Record<string, Array<{ hooks: HookCallback[] }>>;
+  };
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function spanDurationMs(span: { duration: [number, number] }): number {
+  return span.duration[0] * 1000 + span.duration[1] / 1_000_000;
+}
+
+function spanStartMs(span: { startTime: [number, number] }): number {
+  return span.startTime[0] * 1000 + span.startTime[1] / 1_000_000;
+}
+
+function spanEndMs(span: { duration: [number, number]; startTime: [number, number] }): number {
+  return spanStartMs(span) + spanDurationMs(span);
+}
+
+async function runHooks(params: QueryParams, event: string, input: HookInput, toolUseId: string) {
+  const matchers = params.options?.hooks?.[event] ?? [];
+  for (const matcher of matchers) {
+    for (const hook of matcher.hooks) {
+      await hook({ ...input, hook_event_name: event, tool_use_id: toolUseId }, toolUseId);
+    }
+  }
+}
+
+async function exhaustQuery(
+  sdk: { query(params: QueryParams): AsyncIterable<unknown> },
+  params: QueryParams = { prompt: 'test prompt', options: { model: 'claude-opus-4-7' } },
+): Promise<void> {
+  for await (const _message of sdk.query(params)) {
+    // Exhaust the stream.
+  }
+}
+
+describe('Claude Agent SDK instrumentation', () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider();
+    provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+    provider.register();
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+    exporter.reset();
+    trace.disable();
+    context.disable();
+    propagation.disable();
+  });
+
+  it('emits a bare Claude Agent SDK tree with models and cache tokens', async () => {
+    const sdk = {
+      async *query(params: QueryParams) {
+        await sleep(5);
+        yield {
+          type: 'assistant',
+          message: {
+            id: 'msg_main_1',
+            role: 'assistant',
+            model: 'claude-opus-4-7',
+            usage: {
+              input_tokens: 10,
+              output_tokens: 1,
+              cache_read_input_tokens: 20,
+              cache_creation_input_tokens: 30,
+            },
+            content: [
+              {
+                type: 'tool_use',
+                id: 'toolu_agent_1',
+                name: 'Agent',
+                input: { subagent_type: 'researcher' },
+              },
+            ],
+          },
+        };
+
+        await sleep(5);
+        await runHooks(
+          params,
+          'PreToolUse',
+          {
+            tool_name: 'Agent',
+            tool_input: { subagent_type: 'researcher' },
+            session_id: 'session-1',
+          },
+          'toolu_agent_1',
+        );
+        await runHooks(
+          params,
+          'SubagentStart',
+          { agent_id: 'agent-1', agent_type: 'researcher' },
+          'subagent-task-1',
+        );
+
+        await sleep(5);
+        await runHooks(
+          params,
+          'PreToolUse',
+          {
+            agent_id: 'agent-1',
+            tool_name: 'WebSearch',
+            tool_input: { query: 'OpenTelemetry AI observability' },
+            session_id: 'session-1',
+          },
+          'toolu_web_1',
+        );
+        await sleep(5);
+        yield {
+          type: 'assistant',
+          parent_tool_use_id: 'toolu_agent_1',
+          message: {
+            id: 'msg_research_1',
+            role: 'assistant',
+            model: 'claude-haiku-4-5-20251001',
+            usage: { input_tokens: 5, output_tokens: 2 },
+            content: [
+              {
+                type: 'tool_use',
+                id: 'toolu_web_1',
+                name: 'WebSearch',
+                input: { query: 'OpenTelemetry AI observability' },
+              },
+            ],
+          },
+        };
+
+        await sleep(5);
+        await runHooks(
+          params,
+          'PostToolUse',
+          {
+            agent_id: 'agent-1',
+            tool_name: 'WebSearch',
+            tool_response: { results: ['one'] },
+          },
+          'toolu_web_1',
+        );
+        await runHooks(
+          params,
+          'PostToolUse',
+          {
+            tool_name: 'Agent',
+            tool_response: {
+              agentId: 'agent-1',
+              agentType: 'researcher',
+              content: [{ text: 'research done' }],
+              totalDurationMs: 123,
+              totalToolUseCount: 1,
+            },
+          },
+          'toolu_agent_1',
+        );
+
+        yield {
+          type: 'result',
+          result: 'final answer',
+          session_id: 'session-1',
+          usage: { input_tokens: 20, output_tokens: 3 },
+          total_cost_usd: 0.123,
+        };
+      },
+    };
+
+    wireClaudeAgentSDKInstrumentation(sdk);
+
+    const tracer = trace.getTracer('test');
+    const root = tracer.startSpan('root');
+    await context.with(trace.setSpan(context.active(), root), async () => {
+      for await (const _message of sdk.query({
+        prompt: 'test prompt',
+        options: { model: 'claude-opus-4-7' },
+      })) {
+        // Exhaust the stream.
+      }
+    });
+    root.end();
+
+    const spans = exporter.getFinishedSpans();
+    const rootSpan = spans.find((s) => s.name === 'root')!;
+    const query = spans.find((s) => s.name === 'ClaudeAgent.query')!;
+    const agent = spans.find((s) => s.name === 'Agent')!;
+    const subagent = spans.find((s) => s.name === 'Subagent')!;
+    const webSearch = spans.find((s) => s.name === 'WebSearch')!;
+    const llmSpans = spans.filter((s) => s.name === 'anthropic.messages.create');
+
+    assert.ok(rootSpan, 'root missing');
+    assert.ok(query, 'query missing');
+    assert.ok(agent, 'Agent tool missing');
+    assert.ok(subagent, 'Subagent missing');
+    assert.ok(webSearch, 'WebSearch missing');
+    assert.equal(llmSpans.length, 2);
+
+    assert.equal(query.parentSpanId, rootSpan.spanContext().spanId);
+    assert.equal(agent.parentSpanId, query.spanContext().spanId);
+    assert.equal(subagent.parentSpanId, agent.spanContext().spanId);
+    const opus = llmSpans.find((s) => s.attributes['llm.model_name'] === 'claude-opus-4-7')!;
+    const haiku = llmSpans.find(
+      (s) => s.attributes['llm.model_name'] === 'claude-haiku-4-5-20251001',
+    )!;
+    assert.ok(opus, 'opus LLM span missing');
+    assert.ok(haiku, 'haiku LLM span missing');
+    assert.equal(opus.parentSpanId, query.spanContext().spanId);
+    assert.equal(haiku.parentSpanId, subagent.spanContext().spanId);
+    assert.equal(webSearch.parentSpanId, subagent.spanContext().spanId);
+    assert.ok(spanDurationMs(opus) > 0, 'opus LLM span should have inferred duration');
+    assert.ok(spanDurationMs(haiku) > 0, 'haiku LLM span should have inferred duration');
+    assert.ok(
+      spanStartMs(opus) > spanStartMs(query),
+      'first LLM span should start at the assistant message boundary, not query start',
+    );
+    assert.ok(
+      spanEndMs(haiku) >= spanEndMs(webSearch) - 1,
+      'tool-use LLM turn should be allowed to cover tool execution',
+    );
+    assert.equal(query.attributes['claude_agent_sdk.model'], 'claude-opus-4-7');
+    assert.equal(query.attributes['claude_agent_sdk.total_cost_usd'], 0.123);
+    assert.equal(query.attributes['llm.model_name'], undefined);
+    assert.equal(query.attributes['llm.token_count.prompt'], undefined);
+    assert.equal(query.attributes['llm.token_count.completion'], undefined);
+    assert.equal(query.attributes['llm.cost.total'], undefined);
+    assert.equal(opus.attributes['llm.token_count.prompt'], 60);
+    assert.equal(opus.attributes['llm.token_count.prompt_details.cache_read'], 20);
+    assert.equal(opus.attributes['llm.token_count.prompt_details.cache_creation'], 30);
+    assert.equal(haiku.attributes['llm.token_count.prompt'], 5);
+    assert.equal(subagent.attributes['claude_agent_sdk.agent_type'], 'researcher');
+    assert.equal(subagent.attributes['claude_agent_sdk.tool_use_count'], 1);
+  });
+
+  it('groups repeated assistant chunks by message id', async () => {
+    const sdk = {
+      async *query(_params: QueryParams) {
+        yield {
+          type: 'assistant',
+          message: {
+            id: 'msg_same',
+            role: 'assistant',
+            model: 'claude-opus-4-7',
+            usage: { input_tokens: 10, output_tokens: 0 },
+            content: [{ type: 'text', text: 'partial' }],
+          },
+        };
+        yield {
+          type: 'assistant',
+          message: {
+            id: 'msg_same',
+            role: 'assistant',
+            model: 'claude-opus-4-7',
+            usage: { input_tokens: 10, output_tokens: 5 },
+            content: [{ type: 'text', text: 'done' }],
+          },
+        };
+        yield {
+          type: 'result',
+          result: 'done',
+          usage: { input_tokens: 10, output_tokens: 5 },
+        };
+      },
+    };
+
+    wireClaudeAgentSDKInstrumentation(sdk);
+
+    for await (const _message of sdk.query({
+      prompt: 'test prompt',
+      options: { model: 'claude-opus-4-7' },
+    })) {
+      // Exhaust the stream.
+    }
+
+    const llmSpans = exporter
+      .getFinishedSpans()
+      .filter((s) => s.name === 'anthropic.messages.create');
+
+    assert.equal(llmSpans.length, 1);
+    assert.equal(llmSpans[0].attributes['llm.token_count.completion'], 5);
+  });
+
+  it('keeps tools as subagent siblings when tool hooks arrive before assistant usage', async () => {
+    const sdk = {
+      async *query(params: QueryParams) {
+        yield {
+          type: 'assistant',
+          message: {
+            id: 'msg_main',
+            role: 'assistant',
+            model: 'claude-opus-4-7',
+            usage: { input_tokens: 10, output_tokens: 1 },
+            content: [{ type: 'tool_use', id: 'toolu_agent_1', name: 'Agent', input: {} }],
+          },
+        };
+
+        await runHooks(
+          params,
+          'PreToolUse',
+          { tool_name: 'Agent', tool_input: {} },
+          'toolu_agent_1',
+        );
+        await runHooks(
+          params,
+          'SubagentStart',
+          { agent_id: 'agent-1', agent_type: 'researcher' },
+          'toolu_agent_1',
+        );
+        await runHooks(
+          params,
+          'PreToolUse',
+          {
+            agent_id: 'agent-1',
+            tool_name: 'WebSearch',
+            tool_input: { query: 'OpenTelemetry' },
+          },
+          'toolu_web_1',
+        );
+
+        yield {
+          type: 'assistant',
+          parent_tool_use_id: 'toolu_agent_1',
+          message: {
+            id: 'msg_subagent',
+            role: 'assistant',
+            model: 'claude-haiku-4-5-20251001',
+            usage: { input_tokens: 20, output_tokens: 2 },
+            content: [
+              {
+                type: 'tool_use',
+                id: 'toolu_web_1',
+                name: 'WebSearch',
+                input: { query: 'OpenTelemetry' },
+              },
+            ],
+          },
+        };
+
+        await runHooks(
+          params,
+          'PostToolUse',
+          {
+            agent_id: 'agent-1',
+            tool_name: 'WebSearch',
+            tool_response: { results: [] },
+          },
+          'toolu_web_1',
+        );
+        await runHooks(
+          params,
+          'PostToolUse',
+          { tool_name: 'Agent', tool_response: {} },
+          'toolu_agent_1',
+        );
+        yield { type: 'result', result: 'done', usage: { input_tokens: 30, output_tokens: 3 } };
+      },
+    };
+
+    wireClaudeAgentSDKInstrumentation(sdk);
+    await exhaustQuery(sdk);
+
+    const spans = exporter.getFinishedSpans();
+    const subagent = spans.find((s) => s.name === 'Subagent')!;
+    const webSearch = spans.find((s) => s.name === 'WebSearch')!;
+    const haiku = spans.find(
+      (s) =>
+        s.name === 'anthropic.messages.create' &&
+        s.attributes['llm.model_name'] === 'claude-haiku-4-5-20251001',
+    )!;
+
+    assert.ok(subagent, 'Subagent missing');
+    assert.ok(webSearch, 'WebSearch missing');
+    assert.ok(haiku, 'Haiku LLM span missing');
+    assert.equal(webSearch.parentSpanId, subagent.spanContext().spanId);
+    assert.equal(haiku.parentSpanId, subagent.spanContext().spanId);
+  });
+
+  it('parents non-delegation tools under the active LLM when assistant usage arrives first', async () => {
+    const sdk = {
+      async *query(params: QueryParams) {
+        yield {
+          type: 'assistant',
+          message: {
+            id: 'msg_main',
+            role: 'assistant',
+            model: 'claude-opus-4-7',
+            usage: { input_tokens: 10, output_tokens: 1 },
+            content: [{ type: 'tool_use', id: 'toolu_agent_1', name: 'Agent', input: {} }],
+          },
+        };
+
+        await runHooks(
+          params,
+          'PreToolUse',
+          { tool_name: 'Agent', tool_input: {} },
+          'toolu_agent_1',
+        );
+        await runHooks(
+          params,
+          'SubagentStart',
+          { agent_id: 'agent-1', agent_type: 'researcher' },
+          'toolu_agent_1',
+        );
+
+        yield {
+          type: 'assistant',
+          parent_tool_use_id: 'toolu_agent_1',
+          message: {
+            id: 'msg_subagent',
+            role: 'assistant',
+            model: 'claude-haiku-4-5-20251001',
+            usage: { input_tokens: 20, output_tokens: 2 },
+            content: [
+              {
+                type: 'tool_use',
+                id: 'toolu_web_1',
+                name: 'WebSearch',
+                input: { query: 'OpenTelemetry' },
+              },
+            ],
+          },
+        };
+
+        await runHooks(
+          params,
+          'PreToolUse',
+          {
+            agent_id: 'agent-1',
+            tool_name: 'WebSearch',
+            tool_input: { query: 'OpenTelemetry' },
+          },
+          'toolu_web_1',
+        );
+        await runHooks(
+          params,
+          'PostToolUse',
+          {
+            agent_id: 'agent-1',
+            tool_name: 'WebSearch',
+            tool_response: { results: [] },
+          },
+          'toolu_web_1',
+        );
+        await runHooks(
+          params,
+          'PostToolUse',
+          { tool_name: 'Agent', tool_response: {} },
+          'toolu_agent_1',
+        );
+        yield { type: 'result', result: 'done', usage: { input_tokens: 30, output_tokens: 3 } };
+      },
+    };
+
+    wireClaudeAgentSDKInstrumentation(sdk);
+    await exhaustQuery(sdk);
+
+    const spans = exporter.getFinishedSpans();
+    const webSearch = spans.find((s) => s.name === 'WebSearch')!;
+    const haiku = spans.find(
+      (s) =>
+        s.name === 'anthropic.messages.create' &&
+        s.attributes['llm.model_name'] === 'claude-haiku-4-5-20251001',
+    )!;
+
+    assert.ok(webSearch, 'WebSearch missing');
+    assert.ok(haiku, 'Haiku LLM span missing');
+    assert.equal(webSearch.parentSpanId, haiku.spanContext().spanId);
+  });
+
+  it('does not parent later tools under an already-ended LLM span', async () => {
+    const sdk = {
+      async *query(params: QueryParams) {
+        yield {
+          type: 'assistant',
+          message: {
+            id: 'msg_main',
+            role: 'assistant',
+            model: 'claude-opus-4-7',
+            usage: { input_tokens: 10, output_tokens: 1 },
+            content: [{ type: 'tool_use', id: 'toolu_agent_1', name: 'Agent', input: {} }],
+          },
+        };
+
+        await runHooks(
+          params,
+          'PreToolUse',
+          { tool_name: 'Agent', tool_input: {} },
+          'toolu_agent_1',
+        );
+        await runHooks(
+          params,
+          'SubagentStart',
+          { agent_id: 'agent-1', agent_type: 'researcher' },
+          'toolu_agent_1',
+        );
+
+        yield {
+          type: 'assistant',
+          parent_tool_use_id: 'toolu_agent_1',
+          message: {
+            id: 'msg_subagent',
+            role: 'assistant',
+            model: 'claude-haiku-4-5-20251001',
+            usage: { input_tokens: 20, output_tokens: 2 },
+            content: [
+              {
+                type: 'tool_use',
+                id: 'toolu_web_1',
+                name: 'WebSearch',
+                input: { query: 'OpenTelemetry' },
+              },
+            ],
+          },
+        };
+
+        yield {
+          type: 'assistant',
+          message: {
+            id: 'msg_root_2',
+            role: 'assistant',
+            model: 'claude-opus-4-7',
+            usage: { input_tokens: 30, output_tokens: 3 },
+            content: [{ type: 'text', text: 'continue' }],
+          },
+        };
+
+        await runHooks(
+          params,
+          'PreToolUse',
+          {
+            agent_id: 'agent-1',
+            tool_name: 'WebSearch',
+            tool_input: { query: 'OpenTelemetry' },
+          },
+          'toolu_web_1',
+        );
+        await runHooks(
+          params,
+          'PostToolUse',
+          {
+            agent_id: 'agent-1',
+            tool_name: 'WebSearch',
+            tool_response: { results: [] },
+          },
+          'toolu_web_1',
+        );
+        await runHooks(
+          params,
+          'PostToolUse',
+          { tool_name: 'Agent', tool_response: {} },
+          'toolu_agent_1',
+        );
+        yield { type: 'result', result: 'done', usage: { input_tokens: 60, output_tokens: 6 } };
+      },
+    };
+
+    wireClaudeAgentSDKInstrumentation(sdk);
+    await exhaustQuery(sdk);
+
+    const spans = exporter.getFinishedSpans();
+    const subagent = spans.find((s) => s.name === 'Subagent')!;
+    const webSearch = spans.find((s) => s.name === 'WebSearch')!;
+    const haiku = spans.find(
+      (s) =>
+        s.name === 'anthropic.messages.create' &&
+        s.attributes['llm.model_name'] === 'claude-haiku-4-5-20251001',
+    )!;
+
+    assert.ok(subagent, 'Subagent missing');
+    assert.ok(webSearch, 'WebSearch missing');
+    assert.ok(haiku, 'Haiku LLM span missing');
+    assert.equal(webSearch.parentSpanId, subagent.spanContext().spanId);
+    assert.notEqual(webSearch.parentSpanId, haiku.spanContext().spanId);
+  });
+
+  it('keeps Agent and Bash as task siblings even when an LLM span is active', async () => {
+    const sdk = {
+      async *query(params: QueryParams) {
+        yield {
+          type: 'assistant',
+          message: {
+            id: 'msg_main',
+            role: 'assistant',
+            model: 'claude-opus-4-7',
+            usage: { input_tokens: 10, output_tokens: 1 },
+            content: [
+              { type: 'tool_use', id: 'toolu_agent_1', name: 'Agent', input: {} },
+              { type: 'tool_use', id: 'toolu_bash_1', name: 'Bash', input: { command: 'true' } },
+            ],
+          },
+        };
+
+        await runHooks(
+          params,
+          'PreToolUse',
+          { tool_name: 'Agent', tool_input: {} },
+          'toolu_agent_1',
+        );
+        await runHooks(
+          params,
+          'PostToolUse',
+          { tool_name: 'Agent', tool_response: {} },
+          'toolu_agent_1',
+        );
+        await runHooks(
+          params,
+          'PreToolUse',
+          { tool_name: 'Bash', tool_input: { command: 'true' } },
+          'toolu_bash_1',
+        );
+        await runHooks(
+          params,
+          'PostToolUse',
+          { tool_name: 'Bash', tool_response: { stdout: '' } },
+          'toolu_bash_1',
+        );
+        yield { type: 'result', result: 'done', usage: { input_tokens: 10, output_tokens: 1 } };
+      },
+    };
+
+    wireClaudeAgentSDKInstrumentation(sdk);
+    await exhaustQuery(sdk);
+
+    const spans = exporter.getFinishedSpans();
+    const query = spans.find((s) => s.name === 'ClaudeAgent.query')!;
+    const agent = spans.find((s) => s.name === 'Agent')!;
+    const bash = spans.find((s) => s.name === 'Bash')!;
+    const llm = spans.find((s) => s.name === 'anthropic.messages.create')!;
+
+    assert.ok(query, 'query missing');
+    assert.ok(agent, 'Agent missing');
+    assert.ok(bash, 'Bash missing');
+    assert.ok(llm, 'LLM missing');
+    assert.equal(agent.parentSpanId, query.spanContext().spanId);
+    assert.equal(bash.parentSpanId, query.spanContext().spanId);
+    assert.notEqual(agent.parentSpanId, llm.spanContext().spanId);
+    assert.notEqual(bash.parentSpanId, llm.spanContext().spanId);
+  });
+
+  it('ends the query span when the wrapped query throws during iterator construction', async () => {
+    const sdk = {
+      query(_params: QueryParams): AsyncIterable<unknown> {
+        throw new Error('construction failed');
+      },
+    };
+
+    wireClaudeAgentSDKInstrumentation(sdk);
+
+    await assert.rejects(() => exhaustQuery(sdk), /construction failed/);
+
+    const query = exporter.getFinishedSpans().find((s) => s.name === 'ClaudeAgent.query')!;
+    assert.ok(query, 'query missing');
+    assert.equal(query.status.code, 2);
+  });
+
+  it('cleans up the query span only once when an iterator is returned multiple times', async () => {
+    const sdk = {
+      async *query(_params: QueryParams) {
+        yield {
+          type: 'assistant',
+          message: {
+            id: 'msg_one',
+            role: 'assistant',
+            model: 'claude-opus-4-7',
+            usage: { input_tokens: 10, output_tokens: 1 },
+            content: [{ type: 'text', text: 'partial' }],
+          },
+        };
+        await sleep(50);
+        yield { type: 'result', result: 'done', usage: { input_tokens: 10, output_tokens: 1 } };
+      },
+    };
+
+    wireClaudeAgentSDKInstrumentation(sdk);
+
+    const iterator = sdk
+      .query({ prompt: 'test prompt', options: { model: 'claude-opus-4-7' } })
+      [Symbol.asyncIterator]();
+    await iterator.next();
+    await iterator.return?.();
+    await iterator.return?.();
+
+    const querySpans = exporter.getFinishedSpans().filter((s) => s.name === 'ClaudeAgent.query');
+    assert.equal(querySpans.length, 1);
+    assert.equal(querySpans[0].status.code, 1);
+  });
+
+  it('uses final result usage to correct the last pending assistant group', async () => {
+    const sdk = {
+      async *query(params: QueryParams) {
+        yield {
+          type: 'assistant',
+          message: {
+            id: 'msg_tool',
+            role: 'assistant',
+            model: 'claude-opus-4-7',
+            usage: { input_tokens: 100, output_tokens: 10 },
+            content: [{ type: 'tool_use', id: 'toolu_agent_1', name: 'Agent', input: {} }],
+          },
+        };
+        await runHooks(
+          params,
+          'PreToolUse',
+          { tool_name: 'Agent', tool_input: {} },
+          'toolu_agent_1',
+        );
+        await runHooks(
+          params,
+          'PostToolUse',
+          { tool_name: 'Agent', tool_response: {} },
+          'toolu_agent_1',
+        );
+        yield {
+          type: 'assistant',
+          message: {
+            id: 'msg_final',
+            role: 'assistant',
+            model: 'claude-opus-4-7',
+            usage: { input_tokens: 200, output_tokens: 1 },
+            content: [{ type: 'text', text: 'final answer' }],
+          },
+        };
+        yield {
+          type: 'result',
+          result: 'final answer',
+          usage: {
+            input_tokens: 300,
+            output_tokens: 110,
+            cache_read_input_tokens: 20,
+            cache_creation_input_tokens: 30,
+          },
+        };
+      },
+    };
+
+    wireClaudeAgentSDKInstrumentation(sdk);
+
+    for await (const _message of sdk.query({
+      prompt: 'test prompt',
+      options: { model: 'claude-opus-4-7' },
+    })) {
+      // Exhaust the stream.
+    }
+
+    const llmSpans = exporter
+      .getFinishedSpans()
+      .filter((s) => s.name === 'anthropic.messages.create');
+
+    assert.equal(llmSpans.length, 2);
+    assert.equal(llmSpans[0].attributes['llm.token_count.completion'], 10);
+    assert.equal(llmSpans[1].attributes['llm.token_count.completion'], 100);
+    assert.equal(llmSpans[1].attributes['llm.token_count.prompt_details.cache_read'], 20);
+    assert.equal(llmSpans[1].attributes['llm.token_count.prompt_details.cache_creation'], 30);
+  });
+});

--- a/packages/traceroot/tests/claude-agent-sdk.test.ts
+++ b/packages/traceroot/tests/claude-agent-sdk.test.ts
@@ -688,9 +688,8 @@ describe('Claude Agent SDK instrumentation', () => {
 
     wireClaudeAgentSDKInstrumentation(sdk);
 
-    const iterator = sdk
-      .query({ prompt: 'test prompt', options: { model: 'claude-opus-4-7' } })
-      [Symbol.asyncIterator]();
+    const iterable = sdk.query({ prompt: 'test prompt', options: { model: 'claude-opus-4-7' } });
+    const iterator = iterable[Symbol.asyncIterator]();
     await iterator.next();
     await iterator.return?.();
     await iterator.return?.();


### PR DESCRIPTION
## Summary
- add TraceRoot-owned Claude Agent SDK instrumentation for query, LLM, subagent, and tool spans
- keep Claude Agent query spans structural while child anthropic.messages.create spans own model/token accounting
- wire manual Claude Agent SDK instrumentation through the TraceRoot wrapper and avoid divergent upstream auto instrumentation for now
- add regression coverage for span shape, usage grouping, tool ordering, and query cleanup edge cases

## Testing
- pnpm --filter @traceroot-ai/traceroot test -- claude-agent-sdk span-attributes openai-agents
- pnpm --filter @traceroot-ai/traceroot build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add TraceRoot’s Claude Agent SDK instrumentation to emit structured query, LLM, subagent, and tool spans with correct parenting and token/model attribution. Replaces upstream auto-instrumentation with a stable wrapper and adds tests for span shape, lifecycle, and iterator edge cases.

- New Features
  - Introduced `wireClaudeAgentSDKInstrumentation` to instrument `query` with TraceRoot’s wrapper.
  - LLM spans (`anthropic.messages.create`) own model and token counts (incl. cache read/creation); query span stays structural and holds prompt/session/summary data.
  - Smart parenting: tools attach to the active LLM turn or task/subagent; `Agent`/`Task`/`Bash` remain task siblings.
  - Subagent spans carry `agent_id`/`agent_type`, track lifecycle, and handle errors/cleanup. Groups assistant chunks by message ID and adjusts final usage from the result message.
  - Robust iterator lifecycle handling: spans close on construction errors and on double return/throw; tests cover ordering when hooks arrive before usage and not parenting under ended LLM spans.

- Refactors
  - Removed `@arizeai/openinference-instrumentation-claude-agent-sdk` from `instrumentation.ts` and now call the in-house `wireClaudeAgentSDKInstrumentation` when `instrumentModules.claudeAgentSDK` is provided.

<sup>Written for commit d2ee21489c1f69fddc0cffa0c2ec4e8f6c781e62. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot-ts/pull/97?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


## Screenshots

Before
<img width="2302" height="1170" alt="Screenshot 2026-05-24 at 5 37 39 PM" src="https://github.com/user-attachments/assets/c8d4cfe3-2170-42d2-a2e6-2f375c5d693c" />


After
<img width="2300" height="1171" alt="Screenshot 2026-05-24 at 5 37 15 PM" src="https://github.com/user-attachments/assets/c48a92e4-9364-4e77-8a6b-ff3928eeb6fd" />
<img width="2303" height="1175" alt="Screenshot 2026-05-24 at 5 37 05 PM" src="https://github.com/user-attachments/assets/8d33ff2d-121b-421d-9179-5de382407a3c" />

