### PR TITLE
chore(traceroot): bump version to 0.1.7

### DIFF
--- a/packages/traceroot/package.json
+++ b/packages/traceroot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traceroot-ai/traceroot",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "TraceRoot TypeScript SDK for AI observability",
   "keywords": [
     "traceroot",


### PR DESCRIPTION
Bumps `@traceroot/traceroot` from 0.1.6 → 0.1.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `@traceroot-ai/traceroot` from 0.1.6 to 0.1.7 to publish a patch release. No code changes; version bump only.

<sup>Written for commit 33865592e6470f78d8f1cea036d74e0e452b2ab7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-ts/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

