### PR TITLE
feat: add LiveKit Agents instrumentation

### DIFF
--- a/packages/traceroot/README.md
+++ b/packages/traceroot/README.md
@@ -11,6 +11,35 @@
 
 Please see the [TypeScript SDK Docs](https://traceroot.ai/docs/tracing/get-started) for details.
 
+## LiveKit Agents
+
+LiveKit Agents can use the existing TraceRoot SDK primitives. Pass the LiveKit
+Agents module into `initialize`, bind the room to TraceRoot context inside the
+job, and flush when the job shuts down.
+
+```ts
+import { TraceRoot, usingAttributes } from '@traceroot-ai/traceroot';
+import * as livekitAgents from '@livekit/agents';
+
+TraceRoot.initialize({
+  instrumentModules: { livekitAgents },
+});
+
+export async function entrypoint(ctx: livekitAgents.JobContext) {
+  ctx.addShutdownCallback(() => TraceRoot.flush());
+
+  await usingAttributes(
+    {
+      sessionId: ctx.room.name,
+      tags: ['livekit', 'voice-agent'],
+    },
+    async () => {
+      // Start the LiveKit AgentSession here.
+    },
+  );
+}
+```
+
 <!-- Links -->
 
 [discord-image]: https://img.shields.io/discord/1395844148568920114?logo=discord&labelColor=%235462eb&logoColor=%23f5f5f5&color=%235462eb

--- a/packages/traceroot/src/instrumentation.ts
+++ b/packages/traceroot/src/instrumentation.ts
@@ -1,8 +1,10 @@
 // src/instrumentation.ts
 import { registerInstrumentations, type Instrumentation } from '@opentelemetry/instrumentation';
+import type { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import type { InitializeOptions } from './types';
 import { wireOpenAIAgentsProcessor } from './openai-agents';
 import { wireClaudeAgentSDKInstrumentation } from './claude-agent-sdk';
+import { wireLiveKitInstrumentation } from './livekit';
 
 type InstrumentationWithManualPatch = Instrumentation & {
   manuallyInstrument(moduleRef: unknown): void;
@@ -43,6 +45,7 @@ function loadInstrumentation(pkg: string, exportName: string): InstrumentationCt
  */
 export function wireInstrumentations(
   instrumentModules: InitializeOptions['instrumentModules'],
+  tracerProvider?: NodeTracerProvider,
 ): void {
   if (instrumentModules === undefined) {
     // Auto-instrumentation via require-in-the-middle (CJS only).
@@ -77,6 +80,9 @@ export function wireInstrumentations(
   }
   if (instrumentModules.openaiAgents) {
     wireOpenAIAgentsProcessor(instrumentModules.openaiAgents);
+  }
+  if (instrumentModules.livekitAgents) {
+    wireLiveKitInstrumentation(instrumentModules.livekitAgents, tracerProvider);
   }
 
   if (instrs.length > 0) {

--- a/packages/traceroot/src/livekit.ts
+++ b/packages/traceroot/src/livekit.ts
@@ -1,0 +1,140 @@
+import type { AttributeValue } from '@opentelemetry/api';
+import type { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+
+const OI_SPAN_KIND = 'openinference.span.kind';
+const INPUT_VALUE = 'input.value';
+const OUTPUT_VALUE = 'output.value';
+const LLM_MODEL_NAME = 'llm.model_name';
+const LLM_TOKEN_COUNT_PROMPT = 'llm.token_count.prompt';
+const LLM_TOKEN_COUNT_COMPLETION = 'llm.token_count.completion';
+const GEN_AI_TOOL_NAME = 'gen_ai.tool.name';
+
+const AGENT_SPANS = new Set(['agent_turn']);
+const LLM_SPANS = new Set(['llm_request']);
+const TOOL_SPANS = new Set(['function_tool']);
+const KNOWN_LIVEKIT_SPANS = new Set([
+  ...AGENT_SPANS,
+  ...LLM_SPANS,
+  ...TOOL_SPANS,
+  'agent_session',
+  'llm_node',
+  'tts_node',
+  'tts_request',
+  'user_turn',
+]);
+const LIVEKIT_SCOPE_NAME = 'livekit-agents';
+const INPUT_KEYS = [
+  'lk.input_text',
+  'lk.user_transcript',
+  'lk.chat_ctx',
+  'lk.user_input',
+  'lk.function_tool.arguments',
+];
+const OUTPUT_KEYS = ['lk.function_tool.output', 'lk.response.text'];
+
+type SpanLike = {
+  name?: string;
+  attributes?: Record<string, unknown>;
+  instrumentationScope?: { name?: string };
+  instrumentation_scope?: { name?: string };
+  instrumentationLibrary?: { name?: string };
+};
+
+export type LiveKitAttributeOverlay = Record<string, AttributeValue>;
+
+type LiveKitAgentsModule = {
+  telemetry?: {
+    setTracerProvider?: (provider: NodeTracerProvider) => void;
+    set_tracer_provider?: (provider: NodeTracerProvider) => void;
+  };
+  setTracerProvider?: (provider: NodeTracerProvider) => void;
+  set_tracer_provider?: (provider: NodeTracerProvider) => void;
+};
+
+function spanName(span: ReadableSpan): string {
+  return ((span as { name?: string }).name ?? '') || '';
+}
+
+function attrs(span: ReadableSpan): Record<string, unknown> {
+  return ((span as SpanLike).attributes ?? {}) as Record<string, unknown>;
+}
+
+function scopeName(span: ReadableSpan): string | undefined {
+  const candidate = span as SpanLike;
+  return (
+    candidate.instrumentationScope?.name ??
+    candidate.instrumentation_scope?.name ??
+    candidate.instrumentationLibrary?.name
+  );
+}
+
+function first(attributes: Record<string, unknown>, keys: readonly string[]): unknown {
+  for (const key of keys) {
+    const value = attributes[key];
+    if (value !== undefined && value !== null) return value;
+  }
+  return undefined;
+}
+
+function isLiveKitSpan(span: ReadableSpan): boolean {
+  const attributes = attrs(span);
+  if (scopeName(span) === LIVEKIT_SCOPE_NAME) return true;
+  if (KNOWN_LIVEKIT_SPANS.has(spanName(span))) return true;
+  return Object.keys(attributes).some((key) => key.startsWith('lk.'));
+}
+
+function spanKind(name: string): string | undefined {
+  if (AGENT_SPANS.has(name)) return 'AGENT';
+  if (LLM_SPANS.has(name)) return 'LLM';
+  if (TOOL_SPANS.has(name)) return 'TOOL';
+  return undefined;
+}
+
+function setOverlay(overlay: LiveKitAttributeOverlay, key: string, value: unknown): void {
+  if (value === undefined || value === null) return;
+  overlay[key] = value as AttributeValue;
+}
+
+export function getLiveKitAttributeOverlay(span: ReadableSpan): LiveKitAttributeOverlay {
+  const overlay: LiveKitAttributeOverlay = {};
+  if (!isLiveKitSpan(span)) return overlay;
+
+  const name = spanName(span);
+  const attributes = attrs(span);
+
+  setOverlay(overlay, OI_SPAN_KIND, spanKind(name));
+  setOverlay(overlay, INPUT_VALUE, first(attributes, INPUT_KEYS));
+  setOverlay(overlay, OUTPUT_VALUE, first(attributes, OUTPUT_KEYS));
+
+  if (LLM_SPANS.has(name)) {
+    setOverlay(overlay, LLM_MODEL_NAME, attributes['gen_ai.request.model']);
+    setOverlay(overlay, LLM_TOKEN_COUNT_PROMPT, attributes['gen_ai.usage.input_tokens']);
+    setOverlay(overlay, LLM_TOKEN_COUNT_COMPLETION, attributes['gen_ai.usage.output_tokens']);
+  }
+
+  setOverlay(overlay, GEN_AI_TOOL_NAME, attributes['lk.function_tool.name']);
+  return overlay;
+}
+
+export function wireLiveKitInstrumentation(
+  livekitAgents: unknown,
+  provider?: NodeTracerProvider,
+): void {
+  if (!provider) return;
+
+  const candidate = livekitAgents as LiveKitAgentsModule;
+  const setTracerProvider =
+    candidate.telemetry?.setTracerProvider ??
+    candidate.telemetry?.set_tracer_provider ??
+    candidate.setTracerProvider ??
+    candidate.set_tracer_provider;
+
+  if (typeof setTracerProvider !== 'function') {
+    throw new Error(
+      '[TraceRoot] Failed to instrument LiveKit Agents: expected a telemetry.setTracerProvider function.',
+    );
+  }
+
+  setTracerProvider(provider);
+}

--- a/packages/traceroot/src/processor.ts
+++ b/packages/traceroot/src/processor.ts
@@ -1,6 +1,8 @@
 // src/processor.ts
-import { trace as otelTrace, Context, Span } from '@opentelemetry/api';
+import { trace as otelTrace, AttributeValue, Context, Span } from '@opentelemetry/api';
 import { ReadableSpan, SpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { getAttributesFromContext } from '@arizeai/openinference-core';
+import { getLiveKitAttributeOverlay } from './livekit';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { version } = require('../package.json') as { version: string };
@@ -12,6 +14,21 @@ export interface TraceRootSpanProcessorOptions {
   environment?: string;
   gitRepo?: string;
   gitRef?: string;
+}
+
+function withAttributeOverlay(
+  span: ReadableSpan,
+  overlay: Record<string, AttributeValue>,
+): ReadableSpan {
+  if (Object.keys(overlay).length === 0) return span;
+
+  const spanView = Object.create(span) as ReadableSpan;
+  Object.defineProperty(spanView, 'attributes', {
+    value: { ...span.attributes, ...overlay },
+    enumerable: true,
+    configurable: true,
+  });
+  return spanView;
 }
 
 /**
@@ -54,6 +71,12 @@ export class TraceRootSpanProcessor implements SpanProcessor {
     }
     if (this._gitRef !== undefined) {
       span.setAttribute('traceroot.git.ref', this._gitRef);
+    }
+    if (typeof (parentContext as { getValue?: unknown })?.getValue === 'function') {
+      const contextAttributes = getAttributesFromContext(parentContext);
+      if (Object.keys(contextAttributes).length > 0) {
+        span.setAttributes(contextAttributes);
+      }
     }
 
     // Enrich every span with its full name path from root to current span.
@@ -117,13 +140,15 @@ export class TraceRootSpanProcessor implements SpanProcessor {
   }
 
   onEnd(span: ReadableSpan): void {
+    const spanForExport = withAttributeOverlay(span, getLiveKitAttributeOverlay(span));
+
     // Invariant: children must be started before their parent ends. A child span
     // started after onEnd runs here loses the map-based ancestry lookup for
     // NonRecordingSpan parents (no attribute fallback exists for those).
     const spanId = span.spanContext().spanId;
     this._idsPathBySpanId.delete(spanId);
     this._namePathBySpanId.delete(spanId);
-    this.inner.onEnd(span);
+    this.inner.onEnd(spanForExport);
   }
 
   forceFlush(): Promise<void> {

--- a/packages/traceroot/src/traceroot.ts
+++ b/packages/traceroot/src/traceroot.ts
@@ -159,7 +159,7 @@ export class TraceRoot {
     );
     _provider.register();
 
-    wireInstrumentations(options.instrumentModules);
+    wireInstrumentations(options.instrumentModules, _provider);
 
     _isInitialized = true;
     process.once('beforeExit', () => {

--- a/packages/traceroot/src/types.ts
+++ b/packages/traceroot/src/types.ts
@@ -55,6 +55,11 @@ export interface InitializeOptions {
     claudeAgentSDK?: unknown;
     bedrock?: unknown;
     /**
+     * LiveKit Agents module ref. Pass `import * as livekitAgents from '@livekit/agents'`
+     * or the package's agents module that exposes `telemetry.setTracerProvider`.
+     */
+    livekitAgents?: unknown;
+    /**
      * @openai/agents module ref. Pass `import * as agents from '@openai/agents'`.
      *
      * Replaces the SDK's default OpenAI tracing processor with TraceRoot's —

--- a/packages/traceroot/tests/context-propagation.test.ts
+++ b/packages/traceroot/tests/context-propagation.test.ts
@@ -2,8 +2,11 @@ import { afterEach, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { trace } from '@opentelemetry/api';
 import { observe } from '../src/observe';
+import { TraceRootSpanProcessor } from '../src/processor';
 import { _resetForTesting } from '../src/traceroot';
+import { usingAttributes } from '../src/usingAttributes';
 
 describe('async context propagation', () => {
   let exporter: InMemorySpanExporter;
@@ -68,5 +71,28 @@ describe('async context propagation', () => {
     // Cross-bleed check
     assert.notEqual(childA.parentSpanId, parentB.spanContext().spanId);
     assert.notEqual(childB.parentSpanId, parentA.spanContext().spanId);
+  });
+
+  it('usingAttributes() applies to native OpenTelemetry spans', async () => {
+    await provider.shutdown();
+    exporter.reset();
+    _resetForTesting();
+
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider();
+    provider.addSpanProcessor(new TraceRootSpanProcessor(new SimpleSpanProcessor(exporter)));
+    provider.register();
+
+    await usingAttributes({ sessionId: 'room-123', userId: 'user-456' }, async () => {
+      const tracer = trace.getTracer('native-integration-test');
+      tracer.startActiveSpan('livekit-native-span', (span) => {
+        span.end();
+      });
+    });
+
+    const [span] = exporter.getFinishedSpans();
+    assert.equal(span.name, 'livekit-native-span');
+    assert.equal(span.attributes['session.id'], 'room-123');
+    assert.equal(span.attributes['user.id'], 'user-456');
   });
 });

--- a/packages/traceroot/tests/livekit.test.ts
+++ b/packages/traceroot/tests/livekit.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { wireInstrumentations } from '../src/instrumentation';
+import { wireLiveKitInstrumentation } from '../src/livekit';
+import { TraceRootSpanProcessor } from '../src/processor';
+import { TraceRoot, _resetForTesting } from '../src/traceroot';
+
+describe('LiveKit export overlay', () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new NodeTracerProvider();
+    provider.addSpanProcessor(new TraceRootSpanProcessor(new SimpleSpanProcessor(exporter)));
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+    exporter.reset();
+  });
+
+  it('maps LiveKit agent_turn spans to agent kind and IO', () => {
+    const tracer = provider.getTracer('livekit-agents');
+
+    const span = tracer.startSpan('agent_turn');
+    span.setAttribute('lk.user_input', 'Tell me a joke.');
+    span.setAttribute('lk.response.text', 'Why did the test pass?');
+    span.end();
+
+    const [finished] = exporter.getFinishedSpans();
+    assert.equal(finished.attributes['openinference.span.kind'], 'AGENT');
+    assert.equal(finished.attributes['input.value'], 'Tell me a joke.');
+    assert.equal(finished.attributes['output.value'], 'Why did the test pass?');
+  });
+
+  it('maps LiveKit llm_request spans to llm kind, model, tokens, and IO', () => {
+    const tracer = provider.getTracer('livekit-agents');
+
+    const span = tracer.startSpan('llm_request');
+    span.setAttribute('lk.chat_ctx', 'user: hello');
+    span.setAttribute('lk.response.text', 'assistant: hi');
+    span.setAttribute('gen_ai.request.model', 'openai/gpt-5.2-chat-latest');
+    span.setAttribute('gen_ai.usage.input_tokens', 11);
+    span.setAttribute('gen_ai.usage.output_tokens', 7);
+    span.end();
+
+    const [finished] = exporter.getFinishedSpans();
+    assert.equal(finished.attributes['openinference.span.kind'], 'LLM');
+    assert.equal(finished.attributes['input.value'], 'user: hello');
+    assert.equal(finished.attributes['output.value'], 'assistant: hi');
+    assert.equal(finished.attributes['llm.model_name'], 'openai/gpt-5.2-chat-latest');
+    assert.equal(finished.attributes['llm.token_count.prompt'], 11);
+    assert.equal(finished.attributes['llm.token_count.completion'], 7);
+  });
+
+  it('does not force model-carrying LiveKit spans to TraceRoot span kinds', () => {
+    const tracer = provider.getTracer('livekit-agents');
+
+    const userTurn = tracer.startSpan('user_turn');
+    userTurn.setAttribute('gen_ai.request.model', 'deepgram/nova-3');
+    userTurn.setAttribute('gen_ai.usage.input_tokens', 2);
+    userTurn.setAttribute('lk.user_transcript', 'hello');
+    userTurn.end();
+
+    const llmNode = tracer.startSpan('llm_node');
+    llmNode.setAttribute('gen_ai.request.model', 'openai/chat-latest');
+    llmNode.setAttribute('gen_ai.usage.input_tokens', 12);
+    llmNode.setAttribute('gen_ai.usage.output_tokens', 3);
+    llmNode.setAttribute('lk.chat_ctx', 'user: add 12 and 30');
+    llmNode.setAttribute('lk.response.text', 'tool call pending');
+    llmNode.end();
+
+    const spans = exporter.getFinishedSpans();
+    assert.deepEqual(
+      spans.map((span) => span.name),
+      ['user_turn', 'llm_node'],
+    );
+    assert.deepEqual(
+      spans.map((span) => span.attributes['openinference.span.kind']),
+      [undefined, undefined],
+    );
+    assert.deepEqual(
+      spans.map((span) => span.attributes['traceroot.span.type']),
+      [undefined, undefined],
+    );
+  });
+
+  it('does not modify non-LiveKit spans', () => {
+    const tracer = provider.getTracer('openai');
+
+    const span = tracer.startSpan('chat.completion');
+    span.setAttribute('openinference.span.kind', 'LLM');
+    span.setAttribute('input.value', 'existing input');
+    span.setAttribute('gen_ai.request.model', 'gpt-4o');
+    span.end();
+
+    const [finished] = exporter.getFinishedSpans();
+    assert.equal(finished.attributes['openinference.span.kind'], 'LLM');
+    assert.equal(finished.attributes['input.value'], 'existing input');
+    assert.equal(finished.attributes['llm.model_name'], undefined);
+  });
+
+  it('maps LiveKit attributes that are added with setAttributes() before end', () => {
+    const tracer = provider.getTracer('livekit-agents');
+
+    const span = tracer.startSpan('llm_request');
+    span.setAttribute('lk.chat_ctx', 'user: hello');
+    span.setAttribute('gen_ai.request.model', 'openai/gpt-5.2-chat-latest');
+    span.setAttributes({
+      'gen_ai.usage.input_tokens': 11,
+      'gen_ai.usage.output_tokens': 7,
+      'lk.response.text': 'assistant: hi',
+    });
+    span.end();
+
+    const [finished] = exporter.getFinishedSpans();
+    assert.equal(finished.attributes['openinference.span.kind'], 'LLM');
+    assert.equal(finished.attributes['input.value'], 'user: hello');
+    assert.equal(finished.attributes['output.value'], 'assistant: hi');
+    assert.equal(finished.attributes['llm.model_name'], 'openai/gpt-5.2-chat-latest');
+    assert.equal(finished.attributes['llm.token_count.prompt'], 11);
+    assert.equal(finished.attributes['llm.token_count.completion'], 7);
+  });
+
+  it('maps late LiveKit attributes at export time without mutating the live span', () => {
+    const tracer = provider.getTracer('livekit-agents');
+
+    const span = tracer.startSpan('agent_turn');
+    span.setAttribute('lk.response.text', 'assistant: ready');
+
+    assert.equal(
+      (span as unknown as { attributes: Record<string, unknown> }).attributes['output.value'],
+      undefined,
+    );
+
+    span.end();
+
+    const [finished] = exporter.getFinishedSpans();
+    assert.equal(finished.attributes['output.value'], 'assistant: ready');
+  });
+
+  it('maps LiveKit function_tool spans to tool kind, name, and IO', () => {
+    const tracer = provider.getTracer('livekit-agents');
+
+    const span = tracer.startSpan('function_tool');
+    span.setAttribute('lk.function_tool.name', 'lookup_customer');
+    span.setAttribute('lk.function_tool.arguments', '{"user_id":"user-123"}');
+    span.setAttribute('lk.function_tool.output', '{"plan":"pro"}');
+    span.end();
+
+    const [finished] = exporter.getFinishedSpans();
+    assert.equal(finished.attributes['openinference.span.kind'], 'TOOL');
+    assert.equal(finished.attributes['gen_ai.tool.name'], 'lookup_customer');
+    assert.equal(finished.attributes['input.value'], '{"user_id":"user-123"}');
+    assert.equal(finished.attributes['output.value'], '{"plan":"pro"}');
+  });
+});
+
+describe('LiveKit instrumentation wiring', () => {
+  afterEach(async () => {
+    await TraceRoot.shutdown();
+    _resetForTesting();
+  });
+
+  it('passes TraceRoot provider to LiveKit telemetry', () => {
+    const provider = new NodeTracerProvider();
+    const calls: unknown[] = [];
+    const livekitAgents = {
+      telemetry: {
+        setTracerProvider(tracerProvider: unknown) {
+          calls.push(tracerProvider);
+        },
+      },
+    };
+
+    wireLiveKitInstrumentation(livekitAgents, provider);
+
+    assert.deepEqual(calls, [provider]);
+  });
+
+  it('wires livekitAgents through the existing instrumentation entry point', () => {
+    const provider = new NodeTracerProvider();
+    const calls: unknown[] = [];
+    const livekitAgents = {
+      telemetry: {
+        setTracerProvider(tracerProvider: unknown) {
+          calls.push(tracerProvider);
+        },
+      },
+    };
+
+    wireInstrumentations({ livekitAgents }, provider);
+
+    assert.deepEqual(calls, [provider]);
+  });
+
+  it('does not touch LiveKit when livekitAgents is not requested', () => {
+    const provider = new NodeTracerProvider();
+
+    assert.doesNotThrow(() => wireInstrumentations({}, provider));
+  });
+
+  it('passes the initialized TraceRoot provider to LiveKit', async () => {
+    const calls: unknown[] = [];
+    const livekitAgents = {
+      telemetry: {
+        setTracerProvider(tracerProvider: unknown) {
+          calls.push(tracerProvider);
+        },
+      },
+    };
+
+    TraceRoot.initialize({
+      apiKey: 'test-key',
+      disableBatch: true,
+      instrumentModules: { livekitAgents },
+    });
+
+    assert.equal(calls.length, 1);
+    assert.ok(calls[0] instanceof NodeTracerProvider);
+  });
+});


### PR DESCRIPTION
## Summary

- add LiveKit Agents wiring via `instrumentModules.livekitAgents`
- add a LiveKit span processor that lightly maps native LiveKit spans to TraceRoot/OpenInference attributes
- propagate TraceRoot context attributes to native OpenTelemetry spans

## Verification

- `./node_modules/.bin/tsx --test tests/*.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint src tests` (0 errors, existing warnings)


## Screenshot

<img width="1499" height="632" alt="image" src="https://github.com/user-attachments/assets/ea66e496-f0a2-41dc-814d-fe8e446f670b" />


<img width="1502" height="781" alt="image" src="https://github.com/user-attachments/assets/c59e15c2-d77f-41ac-b456-66560ecce963" />

## Regression Test

<img width="1502" height="841" alt="image" src="https://github.com/user-attachments/assets/96c8de31-aa03-49d7-89e7-ec62d730deb0" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds LiveKit Agents instrumentation so TraceRoot overlays OpenInference fields on LiveKit spans and propagates context from `usingAttributes` to native OpenTelemetry spans.

- **New Features**
  - Wire LiveKit via `TraceRoot.initialize({ instrumentModules: { livekitAgents } })`; pass the `@livekit/agents` module exposing `telemetry.setTracerProvider`, and TraceRoot forwards its `NodeTracerProvider` to it.
  - On export, map LiveKit spans (`agent_turn`, `llm_request`, `function_tool`) to OpenInference fields: span kind, `input.value`, `output.value`, `llm.model_name`, token counts, and `gen_ai.tool.name` (honors late-set `lk.*` attributes without mutating live spans; non-LiveKit spans are untouched).
  - `TraceRootSpanProcessor` now applies `usingAttributes` context to all native OpenTelemetry spans.
  - README adds a minimal `@livekit/agents` example showing initialization, room context binding, and flushing on shutdown.

<sup>Written for commit cb75adc731123839bf220bf8030b32292da3c3b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-ts/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

