### PR TITLE
fix(ts-sdk): resolve git context from CI env vars

### DIFF
--- a/packages/traceroot/src/git_context.ts
+++ b/packages/traceroot/src/git_context.ts
@@ -1,7 +1,91 @@
 // src/git_context.ts
 import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 let _gitRootCache: string | null = null; // null = not yet detected, '' = failed
+
+type GitContext = { gitRepo?: string; gitRef?: string };
+type Env = Record<string, string | undefined>;
+
+// Treat whitespace-only env vars the same as missing values.
+function nonEmpty(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+// Normalize CI vars or git remote URLs into TraceRoot's owner/repo form.
+function normalizeRepo(value: string | undefined): string | undefined {
+  const repo = nonEmpty(value);
+  if (!repo) return undefined;
+
+  const match = repo.match(/(?:https?:\/\/[^/]+\/|ssh:\/\/git@[^/]+\/|git@[^:]+:)(.+?)(?:\.git)?$/);
+  return (match ? match[1] : repo).replace(/\.git$/, '').replace(/^\/+|\/+$/g, '') || undefined;
+}
+
+// Some platforms split owner and repo name into separate env vars.
+function joinRepo(owner: string | undefined, repo: string | undefined): string | undefined {
+  const normalizedOwner = nonEmpty(owner)?.replace(/^\/+|\/+$/g, '');
+  const normalizedRepo = nonEmpty(repo)?.replace(/^\/+|\/+$/g, '');
+  if (!normalizedOwner || !normalizedRepo) return undefined;
+  return normalizeRepo(`${normalizedOwner}/${normalizedRepo}`);
+}
+
+// Node stack traces can use file:// URLs when running through ESM/tsx.
+function stackPathToFilePath(filepath: string): string {
+  if (!filepath.startsWith('file://')) return filepath;
+  try {
+    return fileURLToPath(filepath);
+  } catch {
+    return filepath;
+  }
+}
+
+/**
+ * Harvests git context from common CI/deployment environment variables.
+ * Repo and ref are resolved independently, using the first platform that
+ * provides each field.
+ */
+export function harvestCiGitContext(env: Env = process.env): GitContext {
+  // Keep this order aligned with the documented resolution table.
+  const candidates: GitContext[] = [
+    {
+      gitRepo: normalizeRepo(env['GITHUB_REPOSITORY']),
+      gitRef: nonEmpty(env['GITHUB_SHA']),
+    },
+    {
+      gitRepo: joinRepo(env['VERCEL_GIT_REPO_OWNER'], env['VERCEL_GIT_REPO_SLUG']),
+      gitRef: nonEmpty(env['VERCEL_GIT_COMMIT_SHA']),
+    },
+    {
+      gitRepo: normalizeRepo(env['CI_PROJECT_PATH']),
+      gitRef: nonEmpty(env['CI_COMMIT_SHA']),
+    },
+    {
+      gitRepo: joinRepo(env['CIRCLE_PROJECT_USERNAME'], env['CIRCLE_PROJECT_REPONAME']),
+      gitRef: nonEmpty(env['CIRCLE_SHA1']),
+    },
+    {
+      gitRepo: normalizeRepo(env['BITBUCKET_REPO_FULL_NAME']),
+      gitRef: nonEmpty(env['BITBUCKET_COMMIT']),
+    },
+    {
+      gitRef: nonEmpty(env['RENDER_GIT_COMMIT']),
+    },
+  ];
+
+  const result: GitContext = {};
+  for (const candidate of candidates) {
+    // A platform may provide only repo or only ref, so fill each field separately.
+    if (result.gitRepo === undefined && candidate.gitRepo !== undefined) {
+      result.gitRepo = candidate.gitRepo;
+    }
+    if (result.gitRef === undefined && candidate.gitRef !== undefined) {
+      result.gitRef = candidate.gitRef;
+    }
+    if (result.gitRepo !== undefined && result.gitRef !== undefined) break;
+  }
+  return result;
+}
 
 export function getGitRoot(): string | undefined {
   if (_gitRootCache !== null) return _gitRootCache || undefined;
@@ -17,9 +101,15 @@ export function getGitRoot(): string | undefined {
 }
 
 function relativePath(filepath: string): string | undefined {
+  const normalizedFilepath = stackPathToFilePath(filepath).replaceAll('\\', '/');
   const gitRoot = getGitRoot();
-  if (gitRoot && filepath.startsWith(gitRoot)) {
-    return filepath.slice(gitRoot.length).replace(/^[/\\]/, '');
+  // Git and Node can disagree on slash style on Windows.
+  const normalizedGitRoot = gitRoot?.replaceAll('\\', '/');
+  if (
+    normalizedGitRoot &&
+    normalizedFilepath.toLowerCase().startsWith(normalizedGitRoot.toLowerCase())
+  ) {
+    return normalizedFilepath.slice(normalizedGitRoot.length).replace(/^[/\\]/, '');
   }
   // If we can't make the path relative, don't stamp it — avoid leaking absolute paths.
   return undefined;
@@ -40,10 +130,7 @@ export function autoDetectGitContext(): { gitRepo?: string; gitRef?: string } {
     }).trim();
 
     // Normalize to "owner/repo" — handles https, git@, ssh:// formats
-    const match = remote.match(/(?:https?:\/\/|ssh:\/\/git@|git@)github\.com[:/](.+?)(?:\.git)?$/);
-    if (match) {
-      gitRepo = match[1].replace(/\/$/, '');
-    }
+    gitRepo = normalizeRepo(remote);
   } catch {
     /* git unavailable */
   }
@@ -79,8 +166,9 @@ export function captureSourceLocation(): { file?: string; line?: number; functio
 
   const lines = stack.split('\n').slice(1); // remove "Error" header line
   for (const line of lines) {
-    if (line.includes('/packages/traceroot/src/')) continue;
-    if (line.includes('/node_modules/')) continue;
+    const normalizedLine = line.replaceAll('\\', '/');
+    if (normalizedLine.includes('/packages/traceroot/src/')) continue;
+    if (normalizedLine.includes('/node_modules/')) continue;
     if (line.includes('(node:')) continue; // skip Node.js built-in frames (e.g. node:internal/async_local_storage)
 
     // Parse "    at functionName (file:line:col)" or "    at file:line:col"

--- a/packages/traceroot/src/git_context.ts
+++ b/packages/traceroot/src/git_context.ts
@@ -52,13 +52,20 @@ function stackPathToFilePath(filepath: string): string {
   }
 }
 
-function pathStartsWithRoot(filepath: string, gitRoot: string): boolean {
+function isCaseInsensitivePlatform(platform = process.platform): boolean {
+  return platform === 'win32' || platform === 'darwin';
+}
+
+function pathStartsWithRoot(
+  filepath: string,
+  gitRoot: string,
+  platform = process.platform,
+): boolean {
   const normalizedFilepath = filepath.replaceAll('\\', '/');
   const normalizedGitRoot = gitRoot.replaceAll('\\', '/').replace(/\/+$/, '');
-  const compareFilepath =
-    process.platform === 'win32' ? normalizedFilepath.toLowerCase() : normalizedFilepath;
-  const compareGitRoot =
-    process.platform === 'win32' ? normalizedGitRoot.toLowerCase() : normalizedGitRoot;
+  const caseInsensitive = isCaseInsensitivePlatform(platform);
+  const compareFilepath = caseInsensitive ? normalizedFilepath.toLowerCase() : normalizedFilepath;
+  const compareGitRoot = caseInsensitive ? normalizedGitRoot.toLowerCase() : normalizedGitRoot;
 
   if (!compareFilepath.startsWith(compareGitRoot)) return false;
   const nextChar = compareFilepath[compareGitRoot.length];
@@ -125,11 +132,15 @@ export function getGitRoot(): string | undefined {
   return _gitRootCache || undefined;
 }
 
-function relativePath(filepath: string, gitRoot = getGitRoot()): string | undefined {
+function relativePath(
+  filepath: string,
+  gitRoot = getGitRoot(),
+  platform = process.platform,
+): string | undefined {
   const normalizedFilepath = stackPathToFilePath(filepath).replaceAll('\\', '/');
   // Git and Node can disagree on slash style on Windows.
   const normalizedGitRoot = gitRoot?.replaceAll('\\', '/').replace(/\/+$/, '');
-  if (normalizedGitRoot && pathStartsWithRoot(normalizedFilepath, normalizedGitRoot)) {
+  if (normalizedGitRoot && pathStartsWithRoot(normalizedFilepath, normalizedGitRoot, platform)) {
     return normalizedFilepath.slice(normalizedGitRoot.length).replace(/^[/\\]/, '');
   }
   // If we can't make the path relative, don't stamp it — avoid leaking absolute paths.
@@ -178,8 +189,12 @@ export function _resetGitContextCache(): void {
 }
 
 /** @internal — expose path handling without shelling out to git */
-export function _relativePathForTesting(filepath: string, gitRoot: string): string | undefined {
-  return relativePath(filepath, gitRoot);
+export function _relativePathForTesting(
+  filepath: string,
+  gitRoot: string,
+  platform = process.platform,
+): string | undefined {
+  return relativePath(filepath, gitRoot, platform);
 }
 
 /** @internal — expose remote parsing without shelling out to git */

--- a/packages/traceroot/src/git_context.ts
+++ b/packages/traceroot/src/git_context.ts
@@ -22,6 +22,18 @@ function normalizeRepo(value: string | undefined): string | undefined {
   return (match ? match[1] : repo).replace(/\.git$/, '').replace(/^\/+|\/+$/g, '') || undefined;
 }
 
+// Local git remotes should only stamp recognized URL forms, never raw filesystem paths.
+function normalizeRemoteRepo(value: string | undefined): string | undefined {
+  const remote = nonEmpty(value);
+  if (!remote) return undefined;
+
+  const match = remote.match(
+    /^(?:https?:\/\/[^/]+\/|ssh:\/\/git@[^/]+\/|git@[^:]+:)(.+?)(?:\.git)?$/,
+  );
+  if (!match) return undefined;
+  return match[1].replace(/\.git$/, '').replace(/^\/+|\/+$/g, '') || undefined;
+}
+
 // Some platforms split owner and repo name into separate env vars.
 function joinRepo(owner: string | undefined, repo: string | undefined): string | undefined {
   const normalizedOwner = nonEmpty(owner)?.replace(/^\/+|\/+$/g, '');
@@ -38,6 +50,19 @@ function stackPathToFilePath(filepath: string): string {
   } catch {
     return filepath;
   }
+}
+
+function pathStartsWithRoot(filepath: string, gitRoot: string): boolean {
+  const normalizedFilepath = filepath.replaceAll('\\', '/');
+  const normalizedGitRoot = gitRoot.replaceAll('\\', '/').replace(/\/+$/, '');
+  const compareFilepath =
+    process.platform === 'win32' ? normalizedFilepath.toLowerCase() : normalizedFilepath;
+  const compareGitRoot =
+    process.platform === 'win32' ? normalizedGitRoot.toLowerCase() : normalizedGitRoot;
+
+  if (!compareFilepath.startsWith(compareGitRoot)) return false;
+  const nextChar = compareFilepath[compareGitRoot.length];
+  return nextChar === undefined || nextChar === '/';
 }
 
 /**
@@ -100,15 +125,11 @@ export function getGitRoot(): string | undefined {
   return _gitRootCache || undefined;
 }
 
-function relativePath(filepath: string): string | undefined {
+function relativePath(filepath: string, gitRoot = getGitRoot()): string | undefined {
   const normalizedFilepath = stackPathToFilePath(filepath).replaceAll('\\', '/');
-  const gitRoot = getGitRoot();
   // Git and Node can disagree on slash style on Windows.
-  const normalizedGitRoot = gitRoot?.replaceAll('\\', '/');
-  if (
-    normalizedGitRoot &&
-    normalizedFilepath.toLowerCase().startsWith(normalizedGitRoot.toLowerCase())
-  ) {
+  const normalizedGitRoot = gitRoot?.replaceAll('\\', '/').replace(/\/+$/, '');
+  if (normalizedGitRoot && pathStartsWithRoot(normalizedFilepath, normalizedGitRoot)) {
     return normalizedFilepath.slice(normalizedGitRoot.length).replace(/^[/\\]/, '');
   }
   // If we can't make the path relative, don't stamp it — avoid leaking absolute paths.
@@ -130,7 +151,7 @@ export function autoDetectGitContext(): { gitRepo?: string; gitRef?: string } {
     }).trim();
 
     // Normalize to "owner/repo" — handles https, git@, ssh:// formats
-    gitRepo = normalizeRepo(remote);
+    gitRepo = normalizeRemoteRepo(remote);
   } catch {
     /* git unavailable */
   }
@@ -154,6 +175,16 @@ export function autoDetectGitContext(): { gitRepo?: string; gitRef?: string } {
 /** @internal — reset cached git root between tests */
 export function _resetGitContextCache(): void {
   _gitRootCache = null;
+}
+
+/** @internal — expose path handling without shelling out to git */
+export function _relativePathForTesting(filepath: string, gitRoot: string): string | undefined {
+  return relativePath(filepath, gitRoot);
+}
+
+/** @internal — expose remote parsing without shelling out to git */
+export function _normalizeRemoteRepoForTesting(remote: string): string | undefined {
+  return normalizeRemoteRepo(remote);
 }
 
 /**

--- a/packages/traceroot/src/traceroot.ts
+++ b/packages/traceroot/src/traceroot.ts
@@ -18,12 +18,29 @@ import { SDK_NAME, SDK_VERSION, TraceRootSpanProcessor } from './processor';
 import { wireInstrumentations } from './instrumentation';
 import { DEFAULT_FLUSH_AT, DEFAULT_FLUSH_INTERVAL_SEC, DEFAULT_TIMEOUT_SEC } from './constants';
 import { _resetObserveState } from './observe';
-import { autoDetectGitContext, getGitRoot, _resetGitContextCache } from './git_context';
+import {
+  autoDetectGitContext,
+  getGitRoot,
+  harvestCiGitContext,
+  _resetGitContextCache,
+} from './git_context';
 
 const DEFAULT_BASE_URL = 'https://app.traceroot.ai';
 
 let _isInitialized = false;
 let _provider: NodeTracerProvider | undefined;
+let _warnedMissingGitContext = false;
+
+// Avoid noisy logs when initialize() is retried without deploy-time git metadata.
+function warnMissingGitContextOnce(): void {
+  if (_warnedMissingGitContext) return;
+  _warnedMissingGitContext = true;
+  console.warn(
+    '[TraceRoot] Git context could not be resolved. Set TRACEROOT_GIT_REPO and ' +
+      'TRACEROOT_GIT_REF in production so traces can be correlated to source code. ' +
+      'See https://docs.traceroot.ai/tracing/git-context',
+  );
+}
 
 export class TraceRoot {
   private constructor() {}
@@ -87,12 +104,26 @@ export class TraceRoot {
     const gitRefOverride = options.gitRef ?? process.env['TRACEROOT_GIT_REF'];
     let gitRepo = gitRepoOverride;
     let gitRef = gitRefOverride;
+
+    // Production containers usually lack .git, so prefer CI/deploy metadata before local git.
+    if (gitRepo === undefined || gitRef === undefined) {
+      const ciGit = harvestCiGitContext();
+      gitRepo ??= ciGit.gitRepo;
+      gitRef ??= ciGit.gitRef;
+    }
+
+    // Local git detection remains the development fallback after explicit and env sources.
     if (gitRepo === undefined || gitRef === undefined) {
       const autoGit = autoDetectGitContext();
       gitRepo ??= autoGit.gitRepo;
       gitRef ??= autoGit.gitRef;
     } else {
       getGitRoot();
+    }
+
+    // Do not fabricate partial defaults; missing git context is omitted from spans.
+    if (gitRepo === undefined && gitRef === undefined) {
+      warnMissingGitContextOnce();
     }
 
     // Flush/batch tuning — env vars take precedence over SDK defaults.
@@ -147,6 +178,7 @@ export class TraceRoot {
 export function _resetForTesting(): void {
   _isInitialized = false;
   _provider = undefined;
+  _warnedMissingGitContext = false;
   _resetObserveState();
   _resetGitContextCache();
   trace.disable();

--- a/packages/traceroot/src/types.ts
+++ b/packages/traceroot/src/types.ts
@@ -81,12 +81,12 @@ export interface InitializeOptions {
   environment?: string;
   /**
    * Git repository in normalized 'owner/repo' form (e.g. 'acme/my-service').
-   * Falls back to TRACEROOT_GIT_REPO env var, then auto-detected via `git remote get-url origin`.
+   * Falls back to TRACEROOT_GIT_REPO env var, CI/platform env vars, then local git detection.
    */
   gitRepo?: string;
   /**
    * Git commit SHA (typically a 40-character hash). Falls back to TRACEROOT_GIT_REF env var,
-   * then auto-detected via `git rev-parse HEAD`.
+   * CI/platform env vars, then local git detection.
    */
   gitRef?: string;
 }

--- a/packages/traceroot/tests/git_context.test.ts
+++ b/packages/traceroot/tests/git_context.test.ts
@@ -2,6 +2,8 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import {
+  _normalizeRemoteRepoForTesting,
+  _relativePathForTesting,
   autoDetectGitContext,
   captureSourceLocation,
   harvestCiGitContext,
@@ -167,6 +169,28 @@ describe('autoDetectGitContext()', () => {
   });
 });
 
+describe('git remote normalization', () => {
+  it('normalizes HTTPS git remotes', () => {
+    assert.equal(_normalizeRemoteRepoForTesting('https://github.com/acme/api.git'), 'acme/api');
+  });
+
+  it('normalizes SSH git remotes', () => {
+    assert.equal(_normalizeRemoteRepoForTesting('git@github.com:acme/api.git'), 'acme/api');
+  });
+
+  it('normalizes ssh:// git remotes', () => {
+    assert.equal(_normalizeRemoteRepoForTesting('ssh://git@github.com/acme/api.git'), 'acme/api');
+  });
+
+  it('rejects local filesystem git remotes', () => {
+    assert.equal(_normalizeRemoteRepoForTesting('/tmp/acme/api.git'), undefined);
+  });
+
+  it('rejects non-URL remote names', () => {
+    assert.equal(_normalizeRemoteRepoForTesting('acme/api'), undefined);
+  });
+});
+
 describe('captureSourceLocation()', () => {
   it('returns an object with file and line when called from user code', () => {
     const result = captureSourceLocation();
@@ -218,5 +242,29 @@ describe('captureSourceLocation()', () => {
         `functionName should include "myTestFn", got: ${result.functionName}`,
       );
     }
+  });
+});
+
+describe('relative path handling', () => {
+  it('does not treat a sibling path with the same prefix as inside the repo', () => {
+    assert.equal(_relativePathForTesting('/tmp/repo-other/src/app.ts', '/tmp/repo'), undefined);
+  });
+
+  it('returns a relative path when the file is inside the repo', () => {
+    assert.equal(_relativePathForTesting('/tmp/repo/src/app.ts', '/tmp/repo'), 'src/app.ts');
+  });
+
+  it('does not treat a Windows sibling path with the same prefix as inside the repo', () => {
+    assert.equal(
+      _relativePathForTesting('C:\\work\\repo-other\\src\\app.ts', 'C:\\work\\repo'),
+      undefined,
+    );
+  });
+
+  it('returns a slash-normalized relative path for Windows repo files', () => {
+    assert.equal(
+      _relativePathForTesting('C:\\work\\repo\\src\\app.ts', 'C:\\work\\repo'),
+      'src/app.ts',
+    );
   });
 });

--- a/packages/traceroot/tests/git_context.test.ts
+++ b/packages/traceroot/tests/git_context.test.ts
@@ -1,7 +1,127 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
-import { autoDetectGitContext, captureSourceLocation } from '../src/git_context';
+import {
+  autoDetectGitContext,
+  captureSourceLocation,
+  harvestCiGitContext,
+} from '../src/git_context';
+
+describe('harvestCiGitContext()', () => {
+  it('resolves GitHub Actions env vars', () => {
+    assert.deepEqual(
+      harvestCiGitContext({
+        GITHUB_REPOSITORY: 'acme/api',
+        GITHUB_SHA: '1111111111111111111111111111111111111111',
+      }),
+      {
+        gitRepo: 'acme/api',
+        gitRef: '1111111111111111111111111111111111111111',
+      },
+    );
+  });
+
+  it('resolves Vercel env vars', () => {
+    assert.deepEqual(
+      harvestCiGitContext({
+        VERCEL_GIT_REPO_OWNER: 'acme',
+        VERCEL_GIT_REPO_SLUG: 'web',
+        VERCEL_GIT_COMMIT_SHA: '2222222222222222222222222222222222222222',
+      }),
+      {
+        gitRepo: 'acme/web',
+        gitRef: '2222222222222222222222222222222222222222',
+      },
+    );
+  });
+
+  it('resolves GitLab CI env vars', () => {
+    assert.deepEqual(
+      harvestCiGitContext({
+        CI_PROJECT_PATH: 'acme/worker',
+        CI_COMMIT_SHA: '3333333333333333333333333333333333333333',
+      }),
+      {
+        gitRepo: 'acme/worker',
+        gitRef: '3333333333333333333333333333333333333333',
+      },
+    );
+  });
+
+  it('resolves CircleCI env vars', () => {
+    assert.deepEqual(
+      harvestCiGitContext({
+        CIRCLE_PROJECT_USERNAME: 'acme',
+        CIRCLE_PROJECT_REPONAME: 'jobs',
+        CIRCLE_SHA1: '4444444444444444444444444444444444444444',
+      }),
+      {
+        gitRepo: 'acme/jobs',
+        gitRef: '4444444444444444444444444444444444444444',
+      },
+    );
+  });
+
+  it('resolves Bitbucket env vars', () => {
+    assert.deepEqual(
+      harvestCiGitContext({
+        BITBUCKET_REPO_FULL_NAME: 'acme/data',
+        BITBUCKET_COMMIT: '5555555555555555555555555555555555555555',
+      }),
+      {
+        gitRepo: 'acme/data',
+        gitRef: '5555555555555555555555555555555555555555',
+      },
+    );
+  });
+
+  it('resolves Render commit env var independently', () => {
+    // Render exposes the commit SHA but not a standard owner/repo variable.
+    assert.deepEqual(
+      harvestCiGitContext({
+        RENDER_GIT_COMMIT: '6666666666666666666666666666666666666666',
+      }),
+      {
+        gitRef: '6666666666666666666666666666666666666666',
+      },
+    );
+  });
+
+  it('returns empty context for empty env', () => {
+    assert.deepEqual(harvestCiGitContext({}), {});
+  });
+
+  it('uses first-platform-wins precedence per field', () => {
+    // GitHub Actions appears before Vercel in the resolver ladder.
+    assert.deepEqual(
+      harvestCiGitContext({
+        GITHUB_REPOSITORY: 'acme/github',
+        GITHUB_SHA: '7777777777777777777777777777777777777777',
+        VERCEL_GIT_REPO_OWNER: 'acme',
+        VERCEL_GIT_REPO_SLUG: 'vercel',
+        VERCEL_GIT_COMMIT_SHA: '8888888888888888888888888888888888888888',
+      }),
+      {
+        gitRepo: 'acme/github',
+        gitRef: '7777777777777777777777777777777777777777',
+      },
+    );
+  });
+
+  it('resolves repo and ref independently', () => {
+    // Mixed env sources are valid when the first platform only provides one field.
+    assert.deepEqual(
+      harvestCiGitContext({
+        GITHUB_REPOSITORY: 'acme/github',
+        VERCEL_GIT_COMMIT_SHA: '9999999999999999999999999999999999999999',
+      }),
+      {
+        gitRepo: 'acme/github',
+        gitRef: '9999999999999999999999999999999999999999',
+      },
+    );
+  });
+});
 
 describe('autoDetectGitContext()', () => {
   it('returns an object (possibly empty)', () => {

--- a/packages/traceroot/tests/git_context.test.ts
+++ b/packages/traceroot/tests/git_context.test.ts
@@ -267,4 +267,18 @@ describe('relative path handling', () => {
       'src/app.ts',
     );
   });
+
+  it('matches macOS repo paths case-insensitively', () => {
+    assert.equal(
+      _relativePathForTesting('/Users/Gabe/Repo/src/app.ts', '/users/gabe/repo', 'darwin'),
+      'src/app.ts',
+    );
+  });
+
+  it('keeps Linux repo path matching case-sensitive', () => {
+    assert.equal(
+      _relativePathForTesting('/Users/Gabe/Repo/src/app.ts', '/users/gabe/repo', 'linux'),
+      undefined,
+    );
+  });
 });

--- a/packages/traceroot/tests/initialize.test.ts
+++ b/packages/traceroot/tests/initialize.test.ts
@@ -3,6 +3,49 @@ import assert from 'node:assert/strict';
 import { TraceRoot, _resetForTesting } from '../src/traceroot';
 import { TraceRootSpanProcessor } from '../src/processor';
 
+const GIT_ENV_KEYS = [
+  'TRACEROOT_GIT_REPO',
+  'TRACEROOT_GIT_REF',
+  'GITHUB_REPOSITORY',
+  'GITHUB_SHA',
+  'VERCEL_GIT_REPO_OWNER',
+  'VERCEL_GIT_REPO_SLUG',
+  'VERCEL_GIT_COMMIT_SHA',
+  'CI_PROJECT_PATH',
+  'CI_COMMIT_SHA',
+  'CIRCLE_PROJECT_USERNAME',
+  'CIRCLE_PROJECT_REPONAME',
+  'CIRCLE_SHA1',
+  'BITBUCKET_REPO_FULL_NAME',
+  'BITBUCKET_COMMIT',
+  'RENDER_GIT_COMMIT',
+  'PATH',
+] as const;
+
+// Force the unresolved-git path by clearing both deploy metadata and local git access.
+function withGitEnvCleared(fn: () => void): void {
+  const previous = new Map<string, string | undefined>();
+  for (const key of GIT_ENV_KEYS) {
+    previous.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  // Prevent autoDetectGitContext() from finding a git binary on the developer machine.
+  process.env['PATH'] = '';
+
+  try {
+    fn();
+  } finally {
+    for (const key of GIT_ENV_KEYS) {
+      const value = previous.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
 describe('TraceRoot.initialize()', () => {
   afterEach(() => {
     _resetForTesting();
@@ -88,6 +131,26 @@ describe('TraceRoot.initialize()', () => {
   it('completes initialization without error when environment is provided', () => {
     TraceRoot.initialize({ apiKey: 'test-key', disableBatch: true, environment: 'prod' });
     assert.equal(TraceRoot.isInitialized(), true);
+  });
+
+  it('warns once when git context cannot be resolved', () => {
+    const messages: string[] = [];
+    const restore = console.warn;
+    console.warn = (...args: unknown[]) => {
+      messages.push(args.join(' '));
+    };
+    try {
+      withGitEnvCleared(() => {
+        assert.doesNotThrow(() => {
+          TraceRoot.initialize({ apiKey: 'test-key', disableBatch: true });
+        });
+      });
+      const gitWarnings = messages.filter((m) => m.includes('Git context could not be resolved'));
+      assert.equal(gitWarnings.length, 1);
+      assert.ok(gitWarnings[0].includes('https://docs.traceroot.ai/tracing/git-context'));
+    } finally {
+      console.warn = restore;
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes traceroot-ai/traceroot#1023

Adds CI/platform git context resolution before local git auto-detection.

## Changes

- Added `harvestCiGitContext(env)` for CI/deploy metadata.
- Wired resolution as `explicit args -> TRACEROOT_GIT_* -> CI/platform env -> local git -> warn once`.
- Added warn-once behavior when git context remains unresolved.
- Kept unresolved fields omitted instead of fabricating values.
- Normalized Windows stack paths for existing source-location tests.

## Acceptance Criteria

- [x] `harvestCiGitContext(env)` returns `{ gitRepo?, gitRef? }`, normalizes repo to `owner/repo`, and resolves repo/ref independently.
- [x] Covers GitHub Actions, Vercel, GitLab CI, CircleCI, Bitbucket, Render, empty env, and first-platform-wins precedence.
- [x] Resolution is wired between `TRACEROOT_GIT_*` and local git detection.
- [x] Missing git context warns once, does not throw, and does not create default values.
- [x] Tests cover platform rows, empty env, precedence, independent fields, and warn-once behavior.
- [x] Test, typecheck, lint, and format checks pass.

## Design Decisions

- CI/platform resolution is a pure helper so env behavior is easy to test.
- Repo and ref are filled separately because some platforms provide only one field.
- Local git detection remains the development fallback.
- The warning fires only when both repo and ref are unresolved, matching the issue wording.
- Windows path normalization was included because the full suite failed on existing source-location tests on Windows.

## Validation

```text
pnpm --filter @traceroot-ai/traceroot test
pnpm --filter @traceroot-ai/traceroot typecheck
pnpm --filter @traceroot-ai/traceroot lint
pnpm format:check
```

## Follow-Up Considerations

- Consider injectable git auto-detection to avoid clearing `PATH` in tests.
- Consider warning when either repo or ref is missing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve git repo/ref in the TS SDK from CI env vars before local git, and harden path and remote parsing across platforms. This prevents missing git context in production and avoids invalid repo stamping or absolute path leaks.

- Bug Fixes
  - Added `harvestCiGitContext()` to read git repo/ref from CI env vars (GitHub Actions, Vercel, GitLab CI, CircleCI, Bitbucket, Render), resolving fields independently and normalizing `owner/repo`.
  - Updated resolution order: explicit options → `TRACEROOT_GIT_*` → CI/platform env → local git. No fabricated defaults.
  - Warn once when both repo and ref are missing; omit fields instead of guessing.
  - Safer path handling: normalize `file://` stack paths and Windows slashes, prevent prefix collisions, handle macOS case-insensitive repo paths, and never emit absolute paths.
  - Safer remote parsing: accept only https/ssh/git@ URL forms; ignore local filesystem paths and bare names. Expanded tests for platforms, precedence, independent fields, warn-once, remote parsing, and path edges.

<sup>Written for commit e0b3b65f16ef80b463b3dade7eadb9c4bf29b5e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-ts/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

