### PR TITLE
chore: bump version to 0.1.5

### DIFF
--- a/packages/traceroot/package.json
+++ b/packages/traceroot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traceroot-ai/traceroot",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "TraceRoot TypeScript SDK for AI observability",
   "keywords": [
     "traceroot",


### PR DESCRIPTION
## Summary
Bumps `@traceroot-ai/traceroot` from 0.1.4 → 0.1.5.

Rolls up changes landed since #90:
- feat: add Claude Agent SDK instrumentation (#97)
- refactor: centralize telemetry attribute constants (#96)
- feat(instrumentation): add Vercel AI SDK tracing (#66)
- refactor(openai-agents): align naming, types, and wire path with vendor conventions (#78)

## Test plan
- [ ] CI green
- [ ] After merge: `pnpm --filter @traceroot-ai/traceroot build && cd packages/traceroot && npm publish --access public`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release 0.1.5 of `@traceroot-ai/traceroot`, bundling new SDK instrumentation and telemetry refactors to prepare for publish.

- **New Features**
  - Add Claude Agent SDK instrumentation.
  - Add tracing for Vercel AI SDK.

- **Refactors**
  - Centralize telemetry attribute constants.
  - Align OpenAI agents naming, types, and wire path with vendor conventions.

<sup>Written for commit 3984a38a42bb77c1554e49f61d038450c85988d3. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot-ts/pull/98?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

