### PR TITLE
fix: allow undefined values in updateCurrentSpan usage

### DIFF
--- a/packages/traceroot/src/context.ts
+++ b/packages/traceroot/src/context.ts
@@ -15,6 +15,17 @@ import {
   SPAN_TAGS,
   TRACE_METADATA,
 } from './constants';
+import type { SpanUsage } from './types';
+
+function definedUsageEntries(usage: SpanUsage): Record<string, number> {
+  const result: Record<string, number> = {};
+  for (const [key, value] of Object.entries(usage)) {
+    if (value !== undefined) {
+      result[key] = value;
+    }
+  }
+  return result;
+}
 
 /**
  * Sets attributes on the currently active span.
@@ -33,8 +44,8 @@ export function updateCurrentSpan(attrs: {
   model?: string;
   /** LLM model parameters (e.g. { temperature: 0.7, max_tokens: 1024 }). */
   modelParameters?: Record<string, unknown>;
-  /** Token usage (e.g. { inputTokens: 100, outputTokens: 50 }). */
-  usage?: Record<string, number>;
+  /** Token usage (e.g. { inputTokens: 100, outputTokens: 50 }). Undefined fields are omitted. */
+  usage?: SpanUsage;
   /** Prompt / messages sent to the LLM. */
   prompt?: unknown;
 }): void {
@@ -76,10 +87,13 @@ export function updateCurrentSpan(attrs: {
     }
   }
   if (attrs.usage !== undefined) {
-    try {
-      span.setAttribute(LLM_USAGE, JSON.stringify(attrs.usage));
-    } catch {
-      /* non-serializable */
+    const usage = definedUsageEntries(attrs.usage);
+    if (Object.keys(usage).length > 0) {
+      try {
+        span.setAttribute(LLM_USAGE, JSON.stringify(usage));
+      } catch {
+        /* non-serializable */
+      }
     }
   }
   if (attrs.prompt !== undefined) {

--- a/packages/traceroot/src/index.ts
+++ b/packages/traceroot/src/index.ts
@@ -9,6 +9,6 @@ export {
 } from './context';
 export { usingAttributes } from './usingAttributes';
 export { SpanAttributes } from './constants';
-export type { SpanType, ObserveOptions, InitializeOptions } from './types';
+export type { SpanType, SpanUsage, ObserveOptions, InitializeOptions } from './types';
 export type { UsingAttributesOptions } from './usingAttributes';
 export { OpenAIAgentsProcessor } from './openai-agents';

--- a/packages/traceroot/src/types.ts
+++ b/packages/traceroot/src/types.ts
@@ -2,6 +2,13 @@
 
 export type SpanType = 'span' | 'agent' | 'tool' | 'llm';
 
+export interface SpanUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  [key: string]: number | undefined;
+}
+
 export interface ObserveOptions {
   /** Span name. Defaults to fn.name, then 'anonymous'. */
   name?: string;

--- a/packages/traceroot/tests/context.test.ts
+++ b/packages/traceroot/tests/context.test.ts
@@ -97,6 +97,34 @@ describe('updateCurrentSpan()', () => {
     assert.equal(span.attributes['traceroot.llm.usage'], JSON.stringify(usage));
   });
 
+  it('omits undefined usage fields before writing traceroot.llm.usage', async () => {
+    await observe({ name: 'x' }, async () => {
+      updateCurrentSpan({
+        model: 'gemini-2.5-flash',
+        usage: {
+          inputTokens: 100,
+          outputTokens: undefined,
+        },
+      });
+    });
+    const [span] = exporter.getFinishedSpans();
+    assert.equal(span.attributes['traceroot.llm.model'], 'gemini-2.5-flash');
+    assert.equal(span.attributes['traceroot.llm.usage'], JSON.stringify({ inputTokens: 100 }));
+  });
+
+  it('does not set traceroot.llm.usage when all usage fields are undefined', async () => {
+    await observe({ name: 'x' }, async () => {
+      updateCurrentSpan({
+        usage: {
+          inputTokens: undefined,
+          outputTokens: undefined,
+        },
+      });
+    });
+    const [span] = exporter.getFinishedSpans();
+    assert.equal(span.attributes['traceroot.llm.usage'], undefined);
+  });
+
   it('sets traceroot.llm.prompt as JSON on the active span', async () => {
     const prompt = [{ role: 'user', content: 'hello' }];
     await observe({ name: 'x' }, async () => {


### PR DESCRIPTION
## Summary

`updateCurrentSpan` currently types `usage` as `Record<string, number>`, which forces callers to strip `undefined` token counts before every call. Many LLM providers (Gemini, Bedrock, streaming responses, etc.) naturally return partial usage metadata, making the ergonomic usage pattern fail under strict TypeScript.

This PR widens the `usage` type to accept `number | undefined` values and filters out `undefined` entries at runtime before writing the `traceroot.llm.usage` OpenTelemetry attribute.

**Closes:** traceroot-ai/traceroot#1266 *(issue filed in the platform repo; fix belongs here in traceroot-ts)*

---

## Problem

Today, callers must write defensive boilerplate:

```ts
const usage: Record<string, number> = {};

if (result.usageMetadata?.promptTokenCount != null)
  usage.inputTokens = result.usageMetadata.promptTokenCount;
if (result.usageMetadata?.candidatesTokenCount != null)
  usage.outputTokens = result.usageMetadata.candidatesTokenCount;

updateCurrentSpan({
  model: 'gemini-2.5-flash',
  ...(Object.keys(usage).length ? { usage } : {}),
});
```

However, the natural usage pattern should just work:

```ts
updateCurrentSpan({
  model: 'gemini-2.5-flash',
  usage: {
    inputTokens: result.usageMetadata?.promptTokenCount,
    outputTokens: result.usageMetadata?.candidatesTokenCount,
  },
});
```

---

## Solution

### Type Change

Introduced a new exported interface:

```ts
export interface SpanUsage {
  inputTokens?: number;
  outputTokens?: number;
  totalTokens?: number;
  [key: string]: number | undefined;
}
```

---

### Runtime Behavior

Added a helper that filters out `undefined` values before serializing usage:

- Partial usage:

```ts
{
  inputTokens: 100,
  outputTokens: undefined
}
```

Serializes as:

```json
{
  "inputTokens": 100
}
```

- All undefined:

```ts
{
  inputTokens: undefined,
  outputTokens: undefined
}
```

No `traceroot.llm.usage` attribute is written, matching the manual `Object.keys(usage).length` guard callers previously had to implement.

---

## Tests

- [x] `npm run typecheck` — clean
- [x] Added test: partial usage omits undefined fields
- [x] Added test: all-undefined usage skips `traceroot.llm.usage`
- [x] Existing full usage tests remain unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let callers pass partial token usage to updateCurrentSpan. We now drop undefined fields and skip the `traceroot.llm.usage` attribute when empty.

- **Bug Fixes**
  - Introduced `SpanUsage` allowing `number | undefined` and exported it.
  - Filter undefined keys before serializing; don’t set `traceroot.llm.usage` if none remain.
  - Added tests for partial and all-undefined usage.

<sup>Written for commit 98afe0c913744318bdc5349b0ebea20d639926c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-ts/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

