### PR TITLE
chore: bump version to 0.1.6

### DIFF
--- a/packages/traceroot/package.json
+++ b/packages/traceroot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traceroot-ai/traceroot",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "TraceRoot TypeScript SDK for AI observability",
   "keywords": [
     "traceroot",


### PR DESCRIPTION
## Summary
Bumps `@traceroot-ai/traceroot` from 0.1.5 → 0.1.6.

Rolls up changes landed since #98:
- fix: lazy-load OpenInference instrumentations to avoid peer dep crashes (#99)
- feat(git): resolve git context from CI env + .git files; warn when unresolved
- fix(git): resolve packed refs in gitContextFromFiles
- fix(git): tighten packed-refs OID match to exactly 40 or 64 hex
- fix(git): treat empty TRACEROOT_GIT_* env vars as unset (parity with py) (#101)

## Test plan
- [ ] CI green
- [ ] After merge: `gh release create v0.1.6 --target main --title "v0.1.6" --generate-notes` to trigger npm publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `@traceroot-ai/traceroot` to 0.1.6, releasing safer instrumentation loading and more reliable git context detection. Reduces peer dependency crashes and improves CI compatibility.

- **New Features**
  - Resolve git context from CI env and `.git` files; warn if unresolved.

- **Bug Fixes**
  - Lazy-load OpenInference instrumentations to avoid peer dependency crashes.
  - Parse packed refs and enforce 40/64-hex OID matching.
  - Treat empty TRACEROOT_GIT_* env vars as unset (parity with Python SDK).

<sup>Written for commit 24eb0e808d5ab1d79980dbd1c915d2b25adcec6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-ts/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

