### PR TITLE
Production-grade git context: CI env + .git-file resolution, warn-on-missing

### DIFF
--- a/packages/traceroot/src/constants.ts
+++ b/packages/traceroot/src/constants.ts
@@ -1,5 +1,9 @@
 // src/constants.ts — TraceRoot-specific span attribute keys and SDK defaults
 
+// GitHub Actions environment variable names used for git-context harvesting.
+export const GITHUB_REPOSITORY = 'GITHUB_REPOSITORY';
+export const GITHUB_SHA = 'GITHUB_SHA';
+
 // Flush/batch defaults — mirror traceroot-py/traceroot/constants.py
 export const DEFAULT_FLUSH_INTERVAL_SEC = 5; // seconds → BatchSpanProcessor scheduledDelayMillis (×1000)
 export const DEFAULT_FLUSH_AT = 100; // BatchSpanProcessor maxExportBatchSize

--- a/packages/traceroot/src/git_context.ts
+++ b/packages/traceroot/src/git_context.ts
@@ -73,8 +73,29 @@ export function gitContextFromFiles(cwd: string = process.cwd()): {
     } else {
       const rm = head.match(/ref:\s+(\S+)/);
       if (rm) {
-        const refContent = readFileSync(join(gitDir, rm[1]), 'utf8').trim();
-        if (SHA_RE.test(refContent)) gitRef = refContent;
+        const refPath = rm[1]; // e.g. refs/heads/main
+        try {
+          const loose = readFileSync(join(gitDir, refPath), 'utf8').trim();
+          if (SHA_RE.test(loose)) gitRef = loose;
+        } catch {
+          /* loose ref missing — the ref may be packed */
+        }
+        if (gitRef === undefined) {
+          try {
+            // Packed refs (after `git gc`/fresh clone): `<sha> refs/heads/main`.
+            const packed = readFileSync(join(gitDir, 'packed-refs'), 'utf8');
+            for (const line of packed.split(/\r?\n/)) {
+              if (!line || line[0] === '#' || line[0] === '^') continue;
+              const m = line.match(/^([0-9a-f]{40,64})\s+(.+)$/);
+              if (m && m[2] === refPath) {
+                gitRef = m[1];
+                break;
+              }
+            }
+          } catch {
+            /* no packed-refs */
+          }
+        }
       }
     }
   } catch {
@@ -129,9 +150,10 @@ export function autoDetectGitContext(): { gitRepo?: string; gitRef?: string } {
  *
  * repo and ref are resolved independently (a build may provide one, not both).
  */
-export function harvestCiGitContext(
-  env: NodeJS.ProcessEnv = process.env,
-): { gitRepo?: string; gitRef?: string } {
+export function harvestCiGitContext(env: NodeJS.ProcessEnv = process.env): {
+  gitRepo?: string;
+  gitRef?: string;
+} {
   return {
     gitRepo: env[GITHUB_REPOSITORY] || undefined,
     gitRef: env[GITHUB_SHA] || undefined,

--- a/packages/traceroot/src/git_context.ts
+++ b/packages/traceroot/src/git_context.ts
@@ -1,5 +1,11 @@
 // src/git_context.ts
 import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { GITHUB_REPOSITORY, GITHUB_SHA } from './constants';
+
+const REPO_URL_RE = /(?:https?:\/\/|ssh:\/\/git@|git@)github\.com[:/](.+?)(?:\.git)?$/;
+const SHA_RE = /^[0-9a-f]{40}$/;
 
 let _gitRootCache: string | null = null; // null = not yet detected, '' = failed
 
@@ -26,6 +32,59 @@ function relativePath(filepath: string): string | undefined {
 }
 
 /**
+ * Read git context directly from `.git` files (no `git` subprocess).
+ * Works in containers that ship a `.git` dir but no `git` binary.
+ * Only inspects `<cwd>/.git` (does not walk parent directories).
+ */
+export function gitContextFromFiles(cwd: string = process.cwd()): {
+  gitRepo?: string;
+  gitRef?: string;
+} {
+  const gitDir = join(cwd, '.git');
+  let gitRepo: string | undefined;
+  let gitRef: string | undefined;
+
+  try {
+    const config = readFileSync(join(gitDir, 'config'), 'utf8');
+    let seenOrigin = false;
+    for (const line of config.split(/\r?\n/)) {
+      if (/^\[remote "origin"\]/.test(line)) {
+        seenOrigin = true;
+        continue;
+      }
+      if (seenOrigin && line.startsWith('[')) break; // left the origin section
+      if (seenOrigin) {
+        const m = line.match(/\burl\s*=\s*(.+)$/);
+        if (m) {
+          const rm = m[1].trim().match(REPO_URL_RE);
+          if (rm) gitRepo = rm[1].replace(/\/$/, '');
+          break;
+        }
+      }
+    }
+  } catch {
+    /* no .git/config */
+  }
+
+  try {
+    const head = readFileSync(join(gitDir, 'HEAD'), 'utf8').trim();
+    if (SHA_RE.test(head)) {
+      gitRef = head;
+    } else {
+      const rm = head.match(/ref:\s+(\S+)/);
+      if (rm) {
+        const refContent = readFileSync(join(gitDir, rm[1]), 'utf8').trim();
+        if (SHA_RE.test(refContent)) gitRef = refContent;
+      }
+    }
+  } catch {
+    /* no .git/HEAD */
+  }
+
+  return { gitRepo, gitRef };
+}
+
+/**
  * Auto-detects git repo (as "owner/repo") and current commit ref.
  * Returns an empty object if git is unavailable or any command fails.
  */
@@ -40,7 +99,7 @@ export function autoDetectGitContext(): { gitRepo?: string; gitRef?: string } {
     }).trim();
 
     // Normalize to "owner/repo" — handles https, git@, ssh:// formats
-    const match = remote.match(/(?:https?:\/\/|ssh:\/\/git@|git@)github\.com[:/](.+?)(?:\.git)?$/);
+    const match = remote.match(REPO_URL_RE);
     if (match) {
       gitRepo = match[1].replace(/\/$/, '');
     }
@@ -62,6 +121,21 @@ export function autoDetectGitContext(): { gitRepo?: string; gitRef?: string } {
   getGitRoot();
 
   return { gitRepo, gitRef };
+}
+
+/**
+ * Resolve git context from GitHub Actions environment variables —
+ * `GITHUB_REPOSITORY` (owner/repo) and `GITHUB_SHA`.
+ *
+ * repo and ref are resolved independently (a build may provide one, not both).
+ */
+export function harvestCiGitContext(
+  env: NodeJS.ProcessEnv = process.env,
+): { gitRepo?: string; gitRef?: string } {
+  return {
+    gitRepo: env[GITHUB_REPOSITORY] || undefined,
+    gitRef: env[GITHUB_SHA] || undefined,
+  };
 }
 
 /** @internal — reset cached git root between tests */

--- a/packages/traceroot/src/git_context.ts
+++ b/packages/traceroot/src/git_context.ts
@@ -86,7 +86,8 @@ export function gitContextFromFiles(cwd: string = process.cwd()): {
             const packed = readFileSync(join(gitDir, 'packed-refs'), 'utf8');
             for (const line of packed.split(/\r?\n/)) {
               if (!line || line[0] === '#' || line[0] === '^') continue;
-              const m = line.match(/^([0-9a-f]{40,64})\s+(.+)$/);
+              // Object IDs are exactly 40 (SHA-1) or 64 (SHA-256) hex chars.
+              const m = line.match(/^([0-9a-f]{40}|[0-9a-f]{64})\s+(.+)$/);
               if (m && m[2] === refPath) {
                 gitRef = m[1];
                 break;

--- a/packages/traceroot/src/traceroot.ts
+++ b/packages/traceroot/src/traceroot.ts
@@ -89,10 +89,10 @@ export class TraceRoot {
 
     const environment = options.environment ?? process.env['TRACEROOT_ENVIRONMENT'];
 
-    const gitRepoOverride = options.gitRepo ?? process.env['TRACEROOT_GIT_REPO'];
-    const gitRefOverride = options.gitRef ?? process.env['TRACEROOT_GIT_REF'];
-    let gitRepo = gitRepoOverride;
-    let gitRef = gitRefOverride;
+    // `|| undefined` so an empty option/env var ('') is treated as unset —
+    // otherwise it would block fallback detection and suppress the warning.
+    let gitRepo = options.gitRepo || process.env['TRACEROOT_GIT_REPO'] || undefined;
+    let gitRef = options.gitRef || process.env['TRACEROOT_GIT_REF'] || undefined;
 
     // CI/platform env vars — production path (no .git needed).
     if (gitRepo === undefined || gitRef === undefined) {

--- a/packages/traceroot/src/traceroot.ts
+++ b/packages/traceroot/src/traceroot.ts
@@ -18,7 +18,7 @@ import { SDK_NAME, SDK_VERSION, TraceRootSpanProcessor } from './processor';
 import { wireInstrumentations } from './instrumentation';
 import { DEFAULT_FLUSH_AT, DEFAULT_FLUSH_INTERVAL_SEC, DEFAULT_TIMEOUT_SEC } from './constants';
 import { _resetObserveState } from './observe';
-import { autoDetectGitContext, getGitRoot, _resetGitContextCache } from './git_context';
+import { autoDetectGitContext, getGitRoot, harvestCiGitContext, gitContextFromFiles, _resetGitContextCache } from './git_context';
 
 const DEFAULT_BASE_URL = 'https://app.traceroot.ai';
 
@@ -87,12 +87,42 @@ export class TraceRoot {
     const gitRefOverride = options.gitRef ?? process.env['TRACEROOT_GIT_REF'];
     let gitRepo = gitRepoOverride;
     let gitRef = gitRefOverride;
+
+    // CI/platform env vars — production path (no .git needed).
+    if (gitRepo === undefined || gitRef === undefined) {
+      const ci = harvestCiGitContext();
+      gitRepo ??= ci.gitRepo;
+      gitRef ??= ci.gitRef;
+    }
+
+    // .git read as files — dev fallback, no git binary required.
+    if (gitRepo === undefined || gitRef === undefined) {
+      const fromFiles = gitContextFromFiles();
+      gitRepo ??= fromFiles.gitRepo;
+      gitRef ??= fromFiles.gitRef;
+    }
+
+    // git subprocess — last resort (handles run-from-subdirectory).
     if (gitRepo === undefined || gitRef === undefined) {
       const autoGit = autoDetectGitContext();
       gitRepo ??= autoGit.gitRepo;
       gitRef ??= autoGit.gitRef;
-    } else {
-      getGitRoot();
+    }
+
+    // Warm git-root cache for per-span source paths (cached/idempotent).
+    getGitRoot();
+
+    // Honest absence: warn once, never fabricate.
+    if (gitRepo === undefined || gitRef === undefined) {
+      console.warn(
+        '[TraceRoot] git context incomplete (repo=' +
+          (gitRepo ?? 'unset') +
+          ', ref=' +
+          (gitRef ?? 'unset') +
+          '). The AI agent needs both to correlate traces to source. ' +
+          'Set TRACEROOT_GIT_REPO / TRACEROOT_GIT_REF (see ' +
+          'https://docs.traceroot.ai/tracing/git-context).',
+      );
     }
 
     // Flush/batch tuning — env vars take precedence over SDK defaults.

--- a/packages/traceroot/src/traceroot.ts
+++ b/packages/traceroot/src/traceroot.ts
@@ -18,7 +18,13 @@ import { SDK_NAME, SDK_VERSION, TraceRootSpanProcessor } from './processor';
 import { wireInstrumentations } from './instrumentation';
 import { DEFAULT_FLUSH_AT, DEFAULT_FLUSH_INTERVAL_SEC, DEFAULT_TIMEOUT_SEC } from './constants';
 import { _resetObserveState } from './observe';
-import { autoDetectGitContext, getGitRoot, harvestCiGitContext, gitContextFromFiles, _resetGitContextCache } from './git_context';
+import {
+  autoDetectGitContext,
+  getGitRoot,
+  harvestCiGitContext,
+  gitContextFromFiles,
+  _resetGitContextCache,
+} from './git_context';
 
 const DEFAULT_BASE_URL = 'https://app.traceroot.ai';
 

--- a/packages/traceroot/tests/git_context.test.ts
+++ b/packages/traceroot/tests/git_context.test.ts
@@ -1,7 +1,9 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
-import { autoDetectGitContext, captureSourceLocation } from '../src/git_context';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import { autoDetectGitContext, captureSourceLocation, harvestCiGitContext, gitContextFromFiles } from '../src/git_context';
 
 describe('autoDetectGitContext()', () => {
   it('returns an object (possibly empty)', () => {
@@ -44,6 +46,85 @@ describe('autoDetectGitContext()', () => {
       result = autoDetectGitContext();
     });
     assert.ok(result !== null && typeof result === 'object');
+  });
+});
+
+describe('harvestCiGitContext()', () => {
+  it('reads GitHub Actions vars', () => {
+    const r = harvestCiGitContext({
+      GITHUB_REPOSITORY: 'acme/web',
+      GITHUB_SHA: 'a'.repeat(40),
+    } as NodeJS.ProcessEnv);
+    assert.equal(r.gitRepo, 'acme/web');
+    assert.equal(r.gitRef, 'a'.repeat(40));
+  });
+
+  it('returns empty object when no CI vars set', () => {
+    const r = harvestCiGitContext({} as NodeJS.ProcessEnv);
+    assert.equal(r.gitRepo, undefined);
+    assert.equal(r.gitRef, undefined);
+  });
+
+  it('treats empty-string GITHUB_REPOSITORY as absent', () => {
+    const r = harvestCiGitContext({ GITHUB_REPOSITORY: '' } as NodeJS.ProcessEnv);
+    assert.equal(r.gitRepo, undefined);
+  });
+});
+
+describe('gitContextFromFiles()', () => {
+  it('reads owner/repo from config and detached SHA from HEAD', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'tr-git-'));
+    const gitDir = path.join(dir, '.git');
+    mkdirSync(gitDir, { recursive: true });
+    writeFileSync(
+      path.join(gitDir, 'config'),
+      '[remote "origin"]\n\turl = git@github.com:acme/web.git\n',
+    );
+    writeFileSync(path.join(gitDir, 'HEAD'), 'f'.repeat(40) + '\n');
+    const r = gitContextFromFiles(dir);
+    assert.equal(r.gitRepo, 'acme/web');
+    assert.equal(r.gitRef, 'f'.repeat(40));
+  });
+
+  it('resolves ref-based HEAD via refs file', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'tr-git-'));
+    const gitDir = path.join(dir, '.git');
+    mkdirSync(path.join(gitDir, 'refs', 'heads'), { recursive: true });
+    writeFileSync(path.join(gitDir, 'HEAD'), 'ref: refs/heads/main\n');
+    writeFileSync(path.join(gitDir, 'refs', 'heads', 'main'), '1'.repeat(40) + '\n');
+    const r = gitContextFromFiles(dir);
+    assert.equal(r.gitRef, '1'.repeat(40));
+  });
+
+  it('parses https remote url form', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'tr-git-'));
+    const gitDir = path.join(dir, '.git');
+    mkdirSync(gitDir, { recursive: true });
+    writeFileSync(
+      path.join(gitDir, 'config'),
+      '[remote "origin"]\n\turl = https://github.com/acme/web.git\n',
+    );
+    const r = gitContextFromFiles(dir);
+    assert.equal(r.gitRepo, 'acme/web');
+  });
+
+  it('prefers url over pushurl in the origin section', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'tr-git-'));
+    const gitDir = path.join(dir, '.git');
+    mkdirSync(gitDir, { recursive: true });
+    writeFileSync(
+      path.join(gitDir, 'config'),
+      '[remote "origin"]\n\tpushurl = git@github.com:acme/push-mirror.git\n\turl = git@github.com:acme/web.git\n',
+    );
+    const r = gitContextFromFiles(dir);
+    assert.equal(r.gitRepo, 'acme/web');
+  });
+
+  it('returns empty when no .git dir', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'tr-git-'));
+    const r = gitContextFromFiles(dir);
+    assert.equal(r.gitRepo, undefined);
+    assert.equal(r.gitRef, undefined);
   });
 });
 

--- a/packages/traceroot/tests/git_context.test.ts
+++ b/packages/traceroot/tests/git_context.test.ts
@@ -3,7 +3,12 @@ import assert from 'node:assert/strict';
 import path from 'node:path';
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
-import { autoDetectGitContext, captureSourceLocation, harvestCiGitContext, gitContextFromFiles } from '../src/git_context';
+import {
+  autoDetectGitContext,
+  captureSourceLocation,
+  harvestCiGitContext,
+  gitContextFromFiles,
+} from '../src/git_context';
 
 describe('autoDetectGitContext()', () => {
   it('returns an object (possibly empty)', () => {
@@ -94,6 +99,19 @@ describe('gitContextFromFiles()', () => {
     writeFileSync(path.join(gitDir, 'refs', 'heads', 'main'), '1'.repeat(40) + '\n');
     const r = gitContextFromFiles(dir);
     assert.equal(r.gitRef, '1'.repeat(40));
+  });
+
+  it('resolves ref-based HEAD from packed-refs when the loose ref is absent', () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'tr-git-'));
+    const gitDir = path.join(dir, '.git');
+    mkdirSync(gitDir, { recursive: true });
+    writeFileSync(path.join(gitDir, 'HEAD'), 'ref: refs/heads/main\n');
+    writeFileSync(
+      path.join(gitDir, 'packed-refs'),
+      '# pack-refs with: peeled fully-peeled sorted\n' + '2'.repeat(40) + ' refs/heads/main\n',
+    );
+    const r = gitContextFromFiles(dir);
+    assert.equal(r.gitRef, '2'.repeat(40));
   });
 
   it('parses https remote url form', () => {

--- a/packages/traceroot/tests/initialize.test.ts
+++ b/packages/traceroot/tests/initialize.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { TraceRoot, _resetForTesting } from '../src/traceroot';
 import { TraceRootSpanProcessor } from '../src/processor';
 
@@ -88,6 +91,69 @@ describe('TraceRoot.initialize()', () => {
   it('completes initialization without error when environment is provided', () => {
     TraceRoot.initialize({ apiKey: 'test-key', disableBatch: true, environment: 'prod' });
     assert.equal(TraceRoot.isInitialized(), true);
+  });
+
+  it('warns with "git context incomplete" when no git context is resolvable', () => {
+    // Save and clear only the env vars the harvester actually reads.
+    const saved = {
+      GITHUB_REPOSITORY: process.env['GITHUB_REPOSITORY'],
+      GITHUB_SHA: process.env['GITHUB_SHA'],
+      TRACEROOT_GIT_REPO: process.env['TRACEROOT_GIT_REPO'],
+      TRACEROOT_GIT_REF: process.env['TRACEROOT_GIT_REF'],
+    };
+    const origCwd = process.cwd();
+    const messages: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      messages.push(args.map(String).join(' '));
+    };
+
+    try {
+      delete process.env['GITHUB_REPOSITORY'];
+      delete process.env['GITHUB_SHA'];
+      delete process.env['TRACEROOT_GIT_REPO'];
+      delete process.env['TRACEROOT_GIT_REF'];
+      // chdir to a fresh empty temp dir so both gitContextFromFiles() (reads
+      // <cwd>/.git) and the git subprocess (rev-parse from a non-repo dir) find
+      // nothing — regardless of whether this checkout is a worktree, a normal
+      // clone, or a CI environment.
+      process.chdir(mkdtempSync(path.join(os.tmpdir(), 'tr-nogit-')));
+      TraceRoot.initialize({ apiKey: 'test-key', disableBatch: true });
+    } finally {
+      process.chdir(origCwd);
+      console.warn = origWarn;
+      // Restore only what was set; leave unset vars deleted.
+      if (saved.GITHUB_REPOSITORY === undefined) {
+        delete process.env['GITHUB_REPOSITORY'];
+      } else {
+        process.env['GITHUB_REPOSITORY'] = saved.GITHUB_REPOSITORY;
+      }
+      if (saved.GITHUB_SHA === undefined) {
+        delete process.env['GITHUB_SHA'];
+      } else {
+        process.env['GITHUB_SHA'] = saved.GITHUB_SHA;
+      }
+      if (saved.TRACEROOT_GIT_REPO === undefined) {
+        delete process.env['TRACEROOT_GIT_REPO'];
+      } else {
+        process.env['TRACEROOT_GIT_REPO'] = saved.TRACEROOT_GIT_REPO;
+      }
+      if (saved.TRACEROOT_GIT_REF === undefined) {
+        delete process.env['TRACEROOT_GIT_REF'];
+      } else {
+        process.env['TRACEROOT_GIT_REF'] = saved.TRACEROOT_GIT_REF;
+      }
+    }
+
+    assert.ok(
+      messages.some((m) => m.includes('git context incomplete')),
+      `Expected a warn containing "git context incomplete", got: ${JSON.stringify(messages)}`,
+    );
+    assert.equal(
+      messages.filter((m) => m.includes('git context incomplete')).length,
+      1,
+      'git-context warning should fire exactly once per initialize()',
+    );
   });
 });
 

--- a/packages/traceroot/tests/initialize.test.ts
+++ b/packages/traceroot/tests/initialize.test.ts
@@ -155,6 +155,46 @@ describe('TraceRoot.initialize()', () => {
       'git-context warning should fire exactly once per initialize()',
     );
   });
+
+  it('treats empty-string TRACEROOT_GIT_* env vars as unset (warns)', () => {
+    const saved = {
+      GITHUB_REPOSITORY: process.env['GITHUB_REPOSITORY'],
+      GITHUB_SHA: process.env['GITHUB_SHA'],
+      TRACEROOT_GIT_REPO: process.env['TRACEROOT_GIT_REPO'],
+      TRACEROOT_GIT_REF: process.env['TRACEROOT_GIT_REF'],
+    };
+    const origCwd = process.cwd();
+    const messages: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      messages.push(args.map(String).join(' '));
+    };
+    try {
+      delete process.env['GITHUB_REPOSITORY'];
+      delete process.env['GITHUB_SHA'];
+      // Empty strings must be treated as unset, not as resolved values.
+      process.env['TRACEROOT_GIT_REPO'] = '';
+      process.env['TRACEROOT_GIT_REF'] = '';
+      process.chdir(mkdtempSync(path.join(os.tmpdir(), 'tr-nogit-')));
+      TraceRoot.initialize({ apiKey: 'test-key', disableBatch: true });
+    } finally {
+      process.chdir(origCwd);
+      console.warn = origWarn;
+      for (const k of [
+        'GITHUB_REPOSITORY',
+        'GITHUB_SHA',
+        'TRACEROOT_GIT_REPO',
+        'TRACEROOT_GIT_REF',
+      ] as const) {
+        if (saved[k] === undefined) delete process.env[k];
+        else process.env[k] = saved[k];
+      }
+    }
+    assert.ok(
+      messages.some((m) => m.includes('git context incomplete')),
+      `Expected a warn for empty git env vars, got: ${JSON.stringify(messages)}`,
+    );
+  });
 });
 
 // Shared fixture for TraceRootSpanProcessor unit tests


### PR DESCRIPTION
## What

Makes `git_repo` / `git_ref` resolve reliably in production runtimes (containers without a `.git` dir or the `git` binary), where the previous subprocess-only detection silently failed and left the AI agent unable to correlate traces to source.

New resolution ladder (first hit wins, cached):
1. explicit init config (`gitRepo`/`gitRef`)
2. `TRACEROOT_GIT_REPO` / `TRACEROOT_GIT_REF`
3. GitHub Actions env (`GITHUB_REPOSITORY` / `GITHUB_SHA`)
4. `.git` files read directly (`gitContextFromFiles` — no `git` binary needed)
5. `git` subprocess (dev last resort)
6. warn exactly once if still unresolved — never fabricate a value

## Changes
- `src/git_context.ts` — `harvestCiGitContext` (GitHub Actions), `gitContextFromFiles` (`.git/config` + `.git/HEAD`/refs), shared repo-URL/SHA regexes
- `src/traceroot.ts` — layered ladder + warn-once
- `src/constants.ts` — centralized `GITHUB_*` var names
- tests — harvest, file-read, and warn-once coverage

## Testing
- Unit/integration: 144 passing; lint + typecheck clean
- E2E on staging (this build): build-time injection, CI harvest, `.git` auto-detect, and the unresolved→warn path — verified via a real LangGraph agent (34-span trace, all spans carry git context) in ClickHouse

## Issues
Refs traceroot-ai/traceroot#1023 and traceroot-ai/traceroot#1026 (cross-repo — close on merge). Part of epic traceroot-ai/traceroot#1028.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make git context resolution reliable in production with a layered fallback (config/env/CI/.git files/git) and a single warning when repo/ref are missing. Handle empty `TRACEROOT_GIT_REPO`/`TRACEROOT_GIT_REF` as unset, and tighten `packed-refs` parsing to only accept valid 40/64-char object IDs.

- **New Features**
  - Layered resolution: explicit config → `TRACEROOT_GIT_REPO`/`TRACEROOT_GIT_REF` → GitHub Actions (`GITHUB_REPOSITORY`/`GITHUB_SHA`) → `.git` file reads → `git` subprocess.
  - `harvestCiGitContext` (CI env) and `gitContextFromFiles` (`.git/config`, `.git/HEAD`, `packed-refs`); centralized `GITHUB_*` names and tests.
  - Warn once when repo or ref is unset; never fabricate values.

- **Bug Fixes**
  - Treat empty `TRACEROOT_GIT_REPO`/`TRACEROOT_GIT_REF` as unset so fallbacks and the warning still trigger.
  - Tighten `packed-refs` OID matching to exactly 40 or 64 hex chars.

<sup>Written for commit d27cde21d168615723933564d22d51905f61fd9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-ts/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

