### PR TITLE
fix: lazy-load OpenInference instrumentations to avoid peer dep crashes

### DIFF
--- a/packages/traceroot/src/instrumentation.ts
+++ b/packages/traceroot/src/instrumentation.ts
@@ -1,21 +1,45 @@
 // src/instrumentation.ts
-import { registerInstrumentations } from '@opentelemetry/instrumentation';
-import { AnthropicInstrumentation } from '@arizeai/openinference-instrumentation-anthropic';
-import { BedrockInstrumentation } from '@arizeai/openinference-instrumentation-bedrock';
-import { LangChainInstrumentation } from '@arizeai/openinference-instrumentation-langchain';
-import { OpenAIInstrumentation } from '@arizeai/openinference-instrumentation-openai';
-import { InitializeOptions } from './types';
+import { registerInstrumentations, type Instrumentation } from '@opentelemetry/instrumentation';
+import type { InitializeOptions } from './types';
 import { wireOpenAIAgentsProcessor } from './openai-agents';
 import { wireClaudeAgentSDKInstrumentation } from './claude-agent-sdk';
+
+type InstrumentationWithManualPatch = Instrumentation & {
+  manuallyInstrument(moduleRef: unknown): void;
+};
+
+type InstrumentationCtor = new () => InstrumentationWithManualPatch;
+
+const OPENINFERENCE_PACKAGES = {
+  openAI: ['@arizeai/openinference-instrumentation-openai', 'OpenAIInstrumentation'],
+  anthropic: ['@arizeai/openinference-instrumentation-anthropic', 'AnthropicInstrumentation'],
+  langchain: ['@arizeai/openinference-instrumentation-langchain', 'LangChainInstrumentation'],
+  bedrock: ['@arizeai/openinference-instrumentation-bedrock', 'BedrockInstrumentation'],
+} as const;
+
+function loadInstrumentation(pkg: string, exportName: string): InstrumentationCtor | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require(pkg) as Record<string, unknown>;
+    const ctor = mod[exportName];
+    if (typeof ctor !== 'function') return null;
+    return ctor as InstrumentationCtor;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Wires OpenInference instrumentations based on the instrumentModules option:
  *
- * - undefined  → RITM auto-instrumentation for all supported modules (CJS only)
- * - {}         → no instrumentation
- * - { openAI } → manual patch only the provided module refs
+ * - undefined  -> RITM auto-instrumentation for all supported modules (CJS only)
+ * - {}         -> no instrumentation
+ * - { openAI } -> manual patch only the provided module refs
  *
  * Called once by TraceRoot.initialize().
+ *
+ * All OpenInference instrumentations are lazy-loaded via require() so that
+ * missing peer dependencies don't crash initialization.
  */
 export function wireInstrumentations(
   instrumentModules: InitializeOptions['instrumentModules'],
@@ -23,49 +47,33 @@ export function wireInstrumentations(
   if (instrumentModules === undefined) {
     // Auto-instrumentation via require-in-the-middle (CJS only).
     // ESM users must pass explicit module refs.
-    registerInstrumentations({
-      instrumentations: [
-        new OpenAIInstrumentation(),
-        new AnthropicInstrumentation(),
-        new LangChainInstrumentation(),
-        new BedrockInstrumentation(),
-      ],
-    });
+    const instrs: Instrumentation[] = [];
+    for (const [pkg, exportName] of Object.values(OPENINFERENCE_PACKAGES)) {
+      const Ctor = loadInstrumentation(pkg, exportName);
+      if (Ctor) instrs.push(new Ctor());
+    }
+    if (instrs.length > 0) {
+      registerInstrumentations({ instrumentations: instrs });
+    }
     return;
   }
 
-  const instrs: InstanceType<
-    | typeof OpenAIInstrumentation
-    | typeof AnthropicInstrumentation
-    | typeof LangChainInstrumentation
-    | typeof BedrockInstrumentation
-  >[] = [];
+  const instrs: Instrumentation[] = [];
 
-  if (instrumentModules.openAI) {
-    const instr = new OpenAIInstrumentation();
+  for (const [key, [pkg, exportName]] of Object.entries(OPENINFERENCE_PACKAGES)) {
+    const moduleRef = instrumentModules[key as keyof typeof OPENINFERENCE_PACKAGES];
+    if (!moduleRef) continue;
+    const Ctor = loadInstrumentation(pkg, exportName);
+    if (!Ctor) {
+      throw new Error(`[TraceRoot] Failed to load ${pkg}. Install it: npm install ${pkg}`);
+    }
+    const instr = new Ctor();
     instrs.push(instr);
-    instr.manuallyInstrument(instrumentModules.openAI as any);
+    instr.manuallyInstrument(moduleRef);
   }
-  if (instrumentModules.anthropic) {
-    const instr = new AnthropicInstrumentation();
-    instrs.push(instr);
-    instr.manuallyInstrument(instrumentModules.anthropic as any);
-  }
-  if (instrumentModules.langchain) {
-    // langchain must be: import * as lcCallbackManager from '@langchain/core/callbacks/manager'
-    const instr = new LangChainInstrumentation();
-    instrs.push(instr);
-    instr.manuallyInstrument(instrumentModules.langchain as any);
-  }
+
   if (instrumentModules.claudeAgentSDK) {
-    // Claude Agent SDK uses TraceRoot's in-house wrapper for stable agent/tool/LLM structure.
-    // Auto RITM is intentionally not enabled for it until this wrapper has its own loader hook.
     wireClaudeAgentSDKInstrumentation(instrumentModules.claudeAgentSDK);
-  }
-  if (instrumentModules.bedrock) {
-    const instr = new BedrockInstrumentation();
-    instrs.push(instr);
-    instr.manuallyInstrument(instrumentModules.bedrock as any);
   }
   if (instrumentModules.openaiAgents) {
     wireOpenAIAgentsProcessor(instrumentModules.openaiAgents);

--- a/packages/traceroot/tests/instrumentation.test.ts
+++ b/packages/traceroot/tests/instrumentation.test.ts
@@ -1,0 +1,99 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+function runScript(script: string) {
+  const pkgDir = process.cwd();
+  const tsxLoader = pathToFileURL(
+    path.join(pkgDir, 'node_modules', 'tsx', 'dist', 'loader.mjs'),
+  ).href;
+  return spawnSync(process.execPath, ['--import', tsxLoader, '-e', script], {
+    cwd: pkgDir,
+    encoding: 'utf8',
+  });
+}
+
+describe('wireInstrumentations() lazy loading', () => {
+  it('does not load OpenAI package when only Anthropic is requested', () => {
+    const result = runScript(`
+      const Module = require('node:module');
+      const orig = Module._load;
+      Module._load = function(request, ...rest) {
+        if (request === '@arizeai/openinference-instrumentation-openai')
+          throw new Error('should not load openai instrumentation');
+        if (request === '@arizeai/openinference-instrumentation-anthropic')
+          return { AnthropicInstrumentation: class { manuallyInstrument() {} } };
+        if (request === '@arizeai/openinference-instrumentation-langchain')
+          throw new Error('should not load langchain instrumentation');
+        if (request === '@arizeai/openinference-instrumentation-bedrock')
+          throw new Error('should not load bedrock instrumentation');
+        return orig.apply(this, [request, ...rest]);
+      };
+      const { wireInstrumentations } = require('./src/instrumentation.ts');
+      wireInstrumentations({ anthropic: { name: 'mock' } });
+      console.log('OK');
+    `);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.ok(result.stdout.includes('OK'));
+  });
+
+  it('auto-instrumentation path skips missing packages gracefully', () => {
+    const result = runScript(`
+      const Module = require('node:module');
+      const orig = Module._load;
+      const loaded = [];
+      Module._load = function(request, ...rest) {
+        if (request.startsWith('@arizeai/openinference-instrumentation-')) {
+          throw new Error('MODULE_NOT_FOUND');
+        }
+        return orig.apply(this, [request, ...rest]);
+      };
+      const { wireInstrumentations } = require('./src/instrumentation.ts');
+      wireInstrumentations(undefined);
+      console.log('OK');
+    `);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.ok(result.stdout.includes('OK'));
+  });
+
+  it('explicit-modules path throws when a requested package is missing', () => {
+    const result = runScript(`
+      const Module = require('node:module');
+      const orig = Module._load;
+      Module._load = function(request, ...rest) {
+        if (request === '@arizeai/openinference-instrumentation-openai')
+          throw new Error('MODULE_NOT_FOUND');
+        return orig.apply(this, [request, ...rest]);
+      };
+      const { wireInstrumentations } = require('./src/instrumentation.ts');
+      try {
+        wireInstrumentations({ openAI: { name: 'mock' } });
+        console.log('SHOULD_HAVE_THROWN');
+      } catch (e) {
+        console.log('THREW:' + e.message);
+      }
+    `);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.ok(result.stdout.includes('THREW:'));
+    assert.ok(result.stdout.includes('Failed to load'));
+  });
+
+  it('claudeAgentSDK path does not go through OpenInference loader', () => {
+    const result = runScript(`
+      const Module = require('node:module');
+      const orig = Module._load;
+      Module._load = function(request, ...rest) {
+        if (request.startsWith('@arizeai/openinference-instrumentation-'))
+          throw new Error('should not load any openinference package');
+        return orig.apply(this, [request, ...rest]);
+      };
+      const { wireInstrumentations } = require('./src/instrumentation.ts');
+      wireInstrumentations({ claudeAgentSDK: { query: function() {} } });
+      console.log('OK');
+    `);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.ok(result.stdout.includes('OK'));
+  });
+});


### PR DESCRIPTION
 ## Summary

  Fixes #862 — lazy-load all OpenInference instrumentations so `TraceRoot.initialize()` no longer crashes when a project is missing peer dependencies of uninstrumented packages.

  - **Auto-instrumentation path** (`instrumentModules` omitted): gracefully skips unavailable packages
  - **Explicit-modules path** (`instrumentModules: { openAI: ... }`): throws a clear error if the requested package is missing
  - **Preserves** in-house `wireClaudeAgentSDKInstrumentation()` and `wireOpenAIAgentsProcessor()` — these are not OpenInference packages and must not be lazy-loaded via the same path
  - Data-driven `OPENINFERENCE_PACKAGES` map eliminates per-instrumentation code duplication
  - Proper TypeScript types instead of `any`

  ## Test plan

  - [x] New test: only requested instrumentations are loaded (others are not `require()`d)
  - [x] New test: auto path doesn't crash when all arize packages are missing
  - [x] New test: explicit path throws clear error when requested package is missing
  - [x] New test: `claudeAgentSDK` path bypasses OpenInference loader entirely
  - [x] All 135 existing tests pass
  - [x] Build passes

 ## Screenshot

<img width="1649" height="882" alt="截屏2026-05-29 18 16 32" src="https://github.com/user-attachments/assets/9b6d61e0-5c51-4916-93d0-75d2a6700084" />
<img width="1660" height="852" alt="截屏2026-05-29 18 16 47" src="https://github.com/user-attachments/assets/3c8f1f95-6ba1-4209-b0c2-6259be01b849" />


  Thanks to @looooown2006 (#91) and @algojogacor (#93) for their contributions to this fix!


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazy-loads OpenInference instrumentations to prevent `TraceRoot.initialize()` from crashing when peer deps for unused packages are missing. Auto-instrumentation now skips unavailable packages; explicit module instrumentation throws a clear error if the package isn’t installed.

- **Bug Fixes**
  - Replaced top-level imports with a `loadInstrumentation()` helper that lazily `require()`s instrumentations via an `OPENINFERENCE_PACKAGES` map.
  - Auto path (no `instrumentModules`): registers only available instrumentations; missing packages are ignored.
  - Explicit path (e.g., `{ openAI: ... }`): throws a friendly error with an install hint when the requested package is missing.
  - Preserves `wireClaudeAgentSDKInstrumentation()` and `wireOpenAIAgentsProcessor()` paths (not lazy-loaded).
  - Added tests for selective loading, auto path resilience, explicit path errors, and Claude SDK bypass.

<sup>Written for commit 5ed1a7665570f4efeedaf2bdb9a8a455b63d8500. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-ts/pull/99?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

