### PR TITLE
Feat/pi coding agent sdk wrapper

### DIFF
--- a/packages/traceroot/package.json
+++ b/packages/traceroot/package.json
@@ -59,9 +59,11 @@
     "@opentelemetry/semantic-conventions": "^1.40.0"
   },
   "devDependencies": {
+    "@earendil-works/pi-coding-agent": "^0.80.0",
     "@eslint/js": "^9.0.0",
     "@langchain/core": "^1.1.39",
     "@openai/agents": ">=0.0.1",
+    "@opentelemetry/core": "^1.30.1",
     "@types/node": "^20.0.0",
     "anthropic": "^0.0.0",
     "eslint": "^9.0.0",

--- a/packages/traceroot/src/index.ts
+++ b/packages/traceroot/src/index.ts
@@ -10,9 +10,15 @@ export {
 } from './context';
 export { usingAttributes } from './usingAttributes';
 export { SpanAttributes } from './constants';
-export type { SpanType, ObserveOptions, InitializeOptions } from './types';
+export type {
+  SpanType,
+  ObserveOptions,
+  InitializeOptions,
+  PiCodingAgentInstrumentation,
+} from './types';
 export type { UsingAttributesOptions } from './usingAttributes';
 export { OpenAIAgentsProcessor } from './openai-agents';
 export { startSpan, usingSpan } from './spans';
 export type { Span } from './spans';
 export type { StartSpanOptions, SpanUpdate, TokenUsage } from './types';
+export type { PiInstrumentationConfig } from './pi';

--- a/packages/traceroot/src/instrumentation.ts
+++ b/packages/traceroot/src/instrumentation.ts
@@ -3,6 +3,7 @@ import { registerInstrumentations, type Instrumentation } from '@opentelemetry/i
 import type { InitializeOptions } from './types';
 import { wireOpenAIAgentsProcessor } from './openai-agents';
 import { wireClaudeAgentSDKInstrumentation } from './claude-agent-sdk';
+import { wirePiCodingAgentInstrumentation } from './pi';
 
 type InstrumentationWithManualPatch = Instrumentation & {
   manuallyInstrument(moduleRef: unknown): void;
@@ -77,6 +78,9 @@ export function wireInstrumentations(
   }
   if (instrumentModules.openaiAgents) {
     wireOpenAIAgentsProcessor(instrumentModules.openaiAgents);
+  }
+  if (instrumentModules.piCodingAgent) {
+    wirePiCodingAgentInstrumentation(instrumentModules.piCodingAgent);
   }
 
   if (instrs.length > 0) {

--- a/packages/traceroot/src/pi.ts
+++ b/packages/traceroot/src/pi.ts
@@ -259,6 +259,58 @@ function assistantTextOf(message: AgentMessage | undefined): string | undefined 
   return parts.length > 0 ? parts.join('') : undefined;
 }
 
+interface ToolCallPart {
+  type: 'toolCall';
+  id?: string;
+  name?: string;
+  arguments?: unknown;
+}
+
+function isToolCallPart(part: unknown): part is ToolCallPart {
+  return (
+    typeof part === 'object' && part !== null && (part as { type?: unknown }).type === 'toolCall'
+  );
+}
+
+// OpenAI-convention function-call `arguments` is a JSON *string*: keep a string
+// as-is, else serialize. A non-serializable value (circular/BigInt) collapses to
+// "" rather than throwing, so one bad arg can't drop the whole output.
+function toolCallArgumentsString(args: unknown): string {
+  if (typeof args === 'string') return args;
+  try {
+    return JSON.stringify(args) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+// Output value for an assistant turn. A text-only turn stays a plain string
+// (unchanged). A turn that ISSUED tool calls — which is exactly the turn that
+// owns the nested TOOL spans — serializes an OpenAI-style assistant message so
+// the tool calls the model produced aren't silently dropped from the LLM span
+// (assistantTextOf alone returns undefined for a tool-call-only turn). Mirrors
+// claude-agent-sdk.ts, which serializes the full assistant message content.
+function assistantOutputValue(message: AgentMessage | undefined): string | undefined {
+  const text = assistantTextOf(message);
+  if (!message || message.role !== 'assistant' || !Array.isArray(message.content)) {
+    return text;
+  }
+  const toolCalls = message.content.filter(isToolCallPart).map((part) => ({
+    id: part.id,
+    type: 'function' as const,
+    function: { name: part.name, arguments: toolCallArgumentsString(part.arguments) },
+  }));
+  if (toolCalls.length === 0) return text;
+  try {
+    return capJsonWithMarker(
+      JSON.stringify({ role: 'assistant', content: text ?? null, tool_calls: toolCalls }),
+    );
+  } catch {
+    // arguments are already strings, so this should not throw; never lose the close.
+    return text;
+  }
+}
+
 export function openRootSpan(
   tracer: Pick<Tracer, 'startSpan'>,
   parentCtx: Context,
@@ -285,7 +337,7 @@ export function stampRootOutput(
       break;
     }
   }
-  setAttr(span, OI_OUTPUT_VALUE, assistantTextOf(lastAssistant));
+  setAttr(span, OI_OUTPUT_VALUE, assistantOutputValue(lastAssistant));
 }
 
 // Ends the root span exactly once, when the wrapping prompt() call's own returned promise settles.
@@ -340,7 +392,7 @@ export function closeLlmSpan(span: Span, message: AssistantMessage, captureConte
   setAttr(span, OI_LLM_TOKEN_COUNT_CACHE_READ, message.usage?.cacheRead);
   setAttr(span, OI_LLM_TOKEN_COUNT_CACHE_WRITE, message.usage?.cacheWrite);
   if (captureContent) {
-    setAttr(span, OI_OUTPUT_VALUE, assistantTextOf(message));
+    setAttr(span, OI_OUTPUT_VALUE, assistantOutputValue(message));
   }
   if (message.stopReason === 'error' || message.stopReason === 'aborted') {
     span.setStatus({

--- a/packages/traceroot/src/pi.ts
+++ b/packages/traceroot/src/pi.ts
@@ -18,7 +18,7 @@ import { SDK_VERSION } from './processor';
 import type { PiCodingAgentInstrumentation } from './types';
 
 /**
- * Hand-transcribed local mirror of @earendil-works/pi-coding-agent / pi-agent-core, verified against their published .d.ts at 0.80.6 (mirrors claude-agent-sdk.ts).
+ * Hand-transcribed local mirror of @earendil-works/pi-coding-agent / pi-agent-core, verified against published .d.ts at 0.80.6.
  */
 
 export interface Usage {
@@ -317,9 +317,8 @@ export function openLlmSpan(
   setAttr(span, OI_SPAN_KIND, OI_SPAN_KIND_VALUE.LLM);
   setAttr(span, GEN_AI_ATTRIBUTES.SYSTEM, message.provider);
   setAttr(span, GEN_AI_ATTRIBUTES.REQUEST_MODEL, message.model);
-  // Dual-write the OpenInference llm.* family alongside gen_ai.*, so downstream
-  // llm.* consumers (the ones the claude-agent-sdk reference targets) see pi
-  // spans too. model_name starts at the request model; closeLlmSpan resolves it.
+  // Dual-write the OpenInference llm.* family alongside gen_ai.* for downstream
+  // consumers. model_name starts at the request model; closeLlmSpan resolves it.
   setAttr(span, OI_LLM_MODEL_NAME, message.model);
   return span;
 }
@@ -557,13 +556,13 @@ export function instrumentPiCodingAgent(sdk: unknown, config?: PiInstrumentation
     | (AgentSessionInstance & { [WRAPPED]?: boolean })
     | undefined;
   if (typeof proto?.prompt !== 'function' || typeof proto?.subscribe !== 'function') {
-    // Fail loudly, mirroring claude-agent-sdk's wiring throw: a pi SDK rename must not silently emit zero traces.
+    // Fail loudly: a pi SDK rename must not silently emit zero traces.
     throw new Error(
       '[traceroot-pi] AgentSession.prototype.prompt/subscribe not found — cannot install instrumentation.',
     );
   }
 
-  // Idempotent no-op on a second install for the same sdk (mirrors claude-agent-sdk's wrap-once return); the first call's config stands.
+  // Idempotent no-op on a second install for the same sdk; the first call's config stands.
   if (proto[WRAPPED]) {
     return sdk;
   }
@@ -606,7 +605,7 @@ export function instrumentPiCodingAgent(sdk: unknown, config?: PiInstrumentation
         sweepDanglingSpans(state, { includeRoot: true });
       }
 
-      // context.active(), matching claude-agent-sdk.ts, lets a host span nest this trace under it.
+      // context.active() lets a host span nest this trace under it.
       const parentCtx = context.active();
       const rootSpan = openRootSpan(tracer, parentCtx, {
         text: typeof text === 'string' ? text : undefined,

--- a/packages/traceroot/src/pi.ts
+++ b/packages/traceroot/src/pi.ts
@@ -154,8 +154,6 @@ export function resolveConfig(config?: PiInstrumentationConfig): ResolvedPiInstr
   };
 }
 
-// Local by design: constants.ts carries the shared attribute keys, each integration
-// carries its own span-kind values. Mirrors claude-agent-sdk.ts.
 const OI_SPAN_KIND_VALUE = {
   AGENT: 'AGENT',
   LLM: 'LLM',
@@ -213,28 +211,16 @@ const MAX_TOOL_IO_ENTRIES = 2048;
 // Appended whenever capJsonWithMarker cuts, so truncation is distinguishable from coincidence.
 const TRUNCATION_MARKER = '…[truncated]';
 
-/** Surrogate-pair-safe truncation: never splits a pair, which would corrupt the UTF-8 an OTLP/proto collector requires. */
-export function sliceSurrogateSafe(text: string, maxLen: number): string {
-  if (maxLen <= 0) return '';
-  if (text.length <= maxLen) return text;
-  let cut = maxLen;
-  const code = text.charCodeAt(cut - 1);
-  if (code >= 0xd800 && code <= 0xdbff) {
-    cut -= 1;
-  }
-  return text.slice(0, cut);
-}
-
 function capJsonWithMarker(json: string): string {
   if (json.length <= MAX_TOOL_IO_JSON_CHARS) return json;
-  return `${sliceSurrogateSafe(json, MAX_TOOL_IO_JSON_CHARS)}${TRUNCATION_MARKER}`;
+  return `${json.slice(0, MAX_TOOL_IO_JSON_CHARS)}${TRUNCATION_MARKER}`;
 }
 
 // Caps each oversized string field AND array/object breadth while walking the tree, so
 // neither one huge field nor tens of thousands of small ones fully materialize first.
 function capFieldReplacer(_key: string, value: unknown): unknown {
   if (typeof value === 'string' && value.length > MAX_TOOL_IO_JSON_CHARS) {
-    return sliceSurrogateSafe(value, MAX_TOOL_IO_JSON_CHARS);
+    return value.slice(0, MAX_TOOL_IO_JSON_CHARS);
   }
   if (Array.isArray(value) && value.length > MAX_TOOL_IO_ENTRIES) {
     return [...value.slice(0, MAX_TOOL_IO_ENTRIES), TRUNCATION_MARKER];
@@ -292,8 +278,6 @@ export function stampRootOutput(
   captureContent: boolean,
 ): void {
   if (!captureContent) return;
-  // Walk backwards rather than Array.findLast, which would need ES2023 in the
-  // package's tsconfig lib.
   let lastAssistant: AgentMessage | undefined;
   for (let i = finalMessages.length - 1; i >= 0; i -= 1) {
     if (finalMessages[i].role === 'assistant') {
@@ -392,7 +376,7 @@ function firstPathArgument(args: Record<string, unknown>): string | undefined {
 
 function truncateWithEllipsis(text: string, maxLen: number): string {
   if (text.length <= maxLen) return text;
-  return `${sliceSurrogateSafe(text, maxLen)}…`;
+  return `${text.slice(0, maxLen)}…`;
 }
 
 export function describeToolCallSpan(toolName: string, args: unknown): string {

--- a/packages/traceroot/src/pi.ts
+++ b/packages/traceroot/src/pi.ts
@@ -1,0 +1,824 @@
+import { win32 } from 'node:path';
+import { context, diag, ROOT_CONTEXT, SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';
+import type { Context, Span, Tracer } from '@opentelemetry/api';
+import {
+  OI_INPUT_VALUE,
+  OI_LLM_MODEL_NAME,
+  OI_LLM_TOKEN_COUNT_CACHE_READ,
+  OI_LLM_TOKEN_COUNT_CACHE_WRITE,
+  OI_LLM_TOKEN_COUNT_COMPLETION,
+  OI_LLM_TOKEN_COUNT_PROMPT,
+  OI_LLM_TOKEN_COUNT_TOTAL,
+  OI_OUTPUT_VALUE,
+  OI_SPAN_KIND,
+  OI_TRACE_SESSION_ID,
+  TOOL_NAME,
+} from './constants';
+import { SDK_VERSION } from './processor';
+import type { PiCodingAgentInstrumentation } from './types';
+
+/**
+ * Hand-transcribed local mirror of @earendil-works/pi-coding-agent / pi-agent-core, verified against their published .d.ts at 0.80.6 (mirrors claude-agent-sdk.ts).
+ */
+
+export interface Usage {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  reasoning?: number;
+  totalTokens: number;
+  cost: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    total: number;
+  };
+}
+
+export type StopReason = 'stop' | 'length' | 'toolUse' | 'error' | 'aborted';
+
+export interface AssistantMessage {
+  role: 'assistant';
+  content: unknown[];
+  api: string;
+  provider: string;
+  model: string;
+  responseModel?: string;
+  responseId?: string;
+  usage: Usage;
+  stopReason: StopReason;
+  errorMessage?: string;
+  timestamp: number;
+}
+
+export interface UserMessage {
+  role: 'user';
+  content: unknown;
+  timestamp: number;
+}
+
+export interface ToolResultMessage {
+  role: 'toolResult';
+  toolCallId: string;
+  toolName: string;
+  content: unknown[];
+  details?: unknown;
+  isError: boolean;
+  timestamp: number;
+}
+
+// The real AgentMessage union is wider; every consumer here narrows by `.role` first, so these four suffice.
+export interface OtherAgentMessage {
+  role: 'bashExecution' | 'custom' | 'branchSummary' | 'compactionSummary';
+  timestamp?: number;
+}
+
+export type AgentMessage = AssistantMessage | UserMessage | ToolResultMessage | OtherAgentMessage;
+
+// Shapes shared by AgentSession.subscribe() and Agent.subscribe(); the former also adds `willRetry` to agent_end.
+export type AgentEvent =
+  | { type: 'agent_start' }
+  | { type: 'agent_end'; messages: AgentMessage[]; willRetry?: boolean }
+  | { type: 'turn_start' }
+  | { type: 'turn_end'; message: AgentMessage; toolResults: ToolResultMessage[] }
+  | { type: 'message_start'; message: AgentMessage }
+  | { type: 'message_update'; message: AgentMessage }
+  | { type: 'message_end'; message: AgentMessage }
+  | { type: 'tool_execution_start'; toolCallId: string; toolName: string; args: unknown }
+  | {
+      type: 'tool_execution_update';
+      toolCallId: string;
+      toolName: string;
+      args: unknown;
+      partialResult: unknown;
+    }
+  | {
+      type: 'tool_execution_end';
+      toolCallId: string;
+      toolName: string;
+      result: unknown;
+      isError: boolean;
+    };
+
+export interface PromptOptions {
+  images?: unknown[];
+  streamingBehavior?: 'steer' | 'followUp';
+}
+
+export interface AgentSessionInstance {
+  readonly sessionId?: string;
+  /** True while a run is actively executing; prompt() routes through steer()/followUp() instead of starting fresh (see isQueueOnlySteer). */
+  readonly isStreaming?: boolean;
+  prompt(text: string, options?: PromptOptions): Promise<void>;
+  /** Queue a steering message mid-run. Optional so a partial double doesn't disable instrumentation over one missing method. */
+  steer?(text: string, images?: unknown[]): Promise<void>;
+  /** Queue a follow-up message, processed once the agent has no more tool calls or steering messages left. */
+  followUp?(text: string, images?: unknown[]): Promise<void>;
+  subscribe(listener: (event: AgentEvent) => void): () => void;
+  /** dispose() reassigns the private _eventListeners array to a fresh empty array, so no listener (including this file's own) fires again after dispose(). */
+  dispose(): void;
+}
+
+export interface AgentSessionConstructor {
+  prototype: AgentSessionInstance;
+}
+
+/** Structural shape of the imported `@earendil-works/pi-coding-agent` module namespace. */
+export interface PiCodingAgentModule {
+  AgentSession?: AgentSessionConstructor;
+  [key: string]: unknown;
+}
+
+export const TRACER_NAME = '@traceroot-ai/pi-coding-agent';
+
+export interface PiInstrumentationConfig {
+  /** Capture prompt/response text as input.value/output.value on AGENT and LLM spans. Default true. */
+  captureContent?: boolean;
+  /** Capture tool call args/results as input.value/output.value on TOOL spans. Default true. */
+  captureToolIo?: boolean;
+}
+
+export interface ResolvedPiInstrumentationConfig {
+  captureContent: boolean;
+  captureToolIo: boolean;
+}
+
+export function resolveConfig(config?: PiInstrumentationConfig): ResolvedPiInstrumentationConfig {
+  const captureContent = config?.captureContent ?? true;
+  const captureToolIo = config?.captureToolIo ?? true;
+  return {
+    captureContent,
+    captureToolIo,
+  };
+}
+
+// Local by design: constants.ts carries the shared attribute keys, each integration
+// carries its own span-kind values. Mirrors claude-agent-sdk.ts.
+const OI_SPAN_KIND_VALUE = {
+  AGENT: 'AGENT',
+  LLM: 'LLM',
+  TOOL: 'TOOL',
+} as const;
+
+// Attribute triad matching other traceroot-ts integrations: OpenInference span-kind, OTel gen_ai.*, traceroot.pi.* retry/force-close markers.
+const TR_ATTRIBUTES = {
+  RETRY_COUNT: 'traceroot.pi.retry_count',
+  FORCE_CLOSED: 'traceroot.pi.force_closed',
+  FORCE_CLOSED_REASON: 'traceroot.pi.force_closed_reason',
+} as const;
+
+// Pi reports usage in the gen_ai.* family; LLM spans dual-write the OpenInference
+// llm.* keys (from constants.ts) alongside these — see openLlmSpan/closeLlmSpan.
+const GEN_AI_ATTRIBUTES = {
+  SYSTEM: 'gen_ai.system',
+  REQUEST_MODEL: 'gen_ai.request.model',
+  RESPONSE_MODEL: 'gen_ai.response.model',
+  USAGE_INPUT_TOKENS: 'gen_ai.usage.input_tokens',
+  USAGE_OUTPUT_TOKENS: 'gen_ai.usage.output_tokens',
+  CACHE_WRITE_INPUT_TOKENS: 'gen_ai.usage.cache_creation_input_tokens',
+  CACHE_READ_INPUT_TOKENS: 'gen_ai.usage.cache_read_input_tokens',
+  TOOL_NAME: 'gen_ai.tool.name',
+  TOOL_CALL_ID: 'gen_ai.tool.call.id',
+} as const;
+
+function setAttr(
+  span: Span,
+  key: string,
+  value: string | number | boolean | undefined | null,
+): void {
+  if (value === undefined || value === null) return;
+  span.setAttribute(key, value);
+}
+
+function endSpanSafe(span: Span | undefined): void {
+  if (!span) return;
+  try {
+    span.end();
+  } catch {
+    // Never let a misbehaving OTel exporter/processor crash the host app.
+  }
+}
+
+// Caps exported tool JSON so one call can't inflate a span's attribute payload without bound.
+const MAX_TOOL_IO_JSON_CHARS = 32 * 1024; // 32 KB of UTF-16 code units
+
+// Caps array/object breadth so a "wide" payload (tens of thousands of small entries,
+// e.g. a custom/MCP tool result) can't fully materialize in JSON.stringify before
+// capJsonWithMarker discards it — bounds transient serialization cost, not just the
+// final attribute size.
+const MAX_TOOL_IO_ENTRIES = 2048;
+
+// Appended whenever capJsonWithMarker cuts, so truncation is distinguishable from coincidence.
+const TRUNCATION_MARKER = '…[truncated]';
+
+/** Surrogate-pair-safe truncation: never splits a pair, which would corrupt the UTF-8 an OTLP/proto collector requires. */
+export function sliceSurrogateSafe(text: string, maxLen: number): string {
+  if (maxLen <= 0) return '';
+  if (text.length <= maxLen) return text;
+  let cut = maxLen;
+  const code = text.charCodeAt(cut - 1);
+  if (code >= 0xd800 && code <= 0xdbff) {
+    cut -= 1;
+  }
+  return text.slice(0, cut);
+}
+
+function capJsonWithMarker(json: string): string {
+  if (json.length <= MAX_TOOL_IO_JSON_CHARS) return json;
+  return `${sliceSurrogateSafe(json, MAX_TOOL_IO_JSON_CHARS)}${TRUNCATION_MARKER}`;
+}
+
+// Caps each oversized string field AND array/object breadth while walking the tree, so
+// neither one huge field nor tens of thousands of small ones fully materialize first.
+function capFieldReplacer(_key: string, value: unknown): unknown {
+  if (typeof value === 'string' && value.length > MAX_TOOL_IO_JSON_CHARS) {
+    return sliceSurrogateSafe(value, MAX_TOOL_IO_JSON_CHARS);
+  }
+  if (Array.isArray(value) && value.length > MAX_TOOL_IO_ENTRIES) {
+    return [...value.slice(0, MAX_TOOL_IO_ENTRIES), TRUNCATION_MARKER];
+  }
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    const keys = Object.keys(value as Record<string, unknown>);
+    if (keys.length > MAX_TOOL_IO_ENTRIES) {
+      const capped: Record<string, unknown> = {};
+      for (const key of keys.slice(0, MAX_TOOL_IO_ENTRIES)) {
+        capped[key] = (value as Record<string, unknown>)[key];
+      }
+      capped[TRUNCATION_MARKER] = TRUNCATION_MARKER;
+      return capped;
+    }
+  }
+  return value;
+}
+
+// JSON.stringify can return undefined for a top-level undefined value, despite its `string` type — short-circuit before capJsonWithMarker's .length.
+function stringifyToolIo(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  return JSON.stringify(value, capFieldReplacer);
+}
+
+function assistantTextOf(message: AgentMessage | undefined): string | undefined {
+  if (!message) return undefined;
+  if (message.role === 'user' && typeof message.content === 'string') return message.content;
+  if (message.role !== 'assistant') return undefined;
+  // Malformed/non-array content is treated as "no text", not thrown, to avoid skipping the caller's span close.
+  if (!Array.isArray(message.content)) return undefined;
+  const parts = message.content
+    .filter((c): c is { type: 'text'; text: string } => {
+      return typeof c === 'object' && c !== null && (c as { type?: unknown }).type === 'text';
+    })
+    .map((c) => c.text);
+  return parts.length > 0 ? parts.join('') : undefined;
+}
+
+export function openRootSpan(
+  tracer: Pick<Tracer, 'startSpan'>,
+  parentCtx: Context,
+  input: { text: string | undefined; sessionId: string | undefined; captureContent: boolean },
+): Span {
+  const span = tracer.startSpan('AgentSession.prompt', { kind: SpanKind.INTERNAL }, parentCtx);
+  setAttr(span, OI_SPAN_KIND, OI_SPAN_KIND_VALUE.AGENT);
+  setAttr(span, OI_TRACE_SESSION_ID, input.sessionId);
+  if (input.captureContent) setAttr(span, OI_INPUT_VALUE, input.text);
+  return span;
+}
+
+// Stamps output onto the root span without ending it; continuations share one root, so the last agent_end wins.
+export function stampRootOutput(
+  span: Span,
+  finalMessages: AgentMessage[],
+  captureContent: boolean,
+): void {
+  if (!captureContent) return;
+  // Walk backwards rather than Array.findLast, which would need ES2023 in the
+  // package's tsconfig lib.
+  let lastAssistant: AgentMessage | undefined;
+  for (let i = finalMessages.length - 1; i >= 0; i -= 1) {
+    if (finalMessages[i].role === 'assistant') {
+      lastAssistant = finalMessages[i];
+      break;
+    }
+  }
+  setAttr(span, OI_OUTPUT_VALUE, assistantTextOf(lastAssistant));
+}
+
+// Ends the root span exactly once, when the wrapping prompt() call's own returned promise settles.
+export function finalizeRootSpan(
+  span: Span,
+  retryCount: number,
+  status: { code: SpanStatusCode; message?: string },
+  error?: unknown,
+): void {
+  // Called from a detached .then() chain nobody awaits, so guard against unhandledRejection here too.
+  try {
+    setAttr(span, TR_ATTRIBUTES.RETRY_COUNT, retryCount);
+    span.setStatus(status);
+    if (error !== undefined) {
+      span.recordException(error instanceof Error ? error : new Error(String(error)));
+    }
+  } catch {
+    // best-effort, same as endSpanSafe
+  }
+  endSpanSafe(span);
+}
+
+export function openLlmSpan(
+  tracer: Pick<Tracer, 'startSpan'>,
+  parentCtx: Context,
+  message: AssistantMessage,
+): Span {
+  const span = tracer.startSpan(message.model || 'pi.llm', { kind: SpanKind.CLIENT }, parentCtx);
+  setAttr(span, OI_SPAN_KIND, OI_SPAN_KIND_VALUE.LLM);
+  setAttr(span, GEN_AI_ATTRIBUTES.SYSTEM, message.provider);
+  setAttr(span, GEN_AI_ATTRIBUTES.REQUEST_MODEL, message.model);
+  // Dual-write the OpenInference llm.* family alongside gen_ai.*, so downstream
+  // llm.* consumers (the ones the claude-agent-sdk reference targets) see pi
+  // spans too. model_name starts at the request model; closeLlmSpan resolves it.
+  setAttr(span, OI_LLM_MODEL_NAME, message.model);
+  return span;
+}
+
+export function closeLlmSpan(span: Span, message: AssistantMessage, captureContent: boolean): void {
+  span.updateName(message.responseModel || message.model || 'pi.llm');
+  setAttr(span, GEN_AI_ATTRIBUTES.RESPONSE_MODEL, message.responseModel || message.model);
+  setAttr(span, GEN_AI_ATTRIBUTES.USAGE_INPUT_TOKENS, message.usage?.input);
+  setAttr(span, GEN_AI_ATTRIBUTES.USAGE_OUTPUT_TOKENS, message.usage?.output);
+  setAttr(span, GEN_AI_ATTRIBUTES.CACHE_READ_INPUT_TOKENS, message.usage?.cacheRead);
+  setAttr(span, GEN_AI_ATTRIBUTES.CACHE_WRITE_INPUT_TOKENS, message.usage?.cacheWrite);
+  // OpenInference llm.* dual-write of the same numbers (see openLlmSpan). Pi
+  // reports totalTokens directly, so llm.token_count.total uses it as-is rather
+  // than recomputing prompt+completion.
+  setAttr(span, OI_LLM_MODEL_NAME, message.responseModel || message.model);
+  setAttr(span, OI_LLM_TOKEN_COUNT_PROMPT, message.usage?.input);
+  setAttr(span, OI_LLM_TOKEN_COUNT_COMPLETION, message.usage?.output);
+  setAttr(span, OI_LLM_TOKEN_COUNT_TOTAL, message.usage?.totalTokens);
+  setAttr(span, OI_LLM_TOKEN_COUNT_CACHE_READ, message.usage?.cacheRead);
+  setAttr(span, OI_LLM_TOKEN_COUNT_CACHE_WRITE, message.usage?.cacheWrite);
+  if (captureContent) {
+    setAttr(span, OI_OUTPUT_VALUE, assistantTextOf(message));
+  }
+  if (message.stopReason === 'error' || message.stopReason === 'aborted') {
+    span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: message.errorMessage || message.stopReason,
+    });
+  }
+  endSpanSafe(span);
+}
+
+// Privacy-safe tool span naming: never a full file path, commands/basenames capped to MAX_NAME_SEGMENT_CHARS.
+const basename = win32.basename;
+
+const MAX_NAME_SEGMENT_CHARS = 60;
+
+const TOOL_PATH_ARGUMENT_KEYS = [
+  'path',
+  'file',
+  'filePath',
+  'file_path',
+  'filename',
+  'target',
+] as const;
+
+function firstPathArgument(args: Record<string, unknown>): string | undefined {
+  for (const key of TOOL_PATH_ARGUMENT_KEYS) {
+    const value = args[key];
+    if (typeof value === 'string' && value) return value;
+  }
+  return undefined;
+}
+
+function truncateWithEllipsis(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  return `${sliceSurrogateSafe(text, maxLen)}…`;
+}
+
+export function describeToolCallSpan(toolName: string, args: unknown): string {
+  if (args && typeof args === 'object') {
+    const a = args as Record<string, unknown>;
+    // Checked first, exclusively by command, so an incidental path/target argument (e.g. cwd) can't shadow it.
+    if (toolName === 'bash' && typeof a.command === 'string' && a.command) {
+      const cmd = a.command.replace(/\s+/g, ' ').trim();
+      if (cmd) return `bash: ${truncateWithEllipsis(cmd, MAX_NAME_SEGMENT_CHARS)}`;
+    }
+    const pathLike = firstPathArgument(a);
+    if (pathLike) {
+      const base = basename(pathLike);
+      // Can still basename() to '' (e.g. "/") — fall through instead of "toolName: ".
+      if (base) {
+        return `${toolName}: ${truncateWithEllipsis(base, MAX_NAME_SEGMENT_CHARS)}`;
+      }
+    }
+  }
+  return toolName;
+}
+
+export function openToolSpan(
+  tracer: Pick<Tracer, 'startSpan'>,
+  parentCtx: Context,
+  toolCallId: string,
+  toolName: string,
+  args: unknown,
+  captureToolIo: boolean,
+): Span {
+  const span = tracer.startSpan(
+    // captureToolIo gates arg-derived content in the NAME too, not just input/output:
+    // a bash command or file path is tool IO and must not leak into the span name when
+    // the caller opted out (e.g. `bash: curl -H "Authorization: Bearer ..."`).
+    captureToolIo ? describeToolCallSpan(toolName, args) : toolName,
+    { kind: SpanKind.INTERNAL },
+    parentCtx,
+  );
+  setAttr(span, OI_SPAN_KIND, OI_SPAN_KIND_VALUE.TOOL);
+  // Dual-write OpenInference tool.name alongside gen_ai.tool.name (matches
+  // claude-agent-sdk.ts) so dashboards keyed on the OI attribute surface pi tool spans.
+  setAttr(span, TOOL_NAME, toolName);
+  setAttr(span, GEN_AI_ATTRIBUTES.TOOL_NAME, toolName);
+  setAttr(span, GEN_AI_ATTRIBUTES.TOOL_CALL_ID, toolCallId);
+  if (captureToolIo) {
+    try {
+      const serializedArgs = stringifyToolIo(args);
+      if (serializedArgs !== undefined) {
+        setAttr(span, OI_INPUT_VALUE, capJsonWithMarker(serializedArgs));
+      }
+    } catch {
+      // args may contain circular refs or BigInt — skip rather than crash.
+    }
+  }
+  return span;
+}
+
+export function closeToolSpan(
+  span: Span,
+  result: unknown,
+  isError: boolean,
+  captureToolIo: boolean,
+): void {
+  if (captureToolIo) {
+    try {
+      const serializedResult = stringifyToolIo(result);
+      if (serializedResult !== undefined) {
+        setAttr(span, OI_OUTPUT_VALUE, capJsonWithMarker(serializedResult));
+      }
+    } catch {
+      // result may contain circular refs or BigInt — skip rather than crash.
+    }
+  }
+  if (isError) {
+    span.setStatus({ code: SpanStatusCode.ERROR });
+  }
+  endSpanSafe(span);
+}
+
+// Used when a span is force-closed by a later event; only the setAttr call is guarded so a throw there can't skip endSpanSafe.
+export function closeDanglingSpan(span: Span | undefined): void {
+  if (!span) return;
+  try {
+    setAttr(span, TR_ATTRIBUTES.FORCE_CLOSED, true);
+  } catch (err) {
+    // diag.warn, not console: proper OTel logging infrastructure, silent unless the host registers a DiagLogger, and it must never throw mid-flight.
+    diag.warn('[traceroot-pi] failed to mark a dangling span force_closed (still ending it):', err);
+  }
+  endSpanSafe(span);
+}
+
+// Symbol.for(), not a bare Symbol(): two independently-loaded copies of this package must see the same registry key to detect a second instrumentPiCodingAgent() call — do not change this without adding multiplexing support.
+const WRAPPED = Symbol.for('traceroot.pi.wrapped');
+
+interface SessionSpanState {
+  rootSpan: Span | undefined;
+  rootCtx: Context | undefined;
+  llmSpan: Span | undefined;
+  llmCtx: Context | undefined;
+  toolSpans: Map<string, Span>;
+  retryCount: number;
+}
+
+// Force-closes spans left open by an abandoned run, root only when requested.
+function sweepDanglingSpans(
+  state: SessionSpanState,
+  options: { includeRoot?: boolean } = {},
+): void {
+  for (const [, span] of state.toolSpans) {
+    closeDanglingSpan(span);
+  }
+  state.toolSpans.clear();
+  closeDanglingSpan(state.llmSpan);
+  state.llmSpan = undefined;
+  state.llmCtx = undefined;
+  if (options.includeRoot) {
+    closeDanglingSpan(state.rootSpan);
+    state.rootSpan = undefined;
+    state.rootCtx = undefined;
+  }
+}
+
+// Guarantees subscribe() ran once — proto.prompt/steer/followUp can each independently be a session's first call.
+function ensureSubscribed(
+  session: AgentSessionInstance,
+  tracer: Pick<Tracer, 'startSpan'>,
+  config: ResolvedPiInstrumentationConfig,
+  subscribedSessions: WeakSet<AgentSessionInstance>,
+  sessionSpanState: WeakMap<AgentSessionInstance, SessionSpanState>,
+): void {
+  if (subscribedSessions.has(session)) return;
+  subscribedSessions.add(session);
+  attachSpanListener(session, tracer, config, sessionSpanState);
+}
+
+/**
+ * An `instrumentModules.piCodingAgent` value is the `{ module, config }` wrapper
+ * form (vs a raw pi module ref) when it carries a `module` property and is NOT
+ * itself a pi module namespace. The negative `AgentSession` check guards against a
+ * future pi module that also exports a `module` symbol: the real pi namespace
+ * exposes `AgentSession`, the wrapper does not, so the two stay distinguishable.
+ */
+function isPiCodingAgentWrapper(entry: unknown): entry is PiCodingAgentInstrumentation {
+  return (
+    typeof entry === 'object' &&
+    entry !== null &&
+    'module' in entry &&
+    (entry as { module?: unknown }).module != null &&
+    !('AgentSession' in entry)
+  );
+}
+
+/**
+ * Dispatcher entry point for pi, called once by wireInstrumentations() in
+ * instrumentation.ts. Kept here rather than inline in that shared file so the
+ * dispatcher stays symmetric with claude/openai (one import + one call). Unwraps
+ * the optional { module, config } form; pi carries its own captureContent/
+ * captureToolIo config, passed through unmerged (there is no apiKey/baseUrl to
+ * thread). A throw from instrumentPiCodingAgent() surfaces, same as claude's.
+ */
+export function wirePiCodingAgentInstrumentation(entry: unknown): void {
+  let mod: unknown = entry;
+  let explicitConfig: PiInstrumentationConfig | undefined;
+  if (isPiCodingAgentWrapper(entry)) {
+    mod = entry.module;
+    explicitConfig = entry.config;
+  }
+  instrumentPiCodingAgent(mod, explicitConfig);
+}
+
+export function instrumentPiCodingAgent(sdk: unknown, config?: PiInstrumentationConfig): unknown {
+  const mod = sdk as PiCodingAgentModule;
+
+  const resolved = resolveConfig(config);
+
+  // Stamped on AgentSession.prototype, never on `mod`: an ESM namespace object is permanently non-extensible, so defineProperty(mod, ...) would throw.
+  const proto = mod?.AgentSession?.prototype as
+    | (AgentSessionInstance & { [WRAPPED]?: boolean })
+    | undefined;
+  if (typeof proto?.prompt !== 'function' || typeof proto?.subscribe !== 'function') {
+    // Fail loudly, mirroring claude-agent-sdk's wiring throw: a pi SDK rename must not silently emit zero traces.
+    throw new Error(
+      '[traceroot-pi] AgentSession.prototype.prompt/subscribe not found — cannot install instrumentation.',
+    );
+  }
+
+  // Idempotent no-op on a second install for the same sdk (mirrors claude-agent-sdk's wrap-once return); the first call's config stands.
+  if (proto[WRAPPED]) {
+    return sdk;
+  }
+
+  // resolve at use, never capture: TraceRoot.shutdown() calls trace.disable(),
+  // which swaps the OTel proxy provider for a fresh instance. A tracer captured
+  // once here would stay bound to the old, now-detached provider, so after a
+  // shutdown()/initialize() cycle every span it opens goes silently dark.
+  // Re-resolve the globally-registered provider on each span-open.
+  const tracer: Pick<Tracer, 'startSpan'> = {
+    startSpan: (name, options, ctx) =>
+      trace.getTracer(TRACER_NAME, SDK_VERSION).startSpan(name, options, ctx),
+  };
+
+  const subscribedSessions = new WeakSet<AgentSessionInstance>();
+  // Out-of-band, since dispose() (below) has no closure over a session.
+  const sessionSpanState = new WeakMap<AgentSessionInstance, SessionSpanState>();
+
+  const rollback: Array<() => void> = [];
+  try {
+    const originalPrompt = proto.prompt;
+    proto.prompt = function (this: AgentSessionInstance, text, options) {
+      ensureSubscribed(this, tracer, resolved, subscribedSessions, sessionSpanState);
+
+      // Queue-only steer: if already streaming with streamingBehavior set, delegate straight through before any root management, or we'd force-close the active run's still-open root.
+      const isQueueOnlySteer = this.isStreaming === true && !!options?.streamingBehavior;
+      if (isQueueOnlySteer) {
+        return originalPrompt.call(this, text, options);
+      }
+
+      // Non-undefined: ensureSubscribed() above created or found this entry.
+      const state = sessionSpanState.get(this) as SessionSpanState;
+
+      // OVERLAP SAFETY: a new call raced a still-open prior root — force-close it rather than silently leaking it.
+      // This can also fire on an accidental double-submit (isStreaming flips only after several awaits inside
+      // prompt()), so stamp a distinct reason on the superseded root: its trace is truncated by design, and this
+      // keeps that debuggable from the exported data.
+      if (state.rootSpan) {
+        setAttr(state.rootSpan, TR_ATTRIBUTES.FORCE_CLOSED_REASON, 'superseded_by_new_prompt');
+        sweepDanglingSpans(state, { includeRoot: true });
+      }
+
+      // context.active(), matching claude-agent-sdk.ts, lets a host span nest this trace under it.
+      const parentCtx = context.active();
+      const rootSpan = openRootSpan(tracer, parentCtx, {
+        text: typeof text === 'string' ? text : undefined,
+        sessionId: this.sessionId,
+        captureContent: resolved.captureContent,
+      });
+      state.rootSpan = rootSpan;
+      state.rootCtx = trace.setSpan(parentCtx, rootSpan);
+      state.retryCount = 0;
+
+      // Guarded by identity so a mid-run dispose() or a later sweep, which may have already force-closed it, never double-ends. Derives the status message from the error, if any.
+      const finalize = (code: SpanStatusCode, error?: unknown): void => {
+        if (state.rootSpan !== rootSpan) return;
+        state.rootSpan = undefined;
+        state.rootCtx = undefined;
+        // A rejection can leave the in-flight attempt's spans unclosed.
+        sweepDanglingSpans(state);
+        const message =
+          error === undefined ? undefined : error instanceof Error ? error.message : String(error);
+        finalizeRootSpan(rootSpan, state.retryCount, { code, message }, error);
+      };
+
+      // A synchronous throw here never reached agent_start: finalize ERROR and rethrow.
+      let result: Promise<void>;
+      try {
+        result = originalPrompt.call(this, text, options);
+      } catch (err) {
+        finalize(SpanStatusCode.ERROR, err);
+        throw err;
+      }
+      // Separate .then() chain, not a return of result.then(...): that would swallow the rejection since onReject here doesn't rethrow.
+      result.then(
+        () => finalize(SpanStatusCode.OK),
+        (err: unknown) => finalize(SpanStatusCode.ERROR, err),
+      );
+      return result;
+    };
+    rollback.push(() => {
+      proto.prompt = originalPrompt;
+    });
+
+    // Standalone entry points, not prompt() wrappers — needed so a session's first call being one of these still triggers subscribe(). Both just subscribe then delegate, so they share one wrapper.
+    const patchSubscribeTrigger = (name: 'steer' | 'followUp'): void => {
+      const original = proto[name];
+      if (typeof original !== 'function') return;
+      proto[name] = function (this: AgentSessionInstance, text: string, images?: unknown[]) {
+        ensureSubscribed(this, tracer, resolved, subscribedSessions, sessionSpanState);
+        return original.call(this, text, images);
+      };
+      rollback.push(() => {
+        proto[name] = original;
+      });
+    };
+    patchSubscribeTrigger('steer');
+    patchSubscribeTrigger('followUp');
+
+    if (typeof proto.dispose === 'function') {
+      const originalDispose = proto.dispose;
+      proto.dispose = function (this: AgentSessionInstance): void {
+        // The real dispose() only clears _eventListeners, so force-close any still-open spans first.
+        const state = sessionSpanState.get(this);
+        if (state) {
+          try {
+            sweepDanglingSpans(state, { includeRoot: true });
+          } catch (err) {
+            // Must never make dispose() throw — the host still needs teardown. diag.warn, not console (see closeDanglingSpan).
+            diag.warn(
+              '[traceroot-pi] failed to force-close in-flight spans during dispose() (a span may leak):',
+              err,
+            );
+          } finally {
+            // sweepDanglingSpans({ includeRoot: true }) above already nulled every span/ctx field; the state is dropped here regardless.
+            sessionSpanState.delete(this);
+            // Else a reused session would never re-subscribe (still "has" it).
+            subscribedSessions.delete(this);
+          }
+        }
+        return originalDispose.call(this);
+      };
+      rollback.push(() => {
+        proto.dispose = originalDispose;
+      });
+    }
+
+    // Only mark wrapped after every patch succeeded, else a re-entrant call could double-emit spans.
+    Object.defineProperty(proto, WRAPPED, { value: true, enumerable: false });
+  } catch (err) {
+    for (let i = rollback.length - 1; i >= 0; i--) {
+      rollback[i]();
+    }
+    throw new Error('[traceroot-pi] failed to install instrumentation on AgentSession.prototype', {
+      cause: err,
+    });
+  }
+
+  return sdk;
+}
+
+function attachSpanListener(
+  session: AgentSessionInstance,
+  tracer: Pick<Tracer, 'startSpan'>,
+  config: ResolvedPiInstrumentationConfig,
+  sessionSpanState: WeakMap<AgentSessionInstance, SessionSpanState>,
+): void {
+  const state: SessionSpanState = {
+    rootSpan: undefined,
+    rootCtx: undefined,
+    llmSpan: undefined,
+    llmCtx: undefined,
+    toolSpans: new Map(),
+    retryCount: 0,
+  };
+  sessionSpanState.set(session, state);
+
+  session.subscribe((event: AgentEvent) => {
+    try {
+      handleEvent(event, tracer, config, state);
+    } catch (err) {
+      // Must never reach Pi's event dispatcher and destabilize its agent loop. diag.warn, not console (see closeDanglingSpan).
+      diag.warn(
+        '[traceroot-pi] instrumentation handler failed (a span may be missing or incomplete):',
+        err,
+      );
+    }
+  });
+}
+
+function handleEvent(
+  event: AgentEvent,
+  tracer: Pick<Tracer, 'startSpan'>,
+  config: ResolvedPiInstrumentationConfig,
+  state: SessionSpanState,
+): void {
+  switch (event.type) {
+    case 'agent_start': {
+      // Sweep dangling spans from a crashed prior attempt; root is untouched (owned by prompt()).
+      sweepDanglingSpans(state);
+      // An undefined state.rootSpan means this run bypassed the wrapped prompt() call — do not synthesize one.
+      break;
+    }
+    case 'message_start': {
+      if (event.message.role !== 'assistant') return;
+      // A second message_start with no intervening message_end means the previous LLM span was abandoned — force-close it first.
+      closeDanglingSpan(state.llmSpan);
+      // Falls back to ROOT_CONTEXT, never context.active(): the latter is the host's ambient OTel context, unrelated to this session, and would risk cross-trace contamination.
+      const parentCtx = state.rootCtx ?? ROOT_CONTEXT;
+      state.llmSpan = openLlmSpan(tracer, parentCtx, event.message);
+      state.llmCtx = trace.setSpan(parentCtx, state.llmSpan);
+      break;
+    }
+    case 'message_end': {
+      if (event.message.role !== 'assistant') return;
+      if (state.llmSpan) closeLlmSpan(state.llmSpan, event.message, config.captureContent);
+      state.llmSpan = undefined;
+      // llmCtx stays alive on purpose: this turn's tool_execution events fire after message_end but before turn_end, and still parent under the ended LLM span.
+      break;
+    }
+    case 'turn_end': {
+      // If a stream error cut the turn short before message_end closed llmSpan, sweep force-closes it (and tool spans); root is untouched.
+      sweepDanglingSpans(state);
+      break;
+    }
+    case 'tool_execution_start': {
+      // An already-open toolCallId would have its Map slot silently overwritten — force-close first.
+      const existing = state.toolSpans.get(event.toolCallId);
+      closeDanglingSpan(existing);
+      const parentCtx = state.llmCtx ?? state.rootCtx ?? ROOT_CONTEXT;
+      const span = openToolSpan(
+        tracer,
+        parentCtx,
+        event.toolCallId,
+        event.toolName,
+        event.args,
+        config.captureToolIo,
+      );
+      state.toolSpans.set(event.toolCallId, span);
+      break;
+    }
+    case 'tool_execution_end': {
+      const span = state.toolSpans.get(event.toolCallId);
+      if (span) closeToolSpan(span, event.result, event.isError, config.captureToolIo);
+      state.toolSpans.delete(event.toolCallId);
+      break;
+    }
+    case 'agent_end': {
+      // Mirrors turn_end's sweep; root is not swept (closing it is proto.prompt's job) — this only stamps output onto whatever is open.
+      sweepDanglingSpans(state);
+      if (state.rootSpan) {
+        stampRootOutput(state.rootSpan, event.messages, config.captureContent);
+      }
+      if (event.willRetry) {
+        state.retryCount += 1;
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}

--- a/packages/traceroot/src/types.ts
+++ b/packages/traceroot/src/types.ts
@@ -4,14 +4,9 @@ import type { PiInstrumentationConfig } from './pi';
 export type SpanType = 'span' | 'agent' | 'tool' | 'llm';
 
 /**
- * The object form of `instrumentModules.piCodingAgent`: the
- * `@earendil-works/pi-coding-agent` module ref bundled with an explicit
- * {@link PiInstrumentationConfig}. Use this instead of the bare module ref
- * when you need to override capture behavior (e.g. `captureContent: false`
- * or `captureToolIo: false` for PII control). This in-tree integration
- * builds no export pipeline of its own -- there is no apiKey/baseUrl here to
- * override; it always gets its tracer from the globally-registered OTel
- * provider core (`TraceRoot.initialize()`) already set up.
+ * The object form of `instrumentModules.piCodingAgent`: the pi module ref plus
+ * an explicit {@link PiInstrumentationConfig}. Use instead of the bare module
+ * ref to override capture behavior (e.g. `captureContent: false` for PII).
  */
 export interface PiCodingAgentInstrumentation {
   /** `import * as pi from '@earendil-works/pi-coding-agent'`. */
@@ -82,20 +77,13 @@ export interface InitializeOptions {
      */
     openaiAgents?: unknown;
     /**
-     * @earendil-works/pi-coding-agent instrumentation, built in to this
-     * package (packages/traceroot/src/pi.ts). Accepts either:
-     *  - the bare module ref: `import * as pi from '@earendil-works/pi-coding-agent'`; or
-     *  - a {@link PiCodingAgentInstrumentation} wrapper: `{ module: pi, config: {...} }`,
-     *    to override capture behavior (`captureContent`/`captureToolIo`) —
-     *    the deliberate divergence from {@link claudeAgentSDK}, which has no
-     *    config at all.
+     * @earendil-works/pi-coding-agent module ref, or a
+     * {@link PiCodingAgentInstrumentation} wrapper (`{ module: pi, config }`)
+     * to override `captureContent`/`captureToolIo` — a deliberate divergence
+     * from {@link claudeAgentSDK}, which has no config at all.
      *
-     * Delegates directly to instrumentPiCodingAgent() (./pi.ts),
-     * which auto-discovers the already-registered global OTel provider core
-     * sets up, so pi's spans land in the same shared pipeline as the rest of
-     * TraceRoot's traces. No separate package install, no lazy-loading, and
-     * no apiKey/baseUrl threading — this in-tree integration never builds an
-     * export pipeline of its own.
+     * Traces through the globally-registered provider and builds no export
+     * pipeline of its own, so there is no apiKey/baseUrl to thread here.
      */
     piCodingAgent?: unknown;
   };

--- a/packages/traceroot/src/types.ts
+++ b/packages/traceroot/src/types.ts
@@ -1,6 +1,24 @@
 // src/types.ts
+import type { PiInstrumentationConfig } from './pi';
 
 export type SpanType = 'span' | 'agent' | 'tool' | 'llm';
+
+/**
+ * The object form of `instrumentModules.piCodingAgent`: the
+ * `@earendil-works/pi-coding-agent` module ref bundled with an explicit
+ * {@link PiInstrumentationConfig}. Use this instead of the bare module ref
+ * when you need to override capture behavior (e.g. `captureContent: false`
+ * or `captureToolIo: false` for PII control). This in-tree integration
+ * builds no export pipeline of its own -- there is no apiKey/baseUrl here to
+ * override; it always gets its tracer from the globally-registered OTel
+ * provider core (`TraceRoot.initialize()`) already set up.
+ */
+export interface PiCodingAgentInstrumentation {
+  /** `import * as pi from '@earendil-works/pi-coding-agent'`. */
+  module: unknown;
+  /** Explicit pi instrumentation config (captureContent/captureToolIo); overrides the defaults. */
+  config?: PiInstrumentationConfig;
+}
 
 export interface ObserveOptions {
   /** Span name. Defaults to fn.name, then 'anonymous'. */
@@ -63,6 +81,23 @@ export interface InitializeOptions {
      * after `initialize()`.
      */
     openaiAgents?: unknown;
+    /**
+     * @earendil-works/pi-coding-agent instrumentation, built in to this
+     * package (packages/traceroot/src/pi.ts). Accepts either:
+     *  - the bare module ref: `import * as pi from '@earendil-works/pi-coding-agent'`; or
+     *  - a {@link PiCodingAgentInstrumentation} wrapper: `{ module: pi, config: {...} }`,
+     *    to override capture behavior (`captureContent`/`captureToolIo`) —
+     *    the deliberate divergence from {@link claudeAgentSDK}, which has no
+     *    config at all.
+     *
+     * Delegates directly to instrumentPiCodingAgent() (./pi.ts),
+     * which auto-discovers the already-registered global OTel provider core
+     * sets up, so pi's spans land in the same shared pipeline as the rest of
+     * TraceRoot's traces. No separate package install, no lazy-loading, and
+     * no apiKey/baseUrl threading — this in-tree integration never builds an
+     * export pipeline of its own.
+     */
+    piCodingAgent?: unknown;
   };
   /** Use SimpleSpanProcessor instead of BatchSpanProcessor. Useful for scripts/tests. */
   disableBatch?: boolean;

--- a/packages/traceroot/tests/pi-lifecycle-edge-cases.test.ts
+++ b/packages/traceroot/tests/pi-lifecycle-edge-cases.test.ts
@@ -1,0 +1,1193 @@
+// Consolidated pi lifecycle + edge-case coverage: event ordering, span parenting,
+// close-event idempotency, the dangling-span sweep, instrumentation edge cases, install
+// rollback, tracer reresolution, and the real-SDK shape smoke (merged from
+// pi-coding-agent-span-lifecycle.test.ts and pi-coding-agent-lifecycle-edge-cases.test.ts).
+// Span-construction/wrapper/wiring coverage lives in pi.test.ts.
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  ROOT_CONTEXT,
+  SpanStatusCode,
+  TraceFlags,
+  context,
+  propagation,
+  trace,
+} from '@opentelemetry/api';
+import type { Context, ContextManager, SpanContext } from '@opentelemetry/api';
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { instrumentPiCodingAgent, stampRootOutput, type AgentMessage } from '../src/pi';
+import {
+  CapturingExporter,
+  assistantMessage,
+  attrs,
+  makeFakeSessionClass,
+  makeRig,
+} from './pi-test-helpers';
+
+// Shared by the describes below that need to drive instrumentPiCodingAgent() directly.
+function registerCapturingProvider(capture: CapturingExporter): void {
+  trace.disable();
+  const provider = new NodeTracerProvider();
+  provider.addSpanProcessor(new SimpleSpanProcessor(capture));
+  provider.register();
+}
+
+describe('pi span lifecycle event ordering', () => {
+  // Probes out-of-order/malformed AgentEvent sequences: a span never .end()ed is never exported,
+  // so an abandoned span/state must always be force-closed, never silently overwritten.
+  it('a second message_start with no intervening message_end/turn_end force-closes the abandoned first LLM span instead of silently dropping it', async () => {
+    const { capture, Session } = makeRig();
+    const session = new Session();
+
+    const done = session.prompt(
+      'two message_start events fire back to back, no message_end between them',
+    );
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'message_start', message: assistantMessage({ model: 'first-model' }) });
+    assert.doesNotThrow(() => {
+      session.emit({ type: 'message_start', message: assistantMessage({ model: 'second-model' }) });
+    });
+    session.emit({ type: 'message_end', message: assistantMessage({ model: 'second-model' }) });
+    session.emit({ type: 'turn_end', message: assistantMessage(), toolResults: [] });
+    session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    await done;
+
+    const llmSpans = capture.spans.filter((s) => attrs(s)['openinference.span.kind'] === 'LLM');
+    assert.equal(
+      llmSpans.length,
+      2,
+      'both the abandoned first LLM span and the properly-closed second must be exported -- the ' +
+        'first must never silently vanish just because state.llmSpan was overwritten',
+    );
+    const firstSpan = llmSpans.find((s) => attrs(s)['gen_ai.request.model'] === 'first-model');
+    const secondSpan = llmSpans.find((s) => attrs(s)['gen_ai.request.model'] === 'second-model');
+    assert.ok(
+      firstSpan,
+      'the abandoned first LLM span must still have been force-closed and exported',
+    );
+    assert.ok(secondSpan, 'the second LLM span must close normally via message_end');
+    assert.equal(
+      attrs(firstSpan!)['traceroot.pi.force_closed'],
+      true,
+      'the abandoned first LLM span must be marked as abnormally closed',
+    );
+    assert.equal(
+      attrs(secondSpan!)['traceroot.pi.force_closed'],
+      undefined,
+      'the normally-closed second LLM span must NOT be marked force-closed',
+    );
+  });
+});
+
+describe('pi span context parenting', () => {
+  // Probes OTel Context/parent-span correctness across turn boundaries and ambient-context leakage.
+
+  // steer() attaches the listener without ever opening a root, unlike prompt() -- the "no root"
+  // case the ambient test below needs. Fresh class per rig; the prototype is patched directly.
+  function makeSteerRig() {
+    trace.disable();
+    const capture = new CapturingExporter();
+    const provider = new NodeTracerProvider();
+    provider.addSpanProcessor(new SimpleSpanProcessor(capture));
+    provider.register();
+    const Base = makeFakeSessionClass();
+    class SteerAgentSession extends Base {
+      async steer(_text: string): Promise<void> {}
+    }
+    instrumentPiCodingAgent({ AgentSession: SteerAgentSession }, {});
+    return { capture, Session: SteerAgentSession };
+  }
+
+  // A real, synchronous ContextManager, since NoopContextManager makes context.with() a no-op.
+  class StackContextManager implements ContextManager {
+    private stack: Context[] = [ROOT_CONTEXT];
+    active(): Context {
+      return this.stack[this.stack.length - 1]!;
+    }
+    with<A extends unknown[], F extends (...args: A) => ReturnType<F>>(
+      ctx: Context,
+      fn: F,
+      thisArg?: ThisParameterType<F>,
+      ...args: A
+    ): ReturnType<F> {
+      this.stack.push(ctx);
+      try {
+        return fn.call(thisArg, ...args);
+      } finally {
+        this.stack.pop();
+      }
+    }
+    bind<T>(_ctx: Context, target: T): T {
+      return target;
+    }
+    enable(): this {
+      return this;
+    }
+    disable(): this {
+      return this;
+    }
+  }
+
+  const AMBIENT_SPAN_CONTEXT: SpanContext = {
+    traceId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    spanId: 'aaaaaaaaaaaaaaaa',
+    traceFlags: TraceFlags.SAMPLED,
+  };
+
+  it('a tool span opened during turn 1 keeps its parent bound to turn 1s LLM span (OTel Context is captured immutably at open time) even after turn 2 has already opened its own LLM span before turn 1s tool call closes', async () => {
+    const { capture, Session } = makeRig();
+    const session = new Session();
+
+    const done = session.prompt('turn 1s tool call resolves late, after turn 2 already started');
+    session.emit({ type: 'agent_start' });
+
+    // llmCtx stays alive after message_end so a tool call in the grace window still parents under it.
+    session.emit({ type: 'turn_start' });
+    session.emit({ type: 'message_start', message: assistantMessage({ model: 'turn-1-model' }) });
+    session.emit({ type: 'message_end', message: assistantMessage({ model: 'turn-1-model' }) });
+    session.emit({
+      type: 'tool_execution_start',
+      toolCallId: 'turn1-tool',
+      toolName: 'bash',
+      args: { command: 'echo turn1' },
+    });
+    // turn_end clears state.llmSpan/llmCtx before turn 1's tool call closed (slow-to-arrive completion).
+    session.emit({ type: 'turn_end', message: assistantMessage(), toolResults: [] });
+
+    session.emit({ type: 'turn_start' });
+    session.emit({ type: 'message_start', message: assistantMessage({ model: 'turn-2-model' }) });
+
+    session.emit({
+      type: 'tool_execution_end',
+      toolCallId: 'turn1-tool',
+      toolName: 'bash',
+      result: {},
+      isError: false,
+    });
+
+    session.emit({ type: 'message_end', message: assistantMessage({ model: 'turn-2-model' }) });
+    session.emit({ type: 'turn_end', message: assistantMessage(), toolResults: [] });
+    session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    await done;
+
+    const llmSpans = capture.spans.filter((s) => attrs(s)['openinference.span.kind'] === 'LLM');
+    const turn1Llm = llmSpans.find((s) => attrs(s)['gen_ai.request.model'] === 'turn-1-model');
+    const turn2Llm = llmSpans.find((s) => attrs(s)['gen_ai.request.model'] === 'turn-2-model');
+    assert.ok(turn1Llm);
+    assert.ok(turn2Llm);
+
+    const turn1Tool = capture.spans.find((s) => attrs(s)['gen_ai.tool.call.id'] === 'turn1-tool');
+    assert.ok(turn1Tool);
+    assert.equal(
+      turn1Tool!.parentSpanId,
+      turn1Llm!.spanContext().spanId,
+      "turn 1's tool span must stay bound to turn 1's LLM span -- the parent Context was captured at " +
+        'tool_execution_start time and is immutable, so it must not silently move onto turn 2 just ' +
+        'because state.llmCtx has since been reassigned',
+    );
+    assert.notEqual(
+      turn1Tool!.parentSpanId,
+      turn2Llm!.spanContext().spanId,
+      "turn 1's tool span must never parent under turn 2's LLM span",
+    );
+  });
+
+  it('a stray message_start with no rootCtx never parents under whatever span is ambiently active in the host process', async () => {
+    const { capture, Session } = makeSteerRig();
+    const session = new Session();
+
+    // steer() attaches the listener without ever opening a root, unlike prompt() -- the "no root" case.
+    await session.steer('a stray assistant message with no prompt() ever called');
+
+    const manager = new StackContextManager();
+    context.setGlobalContextManager(manager);
+    try {
+      const ambientCtx = trace.setSpanContext(context.active(), AMBIENT_SPAN_CONTEXT);
+      context.with(ambientCtx, () => {
+        session.emit({ type: 'message_start', message: assistantMessage() });
+        session.emit({ type: 'message_end', message: assistantMessage() });
+      });
+    } finally {
+      context.disable();
+    }
+
+    const llmSpan = capture.spans.find((s) => attrs(s)['openinference.span.kind'] === 'LLM');
+    assert.ok(llmSpan, 'the stray message still produces an LLM span');
+    assert.equal(
+      llmSpan!.parentSpanId,
+      undefined,
+      'with no rootCtx, the LLM span must start a fresh standalone trace (ROOT_CONTEXT), not ' +
+        'silently attach to whatever span the host process happens to have ambiently active',
+    );
+    assert.notEqual(
+      llmSpan!.spanContext().traceId,
+      AMBIENT_SPAN_CONTEXT.traceId,
+      'the stray LLM span must not join the ambient hosts trace',
+    );
+  });
+});
+
+describe('pi close-event idempotency and content safety', () => {
+  // Duplicate/late CLOSE events and malformed message content that could throw before
+  // endSpanSafe() ran, silently dropping the span.
+  it('tool_execution_end firing twice for the same toolCallId exports exactly one tool span and never crashes on the second (stale) close', async () => {
+    const { capture, Session } = makeRig();
+    const session = new Session();
+
+    const done = session.prompt('a buggy tool runner emits two end events for one call id');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'message_start', message: assistantMessage() });
+    session.emit({ type: 'message_end', message: assistantMessage() });
+    session.emit({
+      type: 'tool_execution_start',
+      toolCallId: 't1',
+      toolName: 'bash',
+      args: { command: 'echo hi' },
+    });
+    session.emit({
+      type: 'tool_execution_end',
+      toolCallId: 't1',
+      toolName: 'bash',
+      result: { ok: true },
+      isError: false,
+    });
+    assert.doesNotThrow(() => {
+      session.emit({
+        type: 'tool_execution_end',
+        toolCallId: 't1',
+        toolName: 'bash',
+        result: { ok: true },
+        isError: false,
+      });
+    });
+    session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    await done;
+
+    const toolSpans = capture.spans.filter((s) => attrs(s)['gen_ai.tool.call.id'] === 't1');
+    assert.equal(toolSpans.length, 1, 'exactly one tool span despite two end events');
+    assert.equal(
+      attrs(toolSpans[0]!)['traceroot.pi.force_closed'],
+      undefined,
+      'the tool span closed normally via the first end -- it must not be marked force_closed',
+    );
+  });
+
+  // agent_end never closes the root itself, only stamps output -- a duplicate is a harmless repeated stamp.
+  it('agent_end firing twice for one attempt before prompt() settles stamps output idempotently', async () => {
+    const { capture, Session } = makeRig();
+    const session = new Session();
+
+    const done = session.prompt('a duplicate agent_end fires for one run');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    assert.doesNotThrow(() => {
+      session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    });
+    await done;
+
+    const rootSpans = capture.spans.filter((s) => attrs(s)['openinference.span.kind'] === 'AGENT');
+    assert.equal(rootSpans.length, 1, 'the root span must be closed and exported exactly once');
+    assert.equal(
+      attrs(rootSpans[0]!)['traceroot.pi.force_closed'],
+      undefined,
+      'the root span closed normally when prompt() settled',
+    );
+  });
+
+  it('message_end with a malformed assistant message (content is not an array) still ends and exports the LLM span instead of leaking it unended', async () => {
+    const { capture, Session } = makeRig();
+    const session = new Session();
+
+    const done = session.prompt('message_end delivers a malformed assistant message');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'message_start', message: assistantMessage({ model: 'the-model' }) });
+    // assistantTextOf() throws inside closeLlmSpan, wrapped in try/catch so endSpanSafe() still runs.
+    assert.doesNotThrow(() => {
+      session.emit({
+        type: 'message_end',
+        message: {
+          role: 'assistant',
+          // @ts-expect-error intentionally malformed content to probe robustness
+          content: undefined,
+          model: 'the-model',
+          stopReason: 'stop',
+          timestamp: 0,
+        },
+      });
+    });
+    session.emit({ type: 'turn_end', message: assistantMessage(), toolResults: [] });
+    session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    await done;
+
+    const llmSpans = capture.spans.filter((s) => attrs(s)['openinference.span.kind'] === 'LLM');
+    assert.equal(llmSpans.length, 1, 'the LLM span must still be exported');
+    assert.equal(
+      attrs(llmSpans[0]!)['traceroot.pi.force_closed'],
+      undefined,
+      "message_end is the LLM span's normal close -- a malformed content payload must not " +
+        'demote it to a force-closed span (which means span.end() was skipped in closeLlmSpan)',
+    );
+  });
+});
+
+describe('pi dangling-span sweep deduplication', () => {
+  // Guards that the dangling-span sweep runs at every call site (agent_start, turn_end, agent_end,
+  // proto.prompt's overlap check, dispose() -- the last covered in pi.test.ts) via real scenarios.
+  it('agent_start sweeps a dangling LLM + TOOL span from a crashed prior ATTEMPT, but leaves the still-open root untouched', async () => {
+    const { capture, Session } = makeRig();
+    const session = new Session();
+
+    const done = session.prompt('attempt one crashes mid-flight, the loop restarts it');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'message_start', message: assistantMessage({ model: 'attempt1-llm' }) });
+    session.emit({
+      type: 'tool_execution_start',
+      toolCallId: 'attempt1-tool',
+      toolName: 'read_file',
+      args: { path: '/tmp/one' },
+    });
+    assert.equal(capture.spans.length, 0, 'nothing exports while the root is still open');
+
+    session.emit({ type: 'agent_start' });
+
+    assert.equal(
+      capture.spans.length,
+      2,
+      "agent_start must force-close attempt one's LLM and TOOL spans only, not the still-open root " +
+        `(found ${capture.spans.length})`,
+    );
+    const llmSpan = capture.spans.find((s) => attrs(s)['gen_ai.request.model'] === 'attempt1-llm');
+    const toolSpan = capture.spans.find((s) => attrs(s)['gen_ai.tool.call.id'] === 'attempt1-tool');
+    assert.ok(llmSpan && toolSpan, "attempt one's LLM and TOOL spans must be exported");
+    for (const span of [llmSpan!, toolSpan!]) {
+      assert.equal(
+        attrs(span)['traceroot.pi.force_closed'],
+        true,
+        `${span.name} must be marked force_closed by agent_start's sweep`,
+      );
+    }
+    assert.equal(
+      capture.spans.find((s) => s.name === 'AgentSession.prompt'),
+      undefined,
+      'the root span must still be open -- agent_start never force-closes it under the new model',
+    );
+
+    session.emit({
+      type: 'agent_end',
+      messages: [assistantMessage({ content: [{ type: 'text', text: 'recovered' }] })],
+      willRetry: false,
+    });
+    await done;
+
+    const rootSpans = capture.spans.filter((s) => attrs(s)['openinference.span.kind'] === 'AGENT');
+    assert.equal(rootSpans.length, 1, 'exactly one root span for the whole prompt() call');
+    assert.equal(attrs(rootSpans[0]!)['output.value'], 'recovered');
+  });
+
+  it('turn_end force-closes a dangling LLM + TOOL span but leaves the root span open', async () => {
+    const { capture, Session } = makeRig();
+    const session = new Session();
+
+    const done = session.prompt('run with a stream error mid-turn');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'message_start', message: assistantMessage({ model: 'turn-llm' }) });
+    session.emit({
+      type: 'tool_execution_start',
+      toolCallId: 'turn-tool',
+      toolName: 'read_file',
+      args: { path: '/tmp/turn' },
+    });
+
+    session.emit({ type: 'turn_end', message: assistantMessage(), toolResults: [] });
+
+    assert.equal(
+      capture.spans.length,
+      2,
+      'turn_end must force-close exactly the dangling LLM + TOOL spans, not the root span (found ' +
+        `${capture.spans.length})`,
+    );
+    const llmSpan = capture.spans.find((s) => attrs(s)['gen_ai.request.model'] === 'turn-llm');
+    const toolSpan = capture.spans.find((s) => attrs(s)['gen_ai.tool.call.id'] === 'turn-tool');
+    assert.ok(llmSpan && toolSpan, 'the LLM and TOOL spans must be force-closed and exported');
+    assert.equal(attrs(llmSpan!)['traceroot.pi.force_closed'], true);
+    assert.equal(attrs(toolSpan!)['traceroot.pi.force_closed'], true);
+    assert.equal(
+      capture.spans.find((s) => s.name === 'AgentSession.prompt'),
+      undefined,
+      'the root span must still be open (turn_end is not session end), so it must not export yet',
+    );
+
+    session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    await done;
+  });
+
+  it('agent_end sweeps a dangling LLM + TOOL span while stamping (not force-closing, not even ending) the still-open root', async () => {
+    const { capture, Session } = makeRig();
+    const session = new Session();
+
+    const done = session.prompt('run that ends with tool/LLM spans still dangling');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'message_start', message: assistantMessage({ model: 'end-llm' }) });
+    session.emit({
+      type: 'tool_execution_start',
+      toolCallId: 'end-tool',
+      toolName: 'read_file',
+      args: { path: '/tmp/end' },
+    });
+
+    // The LLM + TOOL spans never see their own close: agent_end's sweep force-closes both, then stamps
+    // output onto the root without ending it.
+    session.emit({
+      type: 'agent_end',
+      messages: [assistantMessage({ content: [{ type: 'text', text: 'stamped output' }] })],
+      willRetry: false,
+    });
+
+    assert.equal(capture.spans.length, 2, 'only the LLM and TOOL spans export so far');
+    const llmSpan = capture.spans.find((s) => attrs(s)['gen_ai.request.model'] === 'end-llm');
+    const toolSpan = capture.spans.find((s) => attrs(s)['gen_ai.tool.call.id'] === 'end-tool');
+    assert.ok(llmSpan && toolSpan);
+    assert.equal(
+      attrs(llmSpan!)['traceroot.pi.force_closed'],
+      true,
+      "the dangling LLM span must be force-closed by agent_end's sweep",
+    );
+    assert.equal(
+      attrs(toolSpan!)['traceroot.pi.force_closed'],
+      true,
+      "the dangling TOOL span must be force-closed by agent_end's sweep",
+    );
+    assert.equal(
+      capture.spans.find((s) => s.name === 'AgentSession.prompt'),
+      undefined,
+      'the root span must still be open -- agent_end only stamps it, never ends it',
+    );
+
+    await done;
+
+    const rootSpan = capture.spans.find((s) => s.name === 'AgentSession.prompt');
+    assert.ok(rootSpan, 'the root span exports once prompt() settles');
+    assert.equal(attrs(rootSpan!)['output.value'], 'stamped output');
+    assert.notEqual(
+      attrs(rootSpan!)['traceroot.pi.force_closed'],
+      true,
+      'the root span must be closed normally when prompt() settles, not force-closed',
+    );
+  });
+
+  // A second prompt() call while a previous window's root is still open (rare; isStreaming guards most
+  // overlaps, but not verified to cover every path) must force-close the stale window, not leak it.
+  it("a second prompt() call while the first window's root is still open force-closes the first root (and its dangling LLM/TOOL), then opens a fresh root for the second", async () => {
+    const { capture, Session } = makeRig();
+    const session = new Session();
+
+    const done1 = session.prompt('first window never got its agent_end');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'message_start', message: assistantMessage({ model: 'overlap-llm' }) });
+    assert.equal(capture.spans.length, 0, 'nothing exports while the first root is still open');
+
+    const done2 = session.prompt('second window');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    await done2;
+    // done1 never settles on its own; only the sweep's effect on spans matters here.
+    void done1;
+
+    const rootSpans = capture.spans.filter((s) => attrs(s)['openinference.span.kind'] === 'AGENT');
+    assert.equal(rootSpans.length, 2, 'both the swept first root and the second root export');
+    const firstRoot = rootSpans.find(
+      (s) => attrs(s)['input.value'] === 'first window never got its agent_end',
+    );
+    const secondRoot = rootSpans.find((s) => attrs(s)['input.value'] === 'second window');
+    assert.ok(firstRoot, 'the first (overlapped) root must still export');
+    assert.ok(secondRoot, 'the second root must export normally');
+    assert.equal(
+      attrs(firstRoot!)['traceroot.pi.force_closed'],
+      true,
+      'the first root must be marked force_closed by the overlap sweep',
+    );
+    assert.equal(
+      attrs(firstRoot!)['traceroot.pi.force_closed_reason'],
+      'superseded_by_new_prompt',
+      'the superseded root records WHY it was force-closed, so a truncated trace is debuggable',
+    );
+    assert.notEqual(
+      attrs(secondRoot!)['traceroot.pi.force_closed'],
+      true,
+      'the second root must close normally via its own prompt() settle',
+    );
+    const overlapLlm = capture.spans.find(
+      (s) => attrs(s)['gen_ai.request.model'] === 'overlap-llm',
+    );
+    assert.ok(overlapLlm, "the first window's dangling LLM span must also be swept, not leaked");
+    assert.equal(attrs(overlapLlm!)['traceroot.pi.force_closed'], true);
+    assert.notEqual(
+      firstRoot!.spanContext().traceId,
+      secondRoot!.spanContext().traceId,
+      'the two overlapping windows must live in genuinely separate traces',
+    );
+  });
+
+  // A mid-stream steer/followUp must not be treated as an overlap: before this fix, proto.prompt couldn't
+  // distinguish it from a genuine overlapping call and force-closed the still-live active root/LLM span.
+  it("a mid-stream steer (isStreaming===true, streamingBehavior set) never opens a fresh root or sweeps the active run's still-open root -- the active trace stays intact", async () => {
+    const { capture, Session } = makeRig();
+    const session = new Session();
+
+    const done = session.prompt('first task, still running');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'message_start', message: assistantMessage({ model: 'active-llm' }) });
+
+    // A mid-stream steer call in this state must delegate straight through -- no new root, no overlap sweep.
+    session.isStreaming = true;
+    await session.prompt('steer text', { streamingBehavior: 'steer' });
+
+    assert.equal(
+      capture.spans.length,
+      0,
+      "the mid-stream steer call must not force-close or export anything -- the active run's root " +
+        'and LLM span are still genuinely open',
+    );
+
+    session.isStreaming = false;
+    session.emit({
+      type: 'message_end',
+      message: assistantMessage({
+        model: 'active-llm',
+        content: [{ type: 'text', text: 'steered result' }],
+      }),
+    });
+    session.emit({ type: 'turn_end', message: assistantMessage(), toolResults: [] });
+    session.emit({
+      type: 'agent_end',
+      messages: [assistantMessage({ content: [{ type: 'text', text: 'steered result' }] })],
+      willRetry: false,
+    });
+    await done;
+
+    const rootSpans = capture.spans.filter((s) => attrs(s)['openinference.span.kind'] === 'AGENT');
+    assert.equal(
+      rootSpans.length,
+      1,
+      'exactly one intact root for the whole run -- the steer call never opened a second one',
+    );
+    const root = rootSpans[0]!;
+    assert.notEqual(
+      attrs(root)['traceroot.pi.force_closed'],
+      true,
+      'the active root must NOT be force-closed by the mid-stream steer',
+    );
+    assert.equal(attrs(root)['output.value'], 'steered result');
+
+    const llmSpan = capture.spans.find((s) => attrs(s)['openinference.span.kind'] === 'LLM');
+    assert.ok(llmSpan, "the active run's LLM span must still export normally");
+    assert.notEqual(
+      attrs(llmSpan!)['traceroot.pi.force_closed'],
+      true,
+      'the active LLM span must not have been swept by the steer call',
+    );
+    assert.equal(
+      llmSpan!.parentSpanId,
+      root.spanContext().spanId,
+      'the LLM span must remain a child of the single intact root',
+    );
+  });
+
+  // Before this fix, finalize only ended the root span -- a mid-run rejection left a still-open
+  // tool/LLM span never .end()ed, silently dropped rather than exported.
+  it('a prompt() call that REJECTS mid-run force-closes a still-open tool span before finalizing the root as ERROR (claude-agent-sdk.ts endInFlight parity)', async () => {
+    const { capture, Session } = makeRig();
+    const session = new Session();
+
+    const done = session.prompt(
+      'a run whose internal loop rejects while a tool call is still open',
+    );
+    session.emit({ type: 'agent_start' });
+    session.emit({
+      type: 'tool_execution_start',
+      toolCallId: 'reject-tool',
+      toolName: 'bash',
+      args: { command: 'sleep 999' },
+    });
+    assert.equal(capture.spans.length, 0, 'nothing exports while the run is still open');
+
+    session.rejectPrompt(new Error('internal agent loop failure'));
+    await assert.rejects(() => done, /internal agent loop failure/);
+
+    assert.equal(
+      capture.spans.length,
+      2,
+      'the still-open tool span AND the root must both export once the rejection settles ' +
+        `(found ${capture.spans.length})`,
+    );
+    const rootSpan = capture.spans.find((s) => s.name === 'AgentSession.prompt');
+    const toolSpan = capture.spans.find((s) => attrs(s)['gen_ai.tool.call.id'] === 'reject-tool');
+    assert.ok(rootSpan);
+    assert.ok(toolSpan, 'the dangling tool span must still export, not be dropped forever');
+    assert.equal(
+      attrs(toolSpan!)['traceroot.pi.force_closed'],
+      true,
+      "the tool span must be force-closed by finalize's pre-close sweep",
+    );
+    assert.equal(
+      toolSpan!.parentSpanId,
+      rootSpan!.spanContext().spanId,
+      'the force-closed tool span must still be parented under the root',
+    );
+
+    assert.equal(rootSpan!.status.code, 2 /* SpanStatusCode.ERROR */);
+    assert.equal(
+      rootSpan!.events.some((e) => e.name === 'exception'),
+      true,
+      'the rejection reason must be recorded as an exception on the root span',
+    );
+  });
+});
+
+describe('pi instrumentation edge cases', () => {
+  it('instrumenting the same sdk object twice does not double-wrap prompt', async () => {
+    const capture = new CapturingExporter();
+    const Session = makeFakeSessionClass();
+    const sdk = { AgentSession: Session };
+
+    registerCapturingProvider(capture);
+    instrumentPiCodingAgent(sdk, {});
+    const wrappedOnce = Session.prototype.prompt;
+    instrumentPiCodingAgent(sdk, {});
+    const wrappedTwice = Session.prototype.prompt;
+
+    assert.equal(
+      wrappedOnce,
+      wrappedTwice,
+      'a second instrumentPiCodingAgent() call must be a no-op',
+    );
+
+    const session = new Session();
+    const done = session.prompt('hi');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    await done;
+
+    assert.equal(
+      capture.spans.length,
+      1,
+      'exactly one root span, not two -- proves subscribe() was not registered twice',
+    );
+  });
+
+  // A real `import * as pi` namespace object is always non-extensible per spec; Object.preventExtensions
+  // reproduces that shape -- the wrap-once guard must never be stamped directly onto `sdk` itself.
+  it('instrumenting a non-extensible sdk object (e.g. a real `import * as pi` ES module namespace) does not throw', async () => {
+    const capture = new CapturingExporter();
+    const Session = makeFakeSessionClass();
+    const sdk = Object.preventExtensions({ AgentSession: Session });
+
+    registerCapturingProvider(capture);
+    assert.doesNotThrow(() => {
+      instrumentPiCodingAgent(sdk, {});
+    });
+
+    const session = new Session();
+    const done = session.prompt('hi');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    await done;
+
+    assert.equal(
+      capture.spans.length,
+      1,
+      'instrumentation still works end-to-end against a non-extensible sdk object',
+    );
+
+    const wrappedOnce = Session.prototype.prompt;
+    assert.doesNotThrow(() => {
+      instrumentPiCodingAgent(sdk, {});
+    });
+    assert.equal(Session.prototype.prompt, wrappedOnce);
+  });
+
+  // Guards silent double-instrumentation across independently-loaded copies sharing one prototype: a
+  // module-scoped `Symbol()` guard would fail silently, so this must use the interned Symbol.for(key).
+  it('the wrap-once guard key is the globally-interned Symbol.for() value, and a second call is an idempotent no-op', () => {
+    const Session = makeFakeSessionClass();
+    const sdk = { AgentSession: Session };
+
+    instrumentPiCodingAgent(sdk, {});
+
+    const guardKeys = Object.getOwnPropertySymbols(Session.prototype).filter(
+      (sym) => sym.description === 'traceroot.pi.wrapped',
+    );
+    assert.equal(guardKeys.length, 1, 'exactly one wrap-once guard key should be stamped');
+    assert.equal(
+      guardKeys[0],
+      Symbol.for('traceroot.pi.wrapped'),
+      'the guard key must be the globally-interned Symbol.for() value -- not a ' +
+        'module-scoped Symbol() -- so that two independently-loaded copies of ' +
+        "this module sharing one AgentSession.prototype detect each other's " +
+        'stamp instead of silently double-wrapping and doubling every span export',
+    );
+
+    // A second call for an already-instrumented sdk is silently idempotent (mirrors
+    // claude-agent-sdk's wrap-once return); the first call's config stands.
+    const wrappedOnce = Session.prototype.prompt;
+    instrumentPiCodingAgent(sdk, { captureContent: false });
+    assert.equal(
+      Session.prototype.prompt,
+      wrappedOnce,
+      "a second instrumentPiCodingAgent() call with a different config must not re-wrap; it's an idempotent no-op",
+    );
+  });
+
+  it('two different session instances on the same instrumented sdk keep fully independent span trees', async () => {
+    const capture = new CapturingExporter();
+    const Session = makeFakeSessionClass();
+    const sdk = { AgentSession: Session };
+    registerCapturingProvider(capture);
+    instrumentPiCodingAgent(sdk, {});
+
+    const sessionA = new Session();
+    const sessionB = new Session();
+    (sessionA as { sessionId: string }).sessionId = 'session-a';
+    (sessionB as { sessionId: string }).sessionId = 'session-b';
+
+    // Interleaved on purpose: A starts, B starts, A's tool call runs, B's turn ends, A ends.
+    const doneA = sessionA.prompt('task A');
+    sessionA.emit({ type: 'agent_start' });
+    const doneB = sessionB.prompt('task B');
+    sessionB.emit({ type: 'agent_start' });
+    sessionA.emit({ type: 'message_start', message: assistantMessage() });
+    sessionA.emit({ type: 'message_end', message: assistantMessage() });
+    sessionA.emit({
+      type: 'tool_execution_start',
+      toolCallId: 'a-tool',
+      toolName: 'bash',
+      args: {},
+    });
+    sessionA.emit({
+      type: 'tool_execution_end',
+      toolCallId: 'a-tool',
+      toolName: 'bash',
+      result: {},
+      isError: false,
+    });
+    sessionB.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    sessionA.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    await Promise.all([doneA, doneB]);
+
+    assert.equal(capture.spans.length, 4, 'A: root+LLM+tool (3), B: root (1)');
+
+    const bRoot = capture.spans.find((s) => attrs(s)['session.id'] === 'session-b');
+    const aRoot = capture.spans.find((s) => attrs(s)['session.id'] === 'session-a');
+    assert.ok(bRoot);
+    assert.ok(aRoot);
+    // Only root spans carry session.id and only tool spans carry tool.call.id, so "everything that
+    // isn't B's root" correctly counts A's 3 spans (the LLM span carries neither).
+    const aRelated = capture.spans.filter((s) => s !== bRoot);
+    assert.equal(aRelated.length, 3, 'A: root + LLM + tool span');
+    assert.notEqual(bRoot!.spanContext().traceId, aRoot!.spanContext().traceId);
+  });
+
+  it('message_start/message_end for non-assistant roles never opens an LLM span', async () => {
+    const capture = new CapturingExporter();
+    const Session = makeFakeSessionClass();
+    const sdk = { AgentSession: Session };
+    registerCapturingProvider(capture);
+    instrumentPiCodingAgent(sdk, {});
+    const session = new Session();
+
+    const done = session.prompt('hi');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'message_start', message: { role: 'user', content: 'hi', timestamp: 0 } });
+    session.emit({ type: 'message_end', message: { role: 'user', content: 'hi', timestamp: 0 } });
+    session.emit({
+      type: 'message_start',
+      message: {
+        role: 'toolResult',
+        toolCallId: 'x',
+        toolName: 'bash',
+        content: [],
+        isError: false,
+        timestamp: 0,
+      },
+    });
+    session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    await done;
+
+    assert.equal(
+      capture.spans.length,
+      1,
+      'only the root span -- no LLM span for user/toolResult messages',
+    );
+  });
+
+  it('a handler throw inside span-building is caught and never propagates to session.emit()', async () => {
+    const capture = new CapturingExporter();
+    const Session = makeFakeSessionClass();
+    const sdk = { AgentSession: Session };
+    registerCapturingProvider(capture);
+    instrumentPiCodingAgent(sdk, {});
+    const session = new Session();
+
+    const done = session.prompt('hi');
+    session.emit({ type: 'agent_start' });
+    // A malformed/missing `usage` field must not crash the listener -- attribute setters must tolerate it.
+    assert.doesNotThrow(() => {
+      session.emit({
+        type: 'message_end',
+        // @ts-expect-error intentionally malformed to test resilience
+        message: { role: 'assistant', content: [], stopReason: 'stop', timestamp: 0 },
+      });
+    });
+    assert.doesNotThrow(() => {
+      session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    });
+    await done;
+  });
+
+  // This fake's prompt() is plain (non-async) and throws before returning a promise, exercising the
+  // synchronous catch branch: the wrapper must finalize the root as ERROR and rethrow synchronously.
+  it('a prompt() that throws SYNCHRONOUSLY (before ever returning a promise) still finalizes the root as ERROR and rethrows synchronously, not as a rejected promise', () => {
+    const capture = new CapturingExporter();
+    const Session = makeFakeSessionClass();
+    Session.prototype.prompt = function (): never {
+      throw new Error('synchronous validation failure');
+    };
+    const sdk = { AgentSession: Session };
+    registerCapturingProvider(capture);
+    instrumentPiCodingAgent(sdk, {});
+    const session = new Session();
+
+    assert.throws(() => session.prompt('hi'), /synchronous validation failure/);
+
+    assert.equal(capture.spans.length, 1);
+    const rootSpan = capture.spans[0]!;
+    assert.equal(attrs(rootSpan)['openinference.span.kind'], 'AGENT');
+    assert.equal(rootSpan.status.code, 2 /* SpanStatusCode.ERROR */);
+    assert.equal(
+      rootSpan.events.some((e) => e.name === 'exception'),
+      true,
+      'the synchronously-thrown error must still be recorded as an exception on the root span',
+    );
+  });
+
+  it("a prompt() call whose run retries once (willRetry: true) keeps ONE root span open across the retry continuation, closing it exactly once with retry_count stamped, and both attempts' LLM spans (ERROR then OK) parent under that single root", async () => {
+    const capture = new CapturingExporter();
+    const Session = makeFakeSessionClass();
+    const sdk = { AgentSession: Session };
+    registerCapturingProvider(capture);
+    instrumentPiCodingAgent(sdk, {});
+    const session = new Session();
+
+    // The retry continuation's agent_start/agent_end fire with no new prompt() call, so both attempts
+    // (and each one's own child LLM span) must land under the same still-open root.
+    const done = session.prompt('hi');
+    session.emit({ type: 'agent_start' });
+    session.emit({
+      type: 'message_start',
+      message: assistantMessage({ model: 'attempt-1-model' }),
+    });
+    session.emit({
+      type: 'message_end',
+      message: assistantMessage({
+        model: 'attempt-1-model',
+        stopReason: 'error',
+        errorMessage: 'rate limited',
+      }),
+    });
+    session.emit({ type: 'turn_end', message: assistantMessage(), toolResults: [] });
+    session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: true });
+    // Retry re-enters the loop; no new prompt() call.
+    session.emit({ type: 'agent_start' });
+    session.emit({
+      type: 'message_start',
+      message: assistantMessage({ model: 'attempt-2-model' }),
+    });
+    session.emit({ type: 'message_end', message: assistantMessage({ model: 'attempt-2-model' }) });
+    session.emit({ type: 'turn_end', message: assistantMessage(), toolResults: [] });
+    session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    await done;
+
+    const rootSpans = capture.spans.filter((s) => attrs(s)['openinference.span.kind'] === 'AGENT');
+    assert.equal(
+      rootSpans.length,
+      1,
+      'the retry continuation shares ONE root span with its first attempt, not two',
+    );
+    const root = rootSpans[0]!;
+    assert.equal(attrs(root)['traceroot.pi.retry_count'], 1);
+    assert.equal(attrs(root)['traceroot.pi.will_retry'], undefined, 'the flag is gone');
+
+    const llmSpans = capture.spans.filter((s) => attrs(s)['openinference.span.kind'] === 'LLM');
+    assert.equal(llmSpans.length, 2, 'each attempt gets its own child LLM span, not a merged one');
+    const errorLlm = llmSpans.find((s) => attrs(s)['gen_ai.request.model'] === 'attempt-1-model');
+    const okLlm = llmSpans.find((s) => attrs(s)['gen_ai.request.model'] === 'attempt-2-model');
+    assert.ok(errorLlm, "attempt 1's LLM span must be present");
+    assert.ok(okLlm, "attempt 2's LLM span must be present");
+    assert.equal(
+      errorLlm!.status.code,
+      SpanStatusCode.ERROR,
+      "attempt 1's LLM span must carry the ERROR status from its failing stopReason",
+    );
+    assert.equal(
+      okLlm!.status.code,
+      SpanStatusCode.UNSET,
+      "attempt 2's LLM span must NOT be ERROR -- it is the successful retry",
+    );
+    assert.equal(
+      errorLlm!.parentSpanId,
+      root.spanContext().spanId,
+      "attempt 1's (failed) LLM span must parent under the single shared root, not a discarded one",
+    );
+    assert.equal(
+      okLlm!.parentSpanId,
+      root.spanContext().spanId,
+      "attempt 2's (succeeded) LLM span must parent under the SAME single shared root as attempt 1",
+    );
+  });
+});
+
+describe('pi install rollback', () => {
+  // A failure mid-install must leave AgentSession.prototype exactly as found: no half-patched
+  // methods and no wrap-once guard stamped (which would reject every retry).
+
+  const WRAPPED = Symbol.for('traceroot.pi.wrapped');
+
+  it('a setup failure after the wrap-once decision does not leave the guard stamped or the prototype half-patched', () => {
+    const provider = new NodeTracerProvider();
+    provider.register();
+    try {
+      // `steer` throws the first time setup probes it, standing in for any exception mid-install.
+      class ThrowingSteerSession {
+        sessionId = 's';
+        prompt(): void {}
+        subscribe(): () => void {
+          return () => {};
+        }
+        get steer(): unknown {
+          throw new Error('injected setup failure while probing steer');
+        }
+      }
+      const proto = ThrowingSteerSession.prototype as unknown as Record<PropertyKey, unknown>;
+      const originalPrompt = proto.prompt;
+      const sdk = { AgentSession: ThrowingSteerSession };
+
+      // A mid-setup failure must surface as a clear, rethrown install error, not be swallowed.
+      assert.throws(
+        () => instrumentPiCodingAgent(sdk, {}),
+        /failed to install/i,
+        'a mid-setup failure must surface as a clear instrumentation-install error',
+      );
+
+      // The guard must NOT be stamped after a failed install: leaving it true would reject every retry.
+      assert.equal(
+        proto[WRAPPED],
+        undefined,
+        'the wrap-once guard must not be stamped when install failed partway through',
+      );
+
+      // prompt must be the ORIGINAL method, not a half-installed wrapper, or a retry double-instruments.
+      assert.equal(
+        proto.prompt,
+        originalPrompt,
+        'a failed install must roll the prompt patch back, leaving the prototype unpatched',
+      );
+    } finally {
+      trace.disable();
+    }
+  });
+});
+
+describe('pi close-root-span backward scan', () => {
+  // stampRootOutput's search for the last assistant message must keep walking past trailing
+  // non-assistant messages; it only stamps output.value, so the test ends the span explicitly.
+  it('stampRootOutput still finds the last assistant message when later messages are not assistant messages', () => {
+    const capture = new CapturingExporter();
+    const provider = new NodeTracerProvider();
+    provider.addSpanProcessor(new SimpleSpanProcessor(capture));
+    const tracer = provider.getTracer('close-root-span-backward-scan-test');
+    const span = tracer.startSpan('AgentSession.prompt');
+
+    // Two assistant replies, and the one we want is buried rather than final: this pins
+    // "last assistant", which a forward scan stopping at the first match would fail.
+    const finalMessages: AgentMessage[] = [
+      { role: 'user', content: 'question', timestamp: 0 },
+      assistantMessage({ content: [{ type: 'text', text: 'an earlier, superseded answer' }] }),
+      { role: 'user', content: 'follow-up', timestamp: 0 },
+      assistantMessage({ content: [{ type: 'text', text: 'the real answer' }] }),
+      {
+        role: 'toolResult',
+        toolCallId: 't1',
+        toolName: 'bash',
+        content: [],
+        isError: false,
+        timestamp: 0,
+      },
+    ];
+
+    stampRootOutput(span, finalMessages, true);
+    span.end();
+
+    const exported = capture.spans[0];
+    assert.ok(exported, 'expected the root span to have been exported');
+    assert.equal(attrs(exported)['output.value'], 'the real answer');
+  });
+});
+
+describe('pi tracer reresolution', () => {
+  // TraceRoot.shutdown() swaps the OTel API's ProxyTracerProvider for a new instance rather than
+  // mutating it, so a tracer captured once at wrap time would go dark; pi re-resolves the tracer
+  // through the global `trace` facade on every span-open instead.
+
+  function registerProvider(): { provider: NodeTracerProvider; exporter: InMemorySpanExporter } {
+    const exporter = new InMemorySpanExporter();
+    const provider = new NodeTracerProvider();
+    provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+    provider.register();
+    return { provider, exporter };
+  }
+
+  // The three process-wide resets TraceRoot.shutdown() performs.
+  async function runShutdownSequence(provider: NodeTracerProvider): Promise<void> {
+    await provider.shutdown();
+    trace.disable();
+    context.disable();
+    propagation.disable();
+  }
+
+  it('an already-instrumented AgentSession keeps exporting across a shutdown()/initialize() cycle', async () => {
+    const a = registerProvider();
+    let b: { provider: NodeTracerProvider; exporter: InMemorySpanExporter } | undefined;
+    try {
+      const Session = makeFakeSessionClass();
+      const sdk = { AgentSession: Session };
+      instrumentPiCodingAgent(sdk, {}); // wraps the prototype once, tracer re-resolved per span
+
+      const s1 = new Session();
+      const done1 = s1.prompt('first run');
+      s1.emit({ type: 'agent_start' });
+      s1.emit({
+        type: 'agent_end',
+        messages: [assistantMessage({ content: [{ type: 'text', text: 'done A' }] })],
+        willRetry: false,
+      });
+      await done1;
+      assert.ok(
+        a.exporter.getFinishedSpans().some((s) => attrs(s)['openinference.span.kind'] === 'AGENT'),
+        'sanity: the first run must export through provider A',
+      );
+
+      // The prototype stays wrapped, so recovery depends entirely on the tracer re-resolving.
+      await runShutdownSequence(a.provider);
+      b = registerProvider();
+
+      const s2 = new Session();
+      const done2 = s2.prompt('second run');
+      s2.emit({ type: 'agent_start' });
+      s2.emit({
+        type: 'agent_end',
+        messages: [assistantMessage({ content: [{ type: 'text', text: 'done B' }] })],
+        willRetry: false,
+      });
+      await done2;
+
+      const rootB = b.exporter
+        .getFinishedSpans()
+        .find((s) => attrs(s)['openinference.span.kind'] === 'AGENT');
+      assert.ok(
+        rootB,
+        'the second run must export through provider B after the cycle -- no silent black hole',
+      );
+      assert.equal(attrs(rootB!)['input.value'], 'second run');
+    } finally {
+      trace.disable();
+    }
+  });
+});
+
+describe('pi real SDK shape smoke', () => {
+  // src/pi.ts hand-cites private internals of the real SDK, none part of a stable public contract;
+  // these verify those shapes against the actual devDependency so a version bump fails loudly here.
+
+  // ESM-only, so loaded via dynamic import() rather than a static import this CommonJS file can't use.
+  type RealSdk = {
+    AgentSession?: { prototype: Record<string, unknown> };
+  };
+  let cachedSdk: Promise<RealSdk> | undefined;
+  function loadRealSdk(): Promise<RealSdk> {
+    if (!cachedSdk) {
+      cachedSdk = import('@earendil-works/pi-coding-agent') as unknown as Promise<RealSdk>;
+    }
+    return cachedSdk;
+  }
+
+  it('the real AgentSession still exposes every prototype method instrumentPiCodingAgent patches or reads', async () => {
+    const sdk = await loadRealSdk();
+    const AgentSession = sdk.AgentSession;
+    assert.equal(typeof AgentSession, 'function', 'AgentSession must still be an exported class');
+    const proto = AgentSession!.prototype;
+
+    // Required by the install guard, which disables itself if either is missing.
+    assert.equal(
+      typeof proto.prompt,
+      'function',
+      'AgentSession.prototype.prompt must exist -- the whole patch layer keys off it',
+    );
+    assert.equal(
+      typeof proto.subscribe,
+      'function',
+      'AgentSession.prototype.subscribe must exist -- the entire span tree is built from one subscribe() listener',
+    );
+
+    // Optional-guarded in the patch layer, but expected present on the real SDK.
+    assert.equal(
+      typeof proto.steer,
+      'function',
+      'AgentSession.prototype.steer must exist -- patched as a standalone first-interaction entry point',
+    );
+    assert.equal(
+      typeof proto.followUp,
+      'function',
+      'AgentSession.prototype.followUp must exist -- patched as a standalone first-interaction entry point',
+    );
+    assert.equal(
+      typeof proto.dispose,
+      'function',
+      'AgentSession.prototype.dispose must exist -- patched to force-close in-flight spans on teardown',
+    );
+
+    // isStreaming is a getter read live on every prompt() call; a renamed/dropped getter would silently
+    // reintroduce the mid-stream-steer trace-beheading bug this check exists to prevent.
+    assert.equal(
+      typeof Object.getOwnPropertyDescriptor(proto, 'isStreaming')?.get,
+      'function',
+      'AgentSession.prototype.isStreaming must still be a getter -- proto.prompt reads it to detect a mid-stream queue-only steer/followUp call',
+    );
+  });
+
+  it('the real AgentSession.subscribe() still pushes onto a private _eventListeners array its unsubscribe closure splices back out', async () => {
+    const sdk = await loadRealSdk();
+    // The "no cleanup needed" design rests on subscribe() pushing onto a private field literally named
+    // _eventListeners, which dispose() reassigns to []; a rename leaves this seeded array untouched.
+    const proto = sdk.AgentSession!.prototype as unknown as { subscribe(l: unknown): () => void };
+    const instance = Object.create(proto) as {
+      _eventListeners: unknown[];
+      subscribe(l: unknown): () => void;
+    };
+    instance._eventListeners = [];
+    const listener = (): void => {};
+
+    const unsubscribe = instance.subscribe(listener);
+    assert.equal(typeof unsubscribe, 'function', 'subscribe() must return an unsubscribe closure');
+    assert.ok(
+      instance._eventListeners.includes(listener),
+      "subscribe() must push the listener onto a private array field named _eventListeners -- pi.ts's no-cleanup design depends on this exact field name",
+    );
+
+    unsubscribe();
+    assert.ok(
+      !instance._eventListeners.includes(listener),
+      'the unsubscribe closure returned by subscribe() must splice the listener back out of _eventListeners',
+    );
+  });
+});

--- a/packages/traceroot/tests/pi-lifecycle-edge-cases.test.ts
+++ b/packages/traceroot/tests/pi-lifecycle-edge-cases.test.ts
@@ -1008,8 +1008,6 @@ describe('pi close-root-span backward scan', () => {
     const tracer = provider.getTracer('close-root-span-backward-scan-test');
     const span = tracer.startSpan('AgentSession.prompt');
 
-    // Two assistant replies, and the one we want is buried rather than final: this pins
-    // "last assistant", which a forward scan stopping at the first match would fail.
     const finalMessages: AgentMessage[] = [
       { role: 'user', content: 'question', timestamp: 0 },
       assistantMessage({ content: [{ type: 'text', text: 'an earlier, superseded answer' }] }),

--- a/packages/traceroot/tests/pi-test-helpers.ts
+++ b/packages/traceroot/tests/pi-test-helpers.ts
@@ -1,0 +1,121 @@
+// Shared fixtures for packages/traceroot/tests/pi-*.test.ts.
+// CONTRACT: prompt()'s promise stays pending until a non-retry agent_end; never await it before emitting, and always await it before asserting the root.
+import { trace } from '@opentelemetry/api';
+import type { ExportResult } from '@opentelemetry/core';
+import { ExportResultCode } from '@opentelemetry/core';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
+import {
+  instrumentPiCodingAgent,
+  type AgentEvent,
+  type AssistantMessage,
+  type PiInstrumentationConfig,
+  type PromptOptions,
+} from '../src/pi';
+
+export class CapturingExporter implements SpanExporter {
+  readonly spans: ReadableSpan[] = [];
+  export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
+    this.spans.push(...spans);
+    resultCallback({ code: ExportResultCode.SUCCESS });
+  }
+  async shutdown(): Promise<void> {}
+}
+
+// Fresh class per rig/test; instrumentPiCodingAgent patches the prototype directly.
+export function makeFakeSessionClass(shouldReject?: (text: string) => boolean) {
+  return class FakeAgentSession {
+    sessionId = 'sess-1';
+    disposed = false;
+    isStreaming = false;
+    private listeners: Array<(event: AgentEvent) => void> = [];
+    private pending: { resolve: () => void; reject: (err: unknown) => void } | undefined;
+
+    async prompt(text: string, options?: PromptOptions): Promise<void> {
+      if (shouldReject?.(text)) {
+        throw new Error(`validation failed for: ${text}`);
+      }
+      // Queues into the active run; must not touch this.pending (the earlier call's).
+      if (this.isStreaming && options?.streamingBehavior) {
+        return;
+      }
+      return new Promise<void>((resolve, reject) => {
+        this.pending = { resolve, reject };
+      });
+    }
+    subscribe(listener: (event: AgentEvent) => void): () => void {
+      this.listeners.push(listener);
+      return () => {
+        this.listeners = this.listeners.filter((l) => l !== listener);
+      };
+    }
+    emit(event: AgentEvent): void {
+      for (const listener of this.listeners) listener(event);
+      if (event.type === 'agent_end' && !event.willRetry && this.pending) {
+        const { resolve } = this.pending;
+        this.pending = undefined;
+        resolve();
+      }
+    }
+    // Settles as SUCCESS with no agent_end (mirrors a handled "/command").
+    resolvePrompt(): void {
+      if (!this.pending) return;
+      const { resolve } = this.pending;
+      this.pending = undefined;
+      resolve();
+    }
+    rejectPrompt(err: unknown): void {
+      if (!this.pending) return;
+      const { reject } = this.pending;
+      this.pending = undefined;
+      reject(err);
+    }
+    dispose(): void {
+      this.disposed = true;
+      this.listeners = [];
+    }
+  };
+}
+
+// trace.disable() must run first, or a stale registration leaks spans across rigs.
+export function makeRig(config: PiInstrumentationConfig = {}): {
+  capture: CapturingExporter;
+  Session: ReturnType<typeof makeFakeSessionClass>;
+} {
+  trace.disable();
+  const capture = new CapturingExporter();
+  const provider = new NodeTracerProvider();
+  provider.addSpanProcessor(new SimpleSpanProcessor(capture));
+  provider.register();
+  const Session = makeFakeSessionClass();
+  const sdk = { AgentSession: Session };
+  instrumentPiCodingAgent(sdk, config);
+  return { capture, Session };
+}
+
+// Placeholder usage/cost; tests needing exact figures should pass an explicit override.
+export function assistantMessage(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+  return {
+    role: 'assistant',
+    content: [{ type: 'text', text: 'done' }],
+    api: 'anthropic-messages',
+    provider: 'anthropic',
+    model: 'claude-sonnet-5',
+    usage: {
+      input: 1,
+      output: 1,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 2,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: 'stop',
+    timestamp: 0,
+    ...overrides,
+  } as AssistantMessage;
+}
+
+export function attrs(span: ReadableSpan): Record<string, unknown> {
+  return span.attributes as Record<string, unknown>;
+}

--- a/packages/traceroot/tests/pi.test.ts
+++ b/packages/traceroot/tests/pi.test.ts
@@ -16,7 +16,6 @@ import {
   closeLlmSpan,
   openToolSpan,
   closeToolSpan,
-  sliceSurrogateSafe,
   type AgentEvent,
   type AssistantMessage,
 } from '../src/pi';
@@ -70,7 +69,7 @@ describe('pi span name', () => {
 });
 
 describe('pi spans and config boundary coverage', () => {
-  // Direct unit coverage of pi.ts's LLM/tool span helpers and sliceSurrogateSafe.
+  // Direct unit coverage of pi.ts's LLM/tool span helpers and span-name truncation.
   function makeTracer() {
     const spans: ReadableSpan[] = [];
     const provider = new NodeTracerProvider();
@@ -171,19 +170,12 @@ describe('pi spans and config boundary coverage', () => {
     assert.equal(attrs(toolSpan!)['output.value'], JSON.stringify({ ok: true }));
   });
 
-  it('sliceSurrogateSafe returns text unchanged when at or under maxLen (<=, not <)', () => {
-    assert.equal(sliceSurrogateSafe('hello', 5), 'hello');
-    assert.equal(sliceSurrogateSafe('hello', 10), 'hello');
-    assert.equal(sliceSurrogateSafe('', 0), '');
-  });
+  it('describeToolCallSpan truncates at the cap boundary, not one character early (<=, not <)', () => {
+    const atCap = 'x'.repeat(60);
+    assert.equal(describeToolCallSpan('bash', { command: atCap }), `bash: ${atCap}`);
 
-  it('sliceSurrogateSafe backs off one code unit when a high surrogate sits at the cut boundary', () => {
-    const emoji = '\u{1F600}';
-    const text = `abc${emoji}tail`;
-    const sliced = sliceSurrogateSafe(text, 4);
-    assert.equal(sliced, 'abc');
-    const lastCode = sliced.charCodeAt(sliced.length - 1);
-    assert.ok(lastCode < 0xd800 || lastCode > 0xdbff, 'must not end on an unpaired high surrogate');
+    const overCap = 'x'.repeat(61);
+    assert.equal(describeToolCallSpan('bash', { command: overCap }), `bash: ${'x'.repeat(60)}…`);
   });
 });
 

--- a/packages/traceroot/tests/pi.test.ts
+++ b/packages/traceroot/tests/pi.test.ts
@@ -1,0 +1,1223 @@
+// Consolidated pi coverage: span construction, wrapper/integration behavior, config
+// resolution, and the initialize()/wireInstrumentations() dispatch (merged from
+// pi-spans.test.ts, pi-coding-agent.test.ts, and wiring-dispatch.test.ts).
+// Lifecycle/event-ordering and edge-case coverage lives in pi-lifecycle-edge-cases.test.ts.
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+import { ROOT_CONTEXT, trace } from '@opentelemetry/api';
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import {
+  resolveConfig,
+  instrumentPiCodingAgent,
+  describeToolCallSpan,
+  openLlmSpan,
+  closeLlmSpan,
+  openToolSpan,
+  closeToolSpan,
+  sliceSurrogateSafe,
+  type AgentEvent,
+  type AssistantMessage,
+} from '../src/pi';
+import { TraceRoot, _resetForTesting } from '../src/traceroot';
+import { wireInstrumentations } from '../src/instrumentation';
+import {
+  assistantMessage,
+  assistantMessage as baseAssistantMessage,
+  attrs,
+  CapturingExporter,
+  makeFakeSessionClass,
+  makeRig,
+} from './pi-test-helpers';
+
+// Shared by the dispose and steer/followUp describes below.
+function registerCapturingProvider(capture: CapturingExporter): void {
+  trace.disable();
+  const provider = new NodeTracerProvider();
+  provider.addSpanProcessor(new SimpleSpanProcessor(capture));
+  provider.register();
+}
+
+describe('pi span name', () => {
+  it('describeToolCallSpan uses the file basename for path-like args', () => {
+    assert.equal(describeToolCallSpan('read', { path: '/a/b/app.py' }), 'read: app.py');
+    assert.equal(describeToolCallSpan('write', { file: 'notes.md' }), 'write: notes.md');
+    assert.equal(describeToolCallSpan('edit', { filePath: 'src/x/y.ts' }), 'edit: y.ts');
+    assert.equal(describeToolCallSpan('grep', { target: '/etc/hosts' }), 'grep: hosts');
+    assert.equal(describeToolCallSpan('read', { file_path: '/a/b/app.py' }), 'read: app.py');
+    assert.equal(describeToolCallSpan('read', { filename: 'notes.md' }), 'read: notes.md');
+  });
+
+  it('describeToolCallSpan summarizes bash by its (whitespace-collapsed) command and truncates a long one', () => {
+    assert.equal(describeToolCallSpan('bash', { command: '  npm   test ' }), 'bash: npm test');
+    const name = describeToolCallSpan('bash', { command: `echo ${'x'.repeat(200)}` });
+    assert.ok(name.startsWith('bash: '));
+    assert.ok(name.endsWith('…'));
+    assert.ok(name.length <= 'bash: '.length + 60 + 1);
+  });
+
+  it('describeToolCallSpan falls back to the bare tool name', () => {
+    assert.equal(describeToolCallSpan('think', {}), 'think');
+    assert.equal(describeToolCallSpan('think', undefined), 'think');
+    assert.equal(describeToolCallSpan('bash', { command: '' }), 'bash');
+  });
+
+  it('describeToolCallSpan ignores non-string path-like args', () => {
+    assert.equal(describeToolCallSpan('read', { path: 42 }), 'read');
+    assert.equal(describeToolCallSpan('read', { path: null }), 'read');
+  });
+});
+
+describe('pi spans and config boundary coverage', () => {
+  // Direct unit coverage of pi.ts's LLM/tool span helpers and sliceSurrogateSafe.
+  function makeTracer() {
+    const spans: ReadableSpan[] = [];
+    const provider = new NodeTracerProvider();
+    provider.addSpanProcessor(
+      new SimpleSpanProcessor({
+        export(batch, cb) {
+          spans.push(...batch);
+          cb({ code: 0 });
+        },
+        async shutdown() {},
+      }),
+    );
+    const tracer = provider.getTracer('pi-spans-unit');
+    return { tracer, spans };
+  }
+
+  it('closeLlmSpan emits ZERO-valued usage tokens as attributes (setAttr must not treat 0 as absent)', () => {
+    const { tracer, spans } = makeTracer();
+    const message = assistantMessage({
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+    });
+    const span = openLlmSpan(tracer, ROOT_CONTEXT, message);
+    closeLlmSpan(span, message, true);
+
+    const a = attrs(spans[0]!);
+    assert.equal(a['gen_ai.usage.input_tokens'], 0);
+    assert.equal(a['gen_ai.usage.output_tokens'], 0);
+    assert.equal(a['gen_ai.usage.cache_read_input_tokens'], 0);
+    assert.equal(a['gen_ai.usage.cache_creation_input_tokens'], 0);
+    // OpenInference llm.* dual-write, zero must survive as an attribute here too.
+    assert.equal(a['llm.token_count.prompt'], 0);
+    assert.equal(a['llm.token_count.completion'], 0);
+    assert.equal(a['llm.token_count.total'], 0);
+    assert.equal(a['llm.token_count.prompt_details.cache_read'], 0);
+    assert.equal(a['llm.token_count.prompt_details.cache_write'], 0);
+  });
+
+  it('closeLlmSpan maps cache tokens to the correct gen_ai keys (read<->cacheRead, creation<->cacheWrite)', () => {
+    const { tracer, spans } = makeTracer();
+    const message = assistantMessage({
+      usage: {
+        input: 5,
+        output: 7,
+        cacheRead: 11,
+        cacheWrite: 13,
+        totalTokens: 36,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+    });
+    const span = openLlmSpan(tracer, ROOT_CONTEXT, message);
+    closeLlmSpan(span, message, false);
+
+    const a = attrs(spans[0]!);
+    assert.equal(a['gen_ai.usage.input_tokens'], 5);
+    assert.equal(a['gen_ai.usage.output_tokens'], 7);
+    assert.equal(a['gen_ai.usage.cache_read_input_tokens'], 11);
+    assert.equal(a['gen_ai.usage.cache_creation_input_tokens'], 13);
+    // OpenInference llm.* dual-write of the same numbers; total is pi's own totalTokens.
+    assert.equal(a['llm.token_count.prompt'], 5);
+    assert.equal(a['llm.token_count.completion'], 7);
+    assert.equal(a['llm.token_count.total'], 36);
+    assert.equal(a['llm.token_count.prompt_details.cache_read'], 11);
+    assert.equal(a['llm.token_count.prompt_details.cache_write'], 13);
+  });
+
+  it('closeLlmSpan updates the span name to responseModel when it differs from the request model', () => {
+    const { tracer, spans } = makeTracer();
+    const message = assistantMessage({ model: 'claude-req', responseModel: 'claude-resp-dated' });
+    const span = openLlmSpan(tracer, ROOT_CONTEXT, message);
+    closeLlmSpan(span, message, false);
+    assert.equal(spans[0]!.name, 'claude-resp-dated');
+    assert.equal(attrs(spans[0]!)['gen_ai.response.model'], 'claude-resp-dated');
+    assert.equal(attrs(spans[0]!)['llm.model_name'], 'claude-resp-dated');
+  });
+
+  it('openToolSpan swallows a circular-reference arg without setting input.value or throwing', () => {
+    const { tracer, spans } = makeTracer();
+    const circular: Record<string, unknown> = { a: 1 };
+    circular.self = circular;
+    assert.doesNotThrow(() => {
+      const span = openToolSpan(tracer, ROOT_CONTEXT, 'call-1', 'bash', circular, true);
+      closeToolSpan(span, { ok: true }, false, true);
+    });
+    const toolSpan = spans.find((s) => attrs(s)['gen_ai.tool.call.id'] === 'call-1');
+    assert.ok(toolSpan);
+    assert.equal(
+      attrs(toolSpan!)['input.value'],
+      undefined,
+      'a circular arg must be skipped (caught), not partially serialized',
+    );
+    assert.equal(attrs(toolSpan!)['output.value'], JSON.stringify({ ok: true }));
+  });
+
+  it('sliceSurrogateSafe returns text unchanged when at or under maxLen (<=, not <)', () => {
+    assert.equal(sliceSurrogateSafe('hello', 5), 'hello');
+    assert.equal(sliceSurrogateSafe('hello', 10), 'hello');
+    assert.equal(sliceSurrogateSafe('', 0), '');
+  });
+
+  it('sliceSurrogateSafe backs off one code unit when a high surrogate sits at the cut boundary', () => {
+    const emoji = '\u{1F600}';
+    const text = `abc${emoji}tail`;
+    const sliced = sliceSurrogateSafe(text, 4);
+    assert.equal(sliced, 'abc');
+    const lastCode = sliced.charCodeAt(sliced.length - 1);
+    assert.ok(lastCode < 0xd800 || lastCode > 0xdbff, 'must not end on an unpaired high surrogate');
+  });
+});
+
+describe('pi spans truncation', () => {
+  // Mirrors src/pi.ts's MAX_TOOL_IO_JSON_CHARS (not exported).
+  const MAX_TOOL_IO_JSON_CHARS = 32 * 1024;
+
+  // Mirrors src/pi.ts's capJsonWithMarker marker text exactly.
+  const TRUNCATION_MARKER = '…[truncated]';
+
+  // Drives one tool call through the full instrumented event sequence and returns the exported TOOL span.
+  async function runToolCall(
+    args: unknown,
+    result: unknown,
+    config: { captureToolIo?: boolean } = {},
+  ): Promise<ReadableSpan> {
+    const { capture, Session } = makeRig(config);
+    const session = new Session();
+
+    const done = session.prompt('run a tool');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'message_start', message: assistantMessage() });
+    session.emit({ type: 'message_end', message: assistantMessage() });
+    session.emit({ type: 'tool_execution_start', toolCallId: 't1', toolName: 'bash', args });
+    session.emit({
+      type: 'tool_execution_end',
+      toolCallId: 't1',
+      toolName: 'bash',
+      result,
+      isError: false,
+    });
+    session.emit({ type: 'turn_end', message: assistantMessage(), toolResults: [] });
+    session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    await done;
+
+    const toolSpan = capture.spans.find(
+      (s) => (s.attributes as Record<string, unknown>)['gen_ai.tool.call.id'] === 't1',
+    );
+    assert.ok(toolSpan, 'expected a tool span to have been exported');
+    return toolSpan!;
+  }
+
+  // JSON.stringify overhead for a single-key { data: '' } object, computed at runtime.
+  const JSON_WRAPPER_OVERHEAD = JSON.stringify({ data: '' }).length;
+
+  function payloadOfExactJsonLength(totalLength: number, filler = 'x'): { data: string } {
+    const fillerLength = totalLength - JSON_WRAPPER_OVERHEAD;
+    assert.ok(fillerLength >= 0, 'requested JSON length is smaller than the wrapper overhead');
+    return { data: filler.repeat(fillerLength) };
+  }
+
+  it('a tool arg/result under the cap passes through openToolSpan/closeToolSpan unchanged', async () => {
+    const args = { command: 'echo hello', note: 'small arg' };
+    const result = { content: [{ type: 'text', text: 'hello' }] };
+    const toolSpan = await runToolCall(args, result);
+
+    assert.equal(attrs(toolSpan)['input.value'], JSON.stringify(args));
+    assert.equal(attrs(toolSpan)['output.value'], JSON.stringify(result));
+    assert.ok(!String(attrs(toolSpan)['input.value']).includes(TRUNCATION_MARKER));
+    assert.ok(!String(attrs(toolSpan)['output.value']).includes(TRUNCATION_MARKER));
+  });
+
+  it('a tool arg/result exactly at the cap boundary passes through unchanged (<=, not <)', async () => {
+    const args = payloadOfExactJsonLength(MAX_TOOL_IO_JSON_CHARS);
+    const result = payloadOfExactJsonLength(MAX_TOOL_IO_JSON_CHARS, 'y');
+    assert.equal(
+      JSON.stringify(args).length,
+      MAX_TOOL_IO_JSON_CHARS,
+      'sanity check on args length',
+    );
+    assert.equal(
+      JSON.stringify(result).length,
+      MAX_TOOL_IO_JSON_CHARS,
+      'sanity check on result length',
+    );
+
+    const toolSpan = await runToolCall(args, result);
+
+    assert.equal(attrs(toolSpan)['input.value'], JSON.stringify(args));
+    assert.equal(attrs(toolSpan)['output.value'], JSON.stringify(result));
+    assert.equal((attrs(toolSpan)['input.value'] as string).length, MAX_TOOL_IO_JSON_CHARS);
+    assert.equal((attrs(toolSpan)['output.value'] as string).length, MAX_TOOL_IO_JSON_CHARS);
+    assert.ok(!(attrs(toolSpan)['input.value'] as string).includes(TRUNCATION_MARKER));
+    assert.ok(!(attrs(toolSpan)['output.value'] as string).includes(TRUNCATION_MARKER));
+  });
+
+  it('a tool arg/result over the cap is truncated with the marker appended, total length within bound', async () => {
+    const args = payloadOfExactJsonLength(MAX_TOOL_IO_JSON_CHARS + 1000);
+    const result = payloadOfExactJsonLength(MAX_TOOL_IO_JSON_CHARS + 500, 'y');
+
+    const toolSpan = await runToolCall(args, result);
+
+    const inputValue = attrs(toolSpan)['input.value'] as string;
+    const outputValue = attrs(toolSpan)['output.value'] as string;
+
+    assert.ok(inputValue.endsWith(TRUNCATION_MARKER), 'input.value must end with the marker');
+    assert.ok(outputValue.endsWith(TRUNCATION_MARKER), 'output.value must end with the marker');
+
+    assert.ok(
+      inputValue.length <= MAX_TOOL_IO_JSON_CHARS + TRUNCATION_MARKER.length,
+      'input.value total length must stay within MAX + marker bound',
+    );
+    assert.ok(
+      outputValue.length <= MAX_TOOL_IO_JSON_CHARS + TRUNCATION_MARKER.length,
+      'output.value total length must stay within MAX + marker bound',
+    );
+    assert.equal(inputValue.length, MAX_TOOL_IO_JSON_CHARS + TRUNCATION_MARKER.length);
+    assert.equal(outputValue.length, MAX_TOOL_IO_JSON_CHARS + TRUNCATION_MARKER.length);
+    assert.equal(
+      inputValue,
+      JSON.stringify(args).slice(0, MAX_TOOL_IO_JSON_CHARS) + TRUNCATION_MARKER,
+    );
+    assert.equal(
+      outputValue,
+      JSON.stringify(result).slice(0, MAX_TOOL_IO_JSON_CHARS) + TRUNCATION_MARKER,
+    );
+  });
+
+  it('captureToolIo: false still bypasses capJsonWithMarker entirely (no marker, no attribute)', async () => {
+    const args = payloadOfExactJsonLength(MAX_TOOL_IO_JSON_CHARS + 1000);
+    const toolSpan = await runToolCall(args, {}, { captureToolIo: false });
+
+    assert.equal(attrs(toolSpan)['input.value'], undefined);
+    assert.equal(attrs(toolSpan)['output.value'], undefined);
+  });
+
+  it('captureToolIo: false keeps arg-derived content out of the tool span NAME, not just its attributes (H1)', async () => {
+    const secret = 'curl -H "Authorization: Bearer sk-live-SECRET123" https://internal/x';
+
+    const withCapture = await runToolCall({ command: secret }, {}, { captureToolIo: true });
+    assert.ok(
+      (withCapture.name as string).startsWith('bash: '),
+      'with capture on, the name still summarizes the command',
+    );
+
+    const noCapture = await runToolCall({ command: secret }, {}, { captureToolIo: false });
+    assert.equal(noCapture.name, 'bash', 'with capture off, the name must be the bare tool name');
+    assert.ok(
+      !String(noCapture.name).includes('SECRET123'),
+      'a secret in the command must never reach the span name when captureToolIo is off',
+    );
+  });
+
+  it('tool spans dual-write OpenInference tool.name alongside gen_ai.tool.name (M2)', async () => {
+    const toolSpan = await runToolCall({ command: 'echo hi' }, {});
+    assert.equal(attrs(toolSpan)['tool.name'], 'bash', 'OpenInference tool.name must be set');
+    assert.equal(attrs(toolSpan)['gen_ai.tool.name'], 'bash');
+  });
+
+  it('a WIDE tool payload (more entries than the breadth cap) is truncated by entry count, not fully serialized (M1)', async () => {
+    // Small per-element so the FULL array is well under the byte cap; only the entry-count
+    // cap can produce this truncation, which distinguishes the M1 fix from the pre-existing
+    // whole-payload byte cap.
+    const wide = Array.from({ length: 2500 }, (_, i) => `x${i}`);
+    const toolSpan = await runToolCall({ items: wide }, {});
+    const inputValue = attrs(toolSpan)['input.value'] as string;
+
+    assert.ok(inputValue.includes(TRUNCATION_MARKER), 'the breadth cap marks the truncation');
+    assert.ok(
+      !inputValue.includes('"x2499"'),
+      'the far-tail element beyond the cap must be dropped, not serialized',
+    );
+    assert.ok(
+      inputValue.length <= MAX_TOOL_IO_JSON_CHARS + TRUNCATION_MARKER.length,
+      'input.value stays within the size bound',
+    );
+  });
+});
+
+describe('pi config resolution', () => {
+  it('resolveConfig() defaults captureContent and captureToolIo to true when omitted', () => {
+    const resolved = resolveConfig();
+    assert.equal(resolved.captureContent, true);
+    assert.equal(resolved.captureToolIo, true);
+
+    const resolvedFromEmptyObject = resolveConfig({});
+    assert.equal(resolvedFromEmptyObject.captureContent, true);
+    assert.equal(resolvedFromEmptyObject.captureToolIo, true);
+  });
+
+  it('resolveConfig() respects explicit false overrides for captureContent and captureToolIo independently', () => {
+    const contentOff = resolveConfig({ captureContent: false });
+    assert.equal(contentOff.captureContent, false);
+    assert.equal(contentOff.captureToolIo, true, 'captureToolIo must keep its own default');
+
+    const toolIoOff = resolveConfig({ captureToolIo: false });
+    assert.equal(toolIoOff.captureContent, true, 'captureContent must keep its own default');
+    assert.equal(toolIoOff.captureToolIo, false);
+
+    const bothOff = resolveConfig({ captureContent: false, captureToolIo: false });
+    assert.equal(bothOff.captureContent, false);
+    assert.equal(bothOff.captureToolIo, false);
+  });
+});
+
+describe('pi instrumentation', () => {
+  // Overrides the shared helper's placeholder usage since this file asserts on specific numbers.
+  function assistantMessage(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+    return baseAssistantMessage({
+      usage: {
+        input: 100,
+        output: 20,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 120,
+        cost: { input: 0.001, output: 0.0006, cacheRead: 0, cacheWrite: 0, total: 0.0016 },
+      },
+      ...overrides,
+    });
+  }
+
+  it('a full turn with one tool call produces a correctly nested AGENT -> LLM -> TOOL span tree', async () => {
+    const { capture, Session } = makeRig();
+    const session = new Session();
+
+    // NOT awaited yet; see pi-test-helpers CONTRACT.
+    const done = session.prompt('list files in /tmp');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'turn_start' });
+    session.emit({ type: 'message_start', message: assistantMessage() });
+    session.emit({
+      type: 'message_end',
+      message: assistantMessage({
+        content: [
+          { type: 'text', text: "I'll list the files now." },
+          { type: 'toolCall', id: 't1', name: 'bash' },
+        ],
+      }),
+    });
+    session.emit({
+      type: 'tool_execution_start',
+      toolCallId: 't1',
+      toolName: 'bash',
+      args: { command: 'ls /tmp' },
+    });
+    session.emit({
+      type: 'tool_execution_end',
+      toolCallId: 't1',
+      toolName: 'bash',
+      result: { content: [{ type: 'text', text: 'a.txt' }] },
+      isError: false,
+    });
+    session.emit({
+      type: 'turn_end',
+      message: assistantMessage(),
+      toolResults: [],
+    });
+    session.emit({
+      type: 'agent_end',
+      messages: [assistantMessage({ content: [{ type: 'text', text: 'listed the files' }] })],
+      willRetry: false,
+    });
+    await done;
+
+    assert.equal(capture.spans.length, 3, 'expected exactly root, LLM, and tool spans');
+
+    const [llmSpan, toolSpan, rootSpan] = capture.spans;
+
+    assert.equal(rootSpan.name, 'AgentSession.prompt');
+    assert.equal(attrs(rootSpan)['openinference.span.kind'], 'AGENT');
+    assert.equal(attrs(rootSpan)['session.id'], 'sess-1');
+    // traceroot.sdk.name is owned by TraceRootSpanProcessor, which this rig doesn't wire.
+    assert.equal(attrs(rootSpan)['traceroot.sdk.name'], undefined);
+    assert.equal(attrs(rootSpan)['input.value'], 'list files in /tmp');
+    assert.equal(attrs(rootSpan)['output.value'], 'listed the files');
+    assert.equal(attrs(rootSpan)['traceroot.pi.retry_count'], 0);
+
+    assert.equal(attrs(llmSpan)['openinference.span.kind'], 'LLM');
+    assert.equal(attrs(llmSpan)['gen_ai.system'], 'anthropic');
+    assert.equal(attrs(llmSpan)['gen_ai.request.model'], 'claude-sonnet-5');
+    assert.equal(attrs(llmSpan)['gen_ai.usage.input_tokens'], 100);
+    assert.equal(attrs(llmSpan)['gen_ai.usage.output_tokens'], 20);
+    assert.equal(
+      attrs(llmSpan)['output.value'],
+      "I'll list the files now.",
+      'captureContent:true (the default) must populate output.value on the LLM span too, not just the root span',
+    );
+    assert.equal(
+      llmSpan.parentSpanId,
+      rootSpan.spanContext().spanId,
+      'LLM span must be a child of the root span',
+    );
+
+    assert.equal(toolSpan.name, 'bash: ls /tmp');
+    assert.equal(attrs(toolSpan)['openinference.span.kind'], 'TOOL');
+    assert.equal(attrs(toolSpan)['gen_ai.tool.name'], 'bash');
+    assert.equal(attrs(toolSpan)['gen_ai.tool.call.id'], 't1');
+    assert.equal(
+      toolSpan.parentSpanId,
+      llmSpan.spanContext().spanId,
+      'tool span must be a child of the LLM span that requested it, not a sibling under root',
+    );
+  });
+
+  it('two concurrent tool calls in one turn each get their own correctly-keyed span', async () => {
+    const { capture, Session } = makeRig();
+    const session = new Session();
+
+    const done = session.prompt('do two things');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'message_start', message: assistantMessage() });
+    session.emit({ type: 'message_end', message: assistantMessage() });
+    session.emit({
+      type: 'tool_execution_start',
+      toolCallId: 'a',
+      toolName: 'read',
+      args: { path: '/x.txt' },
+    });
+    session.emit({
+      type: 'tool_execution_start',
+      toolCallId: 'b',
+      toolName: 'read',
+      args: { path: '/y.txt' },
+    });
+    session.emit({
+      type: 'tool_execution_end',
+      toolCallId: 'b',
+      toolName: 'read',
+      result: {},
+      isError: false,
+    });
+    session.emit({
+      type: 'tool_execution_end',
+      toolCallId: 'a',
+      toolName: 'read',
+      result: {},
+      isError: false,
+    });
+    session.emit({ type: 'turn_end', message: assistantMessage(), toolResults: [] });
+    session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    await done;
+
+    const toolSpans = capture.spans.filter(
+      (s) => (s.attributes as Record<string, unknown>)['gen_ai.tool.call.id'],
+    );
+    assert.equal(toolSpans.length, 2);
+    const ids = toolSpans
+      .map((s) => (s.attributes as Record<string, unknown>)['gen_ai.tool.call.id'])
+      .sort();
+    assert.deepEqual(ids, ['a', 'b']);
+    assert.equal(toolSpans[0]!.name, 'read: y.txt', 'b ended first, so it should export first');
+    assert.equal(toolSpans[1]!.name, 'read: x.txt');
+  });
+
+  it('a failed LLM turn (stopReason error) marks the LLM span as ERROR', async () => {
+    const { capture, Session } = makeRig();
+    const session = new Session();
+
+    const done = session.prompt('trigger a provider error');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'message_start', message: assistantMessage() });
+    session.emit({
+      type: 'message_end',
+      message: assistantMessage({ stopReason: 'error', errorMessage: 'rate limited' }),
+    });
+    session.emit({ type: 'turn_end', message: assistantMessage(), toolResults: [] });
+    session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    await done;
+
+    const llmSpan = capture.spans.find(
+      (s) => (s.attributes as Record<string, unknown>)['openinference.span.kind'] === 'LLM',
+    );
+    assert.ok(llmSpan);
+    assert.equal(llmSpan!.status.code, 2 /* SpanStatusCode.ERROR */);
+    assert.equal(llmSpan!.status.message, 'rate limited');
+  });
+
+  it('a failed tool call (isError) marks the TOOL span as ERROR', async () => {
+    const { capture, Session } = makeRig();
+    const session = new Session();
+
+    const done = session.prompt('run a failing command');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'message_start', message: assistantMessage() });
+    session.emit({ type: 'message_end', message: assistantMessage() });
+    session.emit({
+      type: 'tool_execution_start',
+      toolCallId: 't1',
+      toolName: 'bash',
+      args: { command: 'false' },
+    });
+    session.emit({
+      type: 'tool_execution_end',
+      toolCallId: 't1',
+      toolName: 'bash',
+      result: { content: [{ type: 'text', text: 'exit 1' }] },
+      isError: true,
+    });
+    session.emit({ type: 'turn_end', message: assistantMessage(), toolResults: [] });
+    session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    await done;
+
+    const toolSpan = capture.spans.find(
+      (s) => (s.attributes as Record<string, unknown>)['gen_ai.tool.call.id'] === 't1',
+    );
+    assert.ok(toolSpan);
+    assert.equal(toolSpan!.status.code, 2 /* SpanStatusCode.ERROR */);
+  });
+
+  it('captureContent: false suppresses input.value/output.value but keeps other attributes', async () => {
+    const { capture, Session } = makeRig({ captureContent: false });
+    const session = new Session();
+
+    const done = session.prompt('sensitive prompt text');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'message_start', message: assistantMessage() });
+    session.emit({
+      type: 'message_end',
+      message: assistantMessage({ content: [{ type: 'text', text: 'sensitive llm reply' }] }),
+    });
+    session.emit({ type: 'turn_end', message: assistantMessage(), toolResults: [] });
+    session.emit({
+      type: 'agent_end',
+      messages: [assistantMessage({ content: [{ type: 'text', text: 'sensitive reply' }] })],
+      willRetry: false,
+    });
+    await done;
+
+    const [llmSpan, rootSpan] = capture.spans;
+    assert.equal(attrs(rootSpan!)['input.value'], undefined);
+    assert.equal(attrs(rootSpan!)['output.value'], undefined);
+    assert.equal(attrs(rootSpan!)['session.id'], 'sess-1');
+
+    assert.ok(llmSpan, 'expected an LLM span to have been captured');
+    assert.equal(attrs(llmSpan!)['openinference.span.kind'], 'LLM');
+    assert.equal(
+      attrs(llmSpan!)['output.value'],
+      undefined,
+      'captureContent:false must suppress output.value on the LLM span too, not just the root span',
+    );
+  });
+
+  it('captureToolIo: false suppresses tool input/output AND arg-derived content in the span name (H1)', async () => {
+    const { capture, Session } = makeRig({ captureToolIo: false });
+    const session = new Session();
+
+    const done = session.prompt('run a tool');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'message_start', message: assistantMessage() });
+    session.emit({ type: 'message_end', message: assistantMessage() });
+    // A path arg (tool IO): with captureToolIo off, the name must fall back to the bare
+    // tool name — no basename, no filename — so nothing arg-derived leaks into it.
+    session.emit({
+      type: 'tool_execution_start',
+      toolCallId: 't1',
+      toolName: 'read',
+      args: { path: '/Users/alice/secret-project/notes.txt' },
+    });
+    session.emit({
+      type: 'tool_execution_end',
+      toolCallId: 't1',
+      toolName: 'read',
+      result: { secret: 'leaked?' },
+      isError: false,
+    });
+    session.emit({ type: 'turn_end', message: assistantMessage(), toolResults: [] });
+    session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    await done;
+
+    const toolSpan = capture.spans.find(
+      (s) => (s.attributes as Record<string, unknown>)['gen_ai.tool.call.id'] === 't1',
+    );
+    assert.ok(toolSpan);
+    assert.equal(attrs(toolSpan!)['input.value'], undefined);
+    assert.equal(attrs(toolSpan!)['output.value'], undefined);
+    assert.equal(attrs(toolSpan!)['gen_ai.tool.name'], 'read');
+    assert.equal(toolSpan!.name, 'read', 'the name is the bare tool name, not the file basename');
+    assert.ok(
+      !toolSpan!.name.includes('notes.txt') && !toolSpan!.name.includes('secret-project'),
+      'no part of the path (filename or directory) may appear in the span name when capture is off',
+    );
+  });
+
+  it('an early-return prompt() call (resolved with no agent_start/agent_end) exports exactly one childless, OK-status AGENT root span', async () => {
+    const { capture, Session } = makeRig();
+    const session = new Session();
+
+    const done = session.prompt('a handled slash command');
+    session.resolvePrompt();
+    await assert.doesNotReject(() => done);
+
+    assert.equal(
+      capture.spans.length,
+      1,
+      'exactly one span: the root, with ZERO child spans (no agent_start ever fired to open any)',
+    );
+    const rootSpan = capture.spans[0]!;
+    assert.equal(rootSpan.name, 'AgentSession.prompt');
+    assert.equal(attrs(rootSpan)['openinference.span.kind'], 'AGENT');
+    assert.equal(
+      rootSpan.status.code,
+      1 /* SpanStatusCode.OK */,
+      'finalize() explicitly stamps OK on a resolved call (a successfully-resolved ' +
+        'promise, even with zero children, is not merely "unset")',
+    );
+    assert.equal(
+      rootSpan.parentSpanId,
+      undefined,
+      'the root itself has no parent (it is the trace root)',
+    );
+  });
+});
+
+describe('pi wiring and wireInstrumentations() dispatch', () => {
+  // A fake `import * as pi from '@earendil-works/pi-coding-agent'` namespace. The
+  // real in-tree pi instrumentation patches AgentSession.prototype.prompt when
+  // wired, so a change in that method's identity is a reliable "pi was actually
+  // instrumented" signal without having to drive a whole agent turn.
+  function makePiModule() {
+    class FakeAgentSession {
+      sessionId = 'core-wiring-sess';
+      async prompt(_text: string): Promise<void> {}
+      subscribe(_listener: (event: { type: string }) => void): () => void {
+        return () => {};
+      }
+      dispose(): void {}
+    }
+    return { AgentSession: FakeAgentSession };
+  }
+
+  function piPromptPatched(mod: ReturnType<typeof makePiModule>, original: unknown): boolean {
+    return mod.AgentSession.prototype.prompt !== original;
+  }
+
+  // A minimally-valid @anthropic-ai/claude-agent-sdk namespace: a mutable object
+  // exposing query(). wireClaudeAgentSDKInstrumentation() replaces .query in place.
+  function makeClaudeModule() {
+    return {
+      query(_params: unknown): AsyncIterable<unknown> {
+        return { async *[Symbol.asyncIterator]() {} };
+      },
+    };
+  }
+
+  const BASE = {
+    apiKey: 'trk_core_wiring',
+    baseUrl: 'http://127.0.0.1:9',
+    disableBatch: true as const,
+    gitRepo: 'traceroot-ai/traceroot-ts',
+    gitRef: 'core-wiring-ref',
+  };
+
+  afterEach(() => {
+    _resetForTesting();
+    delete process.env.TRACEROOT_API_KEY;
+  });
+
+  describe('instrumentModules.piCodingAgent wiring', () => {
+    it('accepts the { module, config } wrapper form and still patches the prototype', () => {
+      const pi = makePiModule();
+      const originalPrompt = pi.AgentSession.prototype.prompt;
+
+      TraceRoot.initialize({
+        ...BASE,
+        instrumentModules: {
+          piCodingAgent: { module: pi, config: { captureContent: false } },
+        },
+      });
+
+      assert.equal(TraceRoot.isInitialized(), true);
+      assert.notStrictEqual(
+        pi.AgentSession.prototype.prompt,
+        originalPrompt,
+        'the { module, config } wrapper must be unwrapped and still patch the prototype',
+      );
+    });
+
+    it('leaves the prototype untouched when piCodingAgent is null', () => {
+      const pi = makePiModule();
+      const originalPrompt = pi.AgentSession.prototype.prompt;
+
+      TraceRoot.initialize({ ...BASE, instrumentModules: { piCodingAgent: null } });
+
+      assert.equal(TraceRoot.isInitialized(), true);
+      assert.strictEqual(
+        pi.AgentSession.prototype.prompt,
+        originalPrompt,
+        'a null piCodingAgent must never touch any AgentSession prototype',
+      );
+    });
+
+    it('throws and rolls initialize() back for a misshapen module (fail loudly, like claude-agent-sdk)', () => {
+      // No prompt/subscribe on the prototype: a pi SDK rename must fail loudly, not silently emit zero traces.
+      const misshapen = { AgentSession: class {} };
+
+      assert.throws(
+        () => TraceRoot.initialize({ ...BASE, instrumentModules: { piCodingAgent: misshapen } }),
+        /prompt\/subscribe not found/,
+        'a misshapen piCodingAgent must throw, not warn-and-noop',
+      );
+      assert.equal(
+        TraceRoot.isInitialized(),
+        false,
+        'the wiring-failure rollback must leave TraceRoot uninitialized (it never reached _isInitialized = true)',
+      );
+    });
+  });
+
+  describe('wireInstrumentations() dispatch — sibling isolation', () => {
+    it('throws a clear diagnostic when claudeAgentSDK is passed without query()', () => {
+      assert.throws(
+        () => wireInstrumentations({ claudeAgentSDK: {} }),
+        /does not expose query/,
+        'a claudeAgentSDK ref without query() must throw an actionable error',
+      );
+    });
+
+    it('a throwing claudeAgentSDK aborts the loop before a co-passed piCodingAgent is wired', () => {
+      // Documents the blast radius: because wireInstrumentations() wires
+      // claudeAgentSDK before piCodingAgent and does not isolate per-module
+      // failures, a bad claudeAgentSDK throws out of the whole loop and a
+      // perfectly valid piCodingAgent alongside it is silently left
+      // un-instrumented.
+      delete process.env.TRACEROOT_API_KEY;
+      const pi = makePiModule();
+      const originalPrompt = pi.AgentSession.prototype.prompt;
+
+      let threw = false;
+      try {
+        TraceRoot.initialize({
+          ...BASE,
+          instrumentModules: { claudeAgentSDK: {}, piCodingAgent: pi },
+        });
+      } catch {
+        threw = true;
+      }
+      assert.equal(threw, true);
+      assert.equal(
+        piPromptPatched(pi, originalPrompt),
+        false,
+        'the valid piCodingAgent was left un-instrumented because the claudeAgentSDK throw aborted the loop',
+      );
+    });
+  });
+
+  describe('both piCodingAgent and claudeAgentSDK in one initialize() call', () => {
+    it('wires both when both are valid, with no interference', () => {
+      delete process.env.TRACEROOT_API_KEY;
+      const pi = makePiModule();
+      const originalPrompt = pi.AgentSession.prototype.prompt;
+      const claude = makeClaudeModule();
+      const originalQuery = claude.query;
+
+      TraceRoot.initialize({
+        ...BASE,
+        instrumentModules: { claudeAgentSDK: claude, piCodingAgent: pi },
+      });
+
+      assert.equal(TraceRoot.isInitialized(), true);
+      assert.notStrictEqual(
+        claude.query,
+        originalQuery,
+        'claudeAgentSDK.query must be wrapped in place',
+      );
+      assert.equal(
+        piPromptPatched(pi, originalPrompt),
+        true,
+        'piCodingAgent must be instrumented alongside claudeAgentSDK',
+      );
+    });
+  });
+
+  describe('double initialize() without an intervening shutdown()', () => {
+    it("drops the second call's instrumentModules (documented Already-initialized guard)", () => {
+      delete process.env.TRACEROOT_API_KEY;
+
+      // First init with no instrumentModules.
+      TraceRoot.initialize({ ...BASE });
+      assert.equal(TraceRoot.isInitialized(), true);
+
+      // Second init supplies a valid piCodingAgent. The Already-initialized guard
+      // returns early, so this config is intentionally NOT applied. This confirms
+      // the documented contract (a second initialize() is a warned no-op), rather
+      // than the alternative one might expect (the new config being merged/applied).
+      const pi = makePiModule();
+      const originalPrompt = pi.AgentSession.prototype.prompt;
+      const warnings: string[] = [];
+      const originalWarn = console.warn;
+      console.warn = (...args: unknown[]) => {
+        warnings.push(args.join(' '));
+      };
+      try {
+        TraceRoot.initialize({ ...BASE, instrumentModules: { piCodingAgent: pi } });
+      } finally {
+        console.warn = originalWarn;
+      }
+
+      assert.equal(
+        piPromptPatched(pi, originalPrompt),
+        false,
+        "the second initialize()'s instrumentModules must be dropped by the Already-initialized guard",
+      );
+      assert.ok(
+        warnings.some((w) => w.includes('Already initialized')),
+        'the dropped second initialize() must warn that it was skipped',
+      );
+    });
+  });
+});
+
+describe('pi integration', () => {
+  // Drives the real pi instrumentation through TraceRoot.initialize() with no mocked pi export.
+
+  // Reaches the provider TraceRoot.initialize() registered as the OTel global delegate.
+  function attachInMemoryExporterToGlobalProvider(): InMemorySpanExporter {
+    const proxy = trace.getTracerProvider() as { getDelegate?: () => unknown };
+    const delegate = (typeof proxy.getDelegate === 'function' ? proxy.getDelegate() : proxy) as {
+      addSpanProcessor(processor: SimpleSpanProcessor): void;
+    };
+    const exporter = new InMemorySpanExporter();
+    delegate.addSpanProcessor(new SimpleSpanProcessor(exporter));
+    return exporter;
+  }
+
+  const spanKind = (span: ReadableSpan): unknown => attrs(span)['openinference.span.kind'];
+
+  afterEach(() => {
+    _resetForTesting();
+  });
+
+  it('the real in-tree pi instrumentation wired through TraceRoot.initialize exports enriched spans into TraceRoot own pipeline', async () => {
+    delete process.env.TRACEROOT_API_KEY;
+
+    const Session = makeFakeSessionClass();
+    const pi = { AgentSession: Session };
+
+    TraceRoot.initialize({
+      apiKey: 'trk_integration_key',
+      // Local, unroutable: must never POST to the real backend.
+      baseUrl: 'http://127.0.0.1:9',
+      disableBatch: true,
+      environment: 'integration-test',
+      gitRepo: 'traceroot-ai/traceroot-ts',
+      gitRef: 'integration-ref',
+      instrumentModules: { piCodingAgent: pi },
+    });
+    assert.equal(TraceRoot.isInitialized(), true);
+
+    const captured = attachInMemoryExporterToGlobalProvider();
+
+    const session = new Session();
+    (session as { sessionId: string }).sessionId = 'integration-sess';
+    const working = assistantMessage({ content: [{ type: 'text', text: 'working on it' }] });
+    const done = session.prompt('summarize the repository');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'turn_start' });
+    session.emit({ type: 'message_start', message: working });
+    session.emit({ type: 'message_end', message: working });
+    session.emit({ type: 'turn_end', message: working, toolResults: [] });
+    session.emit({
+      type: 'agent_end',
+      messages: [
+        assistantMessage({
+          content: [{ type: 'text', text: 'the repository has three packages' }],
+        }),
+      ],
+      willRetry: false,
+    });
+    await done;
+
+    const spans = captured.getFinishedSpans();
+    const rootSpan = spans.find((s) => spanKind(s) === 'AGENT');
+    const llmSpan = spans.find((s) => spanKind(s) === 'LLM');
+
+    assert.ok(
+      rootSpan,
+      'the real in-tree pi instrumentation must export an AGENT root span through TraceRoot shared provider',
+    );
+
+    assert.equal(rootSpan!.name, 'AgentSession.prompt');
+    assert.equal(attrs(rootSpan!)['session.id'], 'integration-sess');
+    assert.equal(attrs(rootSpan!)['input.value'], 'summarize the repository');
+    assert.equal(attrs(rootSpan!)['output.value'], 'the repository has three packages');
+    // traceroot.sdk.name is owned by TraceRootSpanProcessor.onStart, uniformly across every span.
+    assert.equal(attrs(rootSpan!)['traceroot.sdk.name'], 'traceroot-ts');
+
+    assert.equal(attrs(rootSpan!)['deployment.environment'], 'integration-test');
+    assert.equal(attrs(rootSpan!)['traceroot.git.repo'], 'traceroot-ai/traceroot-ts');
+    assert.equal(attrs(rootSpan!)['traceroot.git.ref'], 'integration-ref');
+    assert.deepEqual(
+      attrs(rootSpan!)['traceroot.span.path'],
+      ['AgentSession.prompt'],
+      'the root span must carry TraceRootSpanProcessor span-path enrichment',
+    );
+
+    assert.ok(llmSpan, 'the LLM child span must also route through TraceRoot provider');
+    assert.equal(
+      llmSpan!.parentSpanId,
+      rootSpan!.spanContext().spanId,
+      'the LLM span must nest under the AGENT root span',
+    );
+    assert.deepEqual(
+      attrs(llmSpan!)['traceroot.span.path'],
+      ['AgentSession.prompt', 'claude-sonnet-5'],
+      'the LLM span path must chain off the root span path via TraceRootSpanProcessor',
+    );
+  });
+});
+
+describe('pi session dispose', () => {
+  // dispose() clears every listener via subscribe(), reassigning the internal array to a fresh
+  // empty one. Local instrumentPiCodingAgent() calls (not makeRig()) so tests can drive
+  // dispose() on the raw session.
+
+  it('dispose() mid-run (before agent_end) force-closes and exports any still-open AGENT/LLM/TOOL spans instead of leaking them', async () => {
+    const capture = new CapturingExporter();
+    const Session = makeFakeSessionClass();
+    const sdk = { AgentSession: Session };
+    registerCapturingProvider(capture);
+    instrumentPiCodingAgent(sdk, {});
+    const session = new Session();
+
+    // "Host disposes mid-run": open spans, never fire agent_end. Not awaited: abandoned mid-flight.
+    session.prompt('long-running task');
+    session.emit({ type: 'agent_start' });
+    session.emit({
+      type: 'message_start',
+      message: assistantMessage({ model: 'mid-run-model' }),
+    });
+    session.emit({
+      type: 'tool_execution_start',
+      toolCallId: 'call-1',
+      toolName: 'read_file',
+      args: { path: '/tmp/x' },
+    });
+
+    assert.equal(
+      capture.spans.length,
+      0,
+      'no span should export before dispose() while still open',
+    );
+
+    assert.doesNotThrow(() => {
+      session.dispose();
+    }, 'dispose() must never throw even though it now force-closes in-flight spans');
+    assert.equal(
+      session.disposed,
+      true,
+      'the real dispose() must still run and mark the session disposed',
+    );
+
+    assert.equal(
+      capture.spans.length,
+      3,
+      'the open AGENT root span, LLM span, and TOOL span must all be force-closed and exported by dispose()',
+    );
+
+    const rootSpan = capture.spans.find((s) => s.name === 'AgentSession.prompt');
+    const llmSpan = capture.spans.find((s) => attrs(s)['gen_ai.request.model'] === 'mid-run-model');
+    const toolSpan = capture.spans.find((s) => attrs(s)['gen_ai.tool.call.id'] === 'call-1');
+
+    assert.ok(rootSpan, 'the AGENT root span must be exported');
+    assert.ok(llmSpan, 'the LLM span must be exported');
+    assert.ok(toolSpan, 'the TOOL span must be exported');
+
+    assert.equal(
+      attrs(rootSpan!)['traceroot.pi.force_closed'],
+      true,
+      'the root span must be marked force_closed, distinguishing it from a normal agent_end close',
+    );
+    assert.equal(
+      attrs(llmSpan!)['traceroot.pi.force_closed'],
+      true,
+      'the LLM span must be marked force_closed',
+    );
+    assert.equal(
+      attrs(toolSpan!)['traceroot.pi.force_closed'],
+      true,
+      'the TOOL span must be marked force_closed',
+    );
+
+    session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    assert.equal(
+      capture.spans.length,
+      3,
+      'no further spans may appear after dispose() already force-closed everything',
+    );
+  });
+
+  // Guards a real bug: subscribedSessions used to permanently remember a session as subscribed
+  // and never re-attach its listener after dispose(), so every run after the first dispose() produced zero spans.
+  it('a session reused after dispose() re-subscribes and resumes tracing on its next prompt()', async () => {
+    const capture = new CapturingExporter();
+    const Session = makeFakeSessionClass();
+    const sdk = { AgentSession: Session };
+    registerCapturingProvider(capture);
+    instrumentPiCodingAgent(sdk, {});
+    const session = new Session();
+
+    const done1 = session.prompt('first run');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    await done1;
+    assert.equal(capture.spans.length, 1, 'the first run must export its span');
+
+    session.dispose();
+    assert.equal(session.disposed, true);
+
+    const done2 = session.prompt('second run, after dispose()');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    await done2;
+
+    assert.equal(
+      capture.spans.length,
+      2,
+      'the second run (after dispose() and reuse) must ALSO export its span, not be silently ' +
+        'dropped because instrumentPiCodingAgent() thinks this session is still subscribed',
+    );
+  });
+
+  // Guards a reentrancy race: a host listener registered before pi's own that calls dispose()
+  // synchronously on agent_end force-closes the root before pi's own agent_end handler runs.
+  it('agent_end after a reentrant dispose() force-closed the root still exports it exactly once', async () => {
+    const capture = new CapturingExporter();
+    const Session = makeFakeSessionClass();
+    const sdk = { AgentSession: Session };
+    registerCapturingProvider(capture);
+    instrumentPiCodingAgent(sdk, {});
+    const session = new Session();
+
+    // Registered before pi's own subscribe() (below), so it sits ahead of pi's handler.
+    session.subscribe((event: AgentEvent) => {
+      if (event.type === 'agent_end') session.dispose();
+    });
+
+    const done = session.prompt('do the work'); // pi subscribes here, after the host
+    session.emit({ type: 'agent_start' });
+    session.emit({
+      type: 'agent_end',
+      messages: [assistantMessage({ content: [{ type: 'text', text: 'the final answer' }] })],
+      willRetry: false,
+    });
+    await done;
+
+    assert.equal(
+      capture.spans.length,
+      1,
+      'the root span is force-closed exactly once by dispose()',
+    );
+    const rootSpan = capture.spans[0];
+    assert.equal(attrs(rootSpan)['openinference.span.kind'], 'AGENT');
+    assert.equal(
+      attrs(rootSpan)['traceroot.pi.force_closed'],
+      true,
+      'dispose() force-closed the root span, so it is marked force_closed',
+    );
+    assert.equal(
+      attrs(rootSpan)['output.value'],
+      undefined,
+      "the run's completion output never made it onto the force-closed root span",
+    );
+  });
+});
+
+describe('pi steer / followUp', () => {
+  // Must patch .steer/.followUp too, not just .prompt: real bug was a host whose first interaction
+  // was steer()/followUp() got zero tracing. Their text is deliberately never asserted onto the root's
+  // input.value: they only enqueue, never trigger a run, so attributing it would misattribute to a later run.
+
+  // Extends the shared FakeAgentSession with steer()/followUp(). Fresh per call so patches don't stack.
+  function makeSteerAndFollowUpSessionClass() {
+    const Base = makeFakeSessionClass();
+    return class SteerAndFollowUpAgentSession extends Base {
+      async steer(_text: string, _images?: unknown[]): Promise<void> {}
+      async followUp(_text: string, _images?: unknown[]): Promise<void> {}
+    };
+  }
+
+  // Only prompt() opens a root span; a steer()-only run produces none, so this checks its tool span
+  // still exports (as a parentless mini-trace) to prove the listener is attached, not zero-tracing.
+  it('calling steer() as the FIRST interaction (no prior prompt() call) still attaches tracing -- its run is ROOTLESS (bypasses prompt()), but its child spans still export', async () => {
+    const capture = new CapturingExporter();
+    const Session = makeSteerAndFollowUpSessionClass();
+    const sdk = { AgentSession: Session };
+    registerCapturingProvider(capture);
+    instrumentPiCodingAgent(sdk, {});
+    const session = new Session();
+
+    await session.steer('do X instead');
+    session.emit({ type: 'agent_start' });
+    session.emit({
+      type: 'tool_execution_start',
+      toolCallId: 'bypass-tool',
+      toolName: 'bash',
+      args: {},
+    });
+    session.emit({
+      type: 'tool_execution_end',
+      toolCallId: 'bypass-tool',
+      toolName: 'bash',
+      result: {},
+      isError: false,
+    });
+    session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+
+    assert.equal(
+      capture.spans.find((s) => attrs(s)['openinference.span.kind'] === 'AGENT'),
+      undefined,
+      'a run that bypasses prompt() entirely must never synthesize a root AGENT span',
+    );
+    const toolSpan = capture.spans.find((s) => attrs(s)['gen_ai.tool.call.id'] === 'bypass-tool');
+    assert.ok(
+      toolSpan,
+      "steer() must still attach the span listener itself -- otherwise this bypass run's tool span " +
+        'would never have been captured at all, proving prompt() was not required first',
+    );
+    assert.equal(
+      toolSpan!.parentSpanId,
+      undefined,
+      "with no root open, the bypass run's tool span parents under ROOT_CONTEXT (a fresh, " +
+        'standalone parentless mini-trace)',
+    );
+  });
+
+  it('a session already subscribed via prompt() does not get double-subscribed when steer()/followUp() are called later', async () => {
+    const capture = new CapturingExporter();
+    const Session = makeSteerAndFollowUpSessionClass();
+    const sdk = { AgentSession: Session };
+    registerCapturingProvider(capture);
+    instrumentPiCodingAgent(sdk, {});
+    const session = new Session();
+
+    const done = session.prompt('start the run');
+    await session.steer('steer mid-run');
+    await session.followUp('follow up after');
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'agent_end', messages: [assistantMessage()], willRetry: false });
+    await done;
+
+    assert.equal(
+      capture.spans.length,
+      1,
+      'exactly one root span -- proves steer()/followUp() reused the same listener prompt() already attached, instead of subscribing a second time',
+    );
+  });
+});

--- a/packages/traceroot/tests/pi.test.ts
+++ b/packages/traceroot/tests/pi.test.ts
@@ -152,6 +152,52 @@ describe('pi spans and config boundary coverage', () => {
     assert.equal(attrs(spans[0]!)['llm.model_name'], 'claude-resp-dated');
   });
 
+  it('closeLlmSpan records tool_calls in output.value on a tool-use turn (was dropped when content had no text)', () => {
+    const { tracer, spans } = makeTracer();
+    const message = assistantMessage({
+      content: [
+        { type: 'toolCall', id: 't1', name: 'bash', arguments: { command: 'node test/x.js' } },
+      ],
+      stopReason: 'toolUse',
+    });
+    const span = openLlmSpan(tracer, ROOT_CONTEXT, message);
+    closeLlmSpan(span, message, true);
+    const out = attrs(spans[0]!)['output.value'] as string | undefined;
+    // The LLM turn that ISSUES tool calls owns the nested TOOL spans — it must
+    // still export what the model produced, not an empty output.
+    assert.ok(out, 'a tool-use LLM turn must still emit output.value');
+    const parsed = JSON.parse(out);
+    assert.equal(parsed.tool_calls[0].function.name, 'bash');
+    assert.equal(
+      parsed.tool_calls[0].function.arguments,
+      JSON.stringify({ command: 'node test/x.js' }),
+    );
+  });
+
+  it('closeLlmSpan captures assistant text AND tool_calls when a turn has both', () => {
+    const { tracer, spans } = makeTracer();
+    const message = assistantMessage({
+      content: [
+        { type: 'text', text: 'let me check' },
+        { type: 'toolCall', id: 't1', name: 'grep', arguments: { pattern: 'x' } },
+      ],
+      stopReason: 'toolUse',
+    });
+    const span = openLlmSpan(tracer, ROOT_CONTEXT, message);
+    closeLlmSpan(span, message, true);
+    const parsed = JSON.parse(attrs(spans[0]!)['output.value'] as string);
+    assert.equal(parsed.content, 'let me check');
+    assert.equal(parsed.tool_calls[0].function.name, 'grep');
+  });
+
+  it('closeLlmSpan keeps plain-text output.value for a text-only turn (unchanged)', () => {
+    const { tracer, spans } = makeTracer();
+    const message = assistantMessage({ content: [{ type: 'text', text: 'hello world' }] });
+    const span = openLlmSpan(tracer, ROOT_CONTEXT, message);
+    closeLlmSpan(span, message, true);
+    assert.equal(attrs(spans[0]!)['output.value'], 'hello world');
+  });
+
   it('openToolSpan swallows a circular-reference arg without setting input.value or throwing', () => {
     const { tracer, spans } = makeTracer();
     const circular: Record<string, unknown> = { a: 1 };
@@ -448,11 +494,16 @@ describe('pi instrumentation', () => {
     assert.equal(attrs(llmSpan)['gen_ai.request.model'], 'claude-sonnet-5');
     assert.equal(attrs(llmSpan)['gen_ai.usage.input_tokens'], 100);
     assert.equal(attrs(llmSpan)['gen_ai.usage.output_tokens'], 20);
+    // This turn emitted assistant text AND a `bash` tool call, so output.value is
+    // the serialized assistant message carrying BOTH — the tool call must not be
+    // dropped just because the turn also produced text.
+    const llmOut = JSON.parse(attrs(llmSpan)['output.value'] as string);
     assert.equal(
-      attrs(llmSpan)['output.value'],
+      llmOut.content,
       "I'll list the files now.",
       'captureContent:true (the default) must populate output.value on the LLM span too, not just the root span',
     );
+    assert.equal(llmOut.tool_calls[0].function.name, 'bash');
     assert.equal(
       llmSpan.parentSpanId,
       rootSpan.spanContext().spanId,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,10 +27,10 @@ importers:
     dependencies:
       '@mastra/core':
         specifier: '>=1.0.0-0 <2.0.0-0'
-        version: 1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6)
+        version: 1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(typebox@1.1.38)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(typebox@1.1.38)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.1.38)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6)
       '@mastra/observability':
         specifier: '>=1.0.0-0 <2.0.0-0'
-        version: 1.7.2(@mastra/core@1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6))
+        version: 1.7.2(@mastra/core@1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(typebox@1.1.38)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(typebox@1.1.38)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.1.38)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6))
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -58,7 +58,7 @@ importers:
         version: 20.19.37
       eslint:
         specifier: ^9.0.0
-        version: 9.39.4
+        version: 9.39.4(jiti@2.7.0)
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
@@ -67,7 +67,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.0.0
-        version: 8.58.0(eslint@9.39.4)(typescript@5.9.3)
+        version: 8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
 
   packages/traceroot:
     dependencies:
@@ -82,7 +82,7 @@ importers:
         version: 0.1.7
       '@arizeai/openinference-instrumentation-bedrock':
         specifier: ^0.4.8
-        version: 0.4.8(@aws-sdk/client-bedrock-runtime@3.1020.0)
+        version: 0.4.8(@aws-sdk/client-bedrock-runtime@3.1048.0)
       '@arizeai/openinference-instrumentation-claude-agent-sdk':
         specifier: ^0.2.0
         version: 0.2.0
@@ -120,6 +120,9 @@ importers:
         specifier: ^1.40.0
         version: 1.40.0
     devDependencies:
+      '@earendil-works/pi-coding-agent':
+        specifier: ^0.80.0
+        version: 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
       '@eslint/js':
         specifier: ^9.0.0
         version: 9.39.4
@@ -129,6 +132,9 @@ importers:
       '@openai/agents':
         specifier: '>=0.0.1'
         version: 0.8.5(@cfworker/json-schema@4.1.1)(ws@8.20.0)(zod@4.3.6)
+      '@opentelemetry/core':
+        specifier: ^1.30.1
+        version: 1.30.1(@opentelemetry/api@1.9.1)
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.37
@@ -137,7 +143,7 @@ importers:
         version: 0.0.0
       eslint:
         specifier: ^9.0.0
-        version: 9.39.4
+        version: 9.39.4(jiti@2.7.0)
       openai:
         specifier: ^6.33.0
         version: 6.33.0(ws@8.20.0)(zod@4.3.6)
@@ -149,7 +155,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.0.0
-        version: 8.58.0(eslint@9.39.4)(typescript@5.9.3)
+        version: 8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
 
 packages:
 
@@ -206,6 +212,15 @@ packages:
       zod:
         optional: true
 
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@arizeai/openinference-core@2.0.5':
     resolution: {integrity: sha512-BnufYaFqmG9twkz/9DHX9WTcOs7YvVAYaufau5tdjOT1c0Y8niJwmNWzV36phNPg3c7SmdD5OYLuzeAUN0T3pQ==}
 
@@ -250,10 +265,6 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.7.0 <2.0.0'
 
-  '@aws-crypto/crc32@5.2.0':
-    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
-    engines: {node: '>=16.0.0'}
-
   '@aws-crypto/sha256-browser@5.2.0':
     resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
 
@@ -267,120 +278,88 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
-  '@aws-sdk/client-bedrock-runtime@3.1020.0':
-    resolution: {integrity: sha512-nqDCbaB05gRc3FuIEN74Mo04+k8RNI0YT2YBAU/9nioqgDyoqzMx8Ia2QWaw9UhUyIHMBjcFEfKIPfCZx7caCw==}
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.973.26':
-    resolution: {integrity: sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==}
+  '@aws-sdk/core@3.975.1':
+    resolution: {integrity: sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.24':
-    resolution: {integrity: sha512-FWg8uFmT6vQM7VuzELzwVo5bzExGaKHdubn0StjgrcU5FvuLExUe+k06kn/40uKv59rYzhez8eFNM4yYE/Yb/w==}
+  '@aws-sdk/credential-provider-env@3.972.57':
+    resolution: {integrity: sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.26':
-    resolution: {integrity: sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==}
+  '@aws-sdk/credential-provider-http@3.972.59':
+    resolution: {integrity: sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.972.27':
-    resolution: {integrity: sha512-Um26EsNSUfVUX0wUXnUA1W3wzKhVy6nviEElsh5lLZUYj9bk6DXOPnpte0gt+WHubcVfVsRk40bbm4KaroTEag==}
+  '@aws-sdk/credential-provider-ini@3.973.1':
+    resolution: {integrity: sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.27':
-    resolution: {integrity: sha512-t3ehEtHomGZwg5Gixw4fYbYtG9JBnjfAjSDabxhPEu/KLLUp0BB37/APX7MSKXQhX6ZH7pseuACFJ19NrAkNdg==}
+  '@aws-sdk/credential-provider-login@3.972.63':
+    resolution: {integrity: sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.972.28':
-    resolution: {integrity: sha512-rren+P6k5rShG5PX61iVi40kKdueyuMLBRTctQbyR5LooO9Ygr5L6R7ilG7RF1957NSH3KC3TU206fZuKwjSpQ==}
+  '@aws-sdk/credential-provider-node@3.972.66':
+    resolution: {integrity: sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.24':
-    resolution: {integrity: sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==}
+  '@aws-sdk/credential-provider-process@3.972.57':
+    resolution: {integrity: sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.27':
-    resolution: {integrity: sha512-CWXeGjlbBuHcm9appZUgXKP2zHDyTti0/+gXpSFJ2J3CnSwf1KWjicjN0qG2ozkMH6blrrzMrimeIOEYNl238Q==}
+  '@aws-sdk/credential-provider-sso@3.973.1':
+    resolution: {integrity: sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.972.27':
-    resolution: {integrity: sha512-CUY4hQIFswdQNEsRGEzGBUKGMK5KpqmNDdu2ROMgI+45PLFS8H0y3Tm7kvM16uvvw3n1pVxk85tnRVUTgtaa1w==}
+  '@aws-sdk/credential-provider-web-identity@3.972.63':
+    resolution: {integrity: sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/eventstream-handler-node@3.972.12':
-    resolution: {integrity: sha512-ruyc/MNR6e+cUrGCth7fLQ12RXBZDy/bV06tgqB9Z5n/0SN/C0m6bsQEV8FF9zPI6VSAOaRd0rNgmpYVnGawrQ==}
+  '@aws-sdk/eventstream-handler-node@3.972.26':
+    resolution: {integrity: sha512-RE1fu7Nn05vG0EUJM+8Sde2GFecC658WGaC/asPzLF6K4x3H5ZaDBcQtHRE67Gdgb1VZpyUUliYejHFK1qt0Uw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-eventstream@3.972.8':
-    resolution: {integrity: sha512-r+oP+tbCxgqXVC3pu3MUVePgSY0ILMjA+aEwOosS77m3/DRbtvHrHwqvMcw+cjANMeGzJ+i0ar+n77KXpRA8RQ==}
+  '@aws-sdk/middleware-eventstream@3.972.22':
+    resolution: {integrity: sha512-jtkgmhevnpzC1WeS+Y/sgymYbaQ6qg7pVOUl5cUT/8MiLptqrtnXQlNV80m+j2WIx5MIL7kVHIZNxxcK2tfUEQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-host-header@3.972.8':
-    resolution: {integrity: sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-logger@3.972.8':
-    resolution: {integrity: sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-recursion-detection@3.972.9':
-    resolution: {integrity: sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-user-agent@3.972.27':
-    resolution: {integrity: sha512-TIRLO5UR2+FVUGmhYoAwVkKhcVzywEDX/5LzR9tjy1h8FQAXOtFg2IqgmwvxU7y933rkTn9rl6AdgcAUgQ1/Kg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-websocket@3.972.14':
-    resolution: {integrity: sha512-qnfDlIHjm6DrTYNvWOUbnZdVKgtoKbO/Qzj+C0Wp5Y7VUrsvBRQtGKxD+hc+mRTS4N0kBJ6iZ3+zxm4N1OSyjg==}
+  '@aws-sdk/middleware-websocket@3.972.39':
+    resolution: {integrity: sha512-CS1spxRSezmTmI3PD+3Xrnp6KryTSEz0EefA8u6uGd0s2I0uXseWHALDI/03Wi0IUczXNWo2QrZEaHDuJNby/Q==}
     engines: {node: '>= 14.0.0'}
 
-  '@aws-sdk/nested-clients@3.996.17':
-    resolution: {integrity: sha512-7B0HIX0tEFmOSJuWzdHZj1WhMXSryM+h66h96ZkqSncoY7J6wq61KOu4Kr57b/YnJP3J/EeQYVFulgR281h+7A==}
+  '@aws-sdk/nested-clients@3.997.31':
+    resolution: {integrity: sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/region-config-resolver@3.972.10':
-    resolution: {integrity: sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==}
+  '@aws-sdk/signature-v4-multi-region@3.996.39':
+    resolution: {integrity: sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/token-providers@3.1020.0':
-    resolution: {integrity: sha512-T61KA/VKl0zVUubdxigr1ut7SEpwE1/4CIKb14JDLyTAOne2yWKtQE1dDCSHl0UqrZNwW/bTt+EBHfQbslZJdw==}
+  '@aws-sdk/token-providers@3.1048.0':
+    resolution: {integrity: sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/types@3.973.6':
-    resolution: {integrity: sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==}
+  '@aws-sdk/token-providers@3.1083.0':
+    resolution: {integrity: sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-endpoints@3.996.5':
-    resolution: {integrity: sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/util-format-url@3.972.8':
-    resolution: {integrity: sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A==}
+  '@aws-sdk/types@3.974.0':
+    resolution: {integrity: sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.5':
     resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-user-agent-browser@3.972.8':
-    resolution: {integrity: sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==}
-
-  '@aws-sdk/util-user-agent-node@3.973.13':
-    resolution: {integrity: sha512-s1dCJ0J9WU9UPkT3FFqhKTSquYTkqWXGRaapHFyWwwJH86ZussewhNST5R5TwXVL1VSHq4aJVl9fWK+svaRVCQ==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      aws-crt: '>=1.0.0'
-    peerDependenciesMeta:
-      aws-crt:
-        optional: true
-
-  '@aws-sdk/xml-builder@3.972.16':
-    resolution: {integrity: sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==}
+  '@aws-sdk/xml-builder@3.972.34':
+    resolution: {integrity: sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws/lambda-invoke-store@0.2.4':
-    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
     engines: {node: '>=18.0.0'}
 
   '@babel/runtime@7.29.2':
@@ -389,6 +368,24 @@ packages:
 
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
+
+  '@earendil-works/pi-agent-core@0.80.6':
+    resolution: {integrity: sha512-Lvn89ko42h5ETUb6Z0Ku6ldskEqXaTdQBYvSa0+7bdG9V6rUEpXptv5e0OVZ1HDcvi8s6/2lGCQWsxKX+DFHNw==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-ai@0.80.6':
+    resolution: {integrity: sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-coding-agent@0.80.6':
+    resolution: {integrity: sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-tui@0.80.6':
+    resolution: {integrity: sha512-bSuzS4EVSqEPj/Qr/p9eqCESfKsGuDNbl77EGci8Iaqqt/C/XCBZL1MjXaxSWW1NsT5afjp/Cb0NTPzOLv/aPA==}
+    engines: {node: '>=22.19.0'}
 
   '@esbuild/aix-ppc64@0.27.4':
     resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
@@ -584,6 +581,15 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@google/genai@1.52.0':
+    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@hono/node-server@1.19.12':
     resolution: {integrity: sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==}
     engines: {node: '>=18.14.1'}
@@ -622,6 +628,69 @@ packages:
     resolution: {integrity: sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==}
     engines: {node: '>=8'}
 
+  '@mariozechner/clipboard-darwin-arm64@0.3.9':
+    resolution: {integrity: sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-universal@0.3.9':
+    resolution: {integrity: sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==}
+    engines: {node: '>= 10'}
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-x64@0.3.9':
+    resolution: {integrity: sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
+    resolution: {integrity: sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
+    resolution: {integrity: sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
+    resolution: {integrity: sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
+    resolution: {integrity: sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
+    resolution: {integrity: sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
+    resolution: {integrity: sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
+    resolution: {integrity: sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@mariozechner/clipboard@0.3.9':
+    resolution: {integrity: sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==}
+    engines: {node: '>= 10'}
+
   '@mastra/core@1.22.0':
     resolution: {integrity: sha512-BNRS3a6teon85+Zzyg87eJFled0sILy5AXrN7Rb/ZWqBOvWSCjjCjzfkx61QZRi0lfbYOzBy2w0Bh79P7oGIzA==}
     engines: {node: '>=22.13.0'}
@@ -639,6 +708,14 @@ packages:
     engines: {node: '>=22.13.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  '@mistralai/mistralai@2.2.6':
+    resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -676,6 +753,10 @@ packages:
   '@opentelemetry/api-logs@0.57.2':
     resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
     engines: {node: '>=14'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
@@ -800,6 +881,9 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
+  '@silvia-odwyer/photon-node@0.3.4':
+    resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
+
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
@@ -812,193 +896,45 @@ packages:
     resolution: {integrity: sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==}
     engines: {node: '>=12'}
 
-  '@smithy/config-resolver@4.4.13':
-    resolution: {integrity: sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==}
+  '@smithy/core@3.29.2':
+    resolution: {integrity: sha512-DXUk6yU0C1Q1tYvJh1VCtl8QOBcSoZpKwjTPkxT6A4MUQYHvgeKGByL8mrEdxnvhdf9nq5GyzmRb5n/vPgu3Lw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/core@3.23.13':
-    resolution: {integrity: sha512-J+2TT9D6oGsUVXVEMvz8h2EmdVnkBiy2auCie4aSJMvKlzUtO5hqjEzXhoCUkIMo7gAYjbQcN0g/MMSXEhDs1Q==}
+  '@smithy/credential-provider-imds@4.4.7':
+    resolution: {integrity: sha512-UEMLOoA0Fl4uYBxh6l0uN0H6EJe/A89OGeDNTteQeXpJ20BcpfIr4wlCY9pel1jEAUHAxaYwuqrYlrKdXE1GKQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/credential-provider-imds@4.2.12':
-    resolution: {integrity: sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-codec@4.2.12':
-    resolution: {integrity: sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-browser@4.2.12':
-    resolution: {integrity: sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-config-resolver@4.3.12':
-    resolution: {integrity: sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-node@4.2.12':
-    resolution: {integrity: sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/eventstream-serde-universal@4.2.12':
-    resolution: {integrity: sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/fetch-http-handler@5.3.15':
-    resolution: {integrity: sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/hash-node@4.2.12':
-    resolution: {integrity: sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/invalid-dependency@4.2.12':
-    resolution: {integrity: sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==}
+  '@smithy/fetch-http-handler@5.6.4':
+    resolution: {integrity: sha512-psnst7NZWdAEvJvyW8YZEE7xNVMyLrQFfHtyrVFrxNyy+dKWkQ+rqC6oI5ZhxThpUy9RSfEshgm34zqbOxzsRw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/is-array-buffer@4.2.2':
-    resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
+  '@smithy/node-http-handler@4.7.3':
+    resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-content-length@4.2.12':
-    resolution: {integrity: sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==}
+  '@smithy/node-http-handler@4.9.4':
+    resolution: {integrity: sha512-BNTop/fSOptmoVk8g+efwHCofFh37g70OWGAFES1TeAAJja1K5aAI8rTE26ETSc5k8IQuWY2kAIoPla01NgYrA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-endpoint@4.4.28':
-    resolution: {integrity: sha512-p1gfYpi91CHcs5cBq982UlGlDrxoYUX6XdHSo91cQ2KFuz6QloHosO7Jc60pJiVmkWrKOV8kFYlGFFbQ2WUKKQ==}
+  '@smithy/signature-v4@5.6.3':
+    resolution: {integrity: sha512-8qVKKzqh7naF27ePmx0SkUfnGP/wBI9dyaeAmhHvopnbIlItUAmB/e6PkPCU3rRb2v9BY8D4EZXSoydSibatvw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-retry@4.4.46':
-    resolution: {integrity: sha512-SpvWNNOPOrKQGUqZbEPO+es+FRXMWvIyzUKUOYdDgdlA6BdZj/R58p4umoQ76c2oJC44PiM7mKizyyex1IJzow==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-serde@4.2.16':
-    resolution: {integrity: sha512-beqfV+RZ9RSv+sQqor3xroUUYgRFCGRw6niGstPG8zO9LgTl0B0MCucxjmrH/2WwksQN7UUgI7KNANoZv+KALA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-stack@4.2.12':
-    resolution: {integrity: sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/node-config-provider@4.3.12':
-    resolution: {integrity: sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/node-http-handler@4.5.1':
-    resolution: {integrity: sha512-ejjxdAXjkPIs9lyYyVutOGNOraqUE9v/NjGMKwwFrfOM354wfSD8lmlj8hVwUzQmlLLF4+udhfCX9Exnbmvfzw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/property-provider@4.2.12':
-    resolution: {integrity: sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/protocol-http@5.3.12':
-    resolution: {integrity: sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/querystring-builder@4.2.12':
-    resolution: {integrity: sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/querystring-parser@4.2.12':
-    resolution: {integrity: sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/service-error-classification@4.2.12':
-    resolution: {integrity: sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/shared-ini-file-loader@4.4.7':
-    resolution: {integrity: sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/signature-v4@5.3.12':
-    resolution: {integrity: sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/smithy-client@4.12.8':
-    resolution: {integrity: sha512-aJaAX7vHe5i66smoSSID7t4rKY08PbD8EBU7DOloixvhOozfYWdcSYE4l6/tjkZ0vBZhGjheWzB2mh31sLgCMA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/types@4.13.1':
-    resolution: {integrity: sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/url-parser@4.2.12':
-    resolution: {integrity: sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-base64@4.3.2':
-    resolution: {integrity: sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-body-length-browser@4.2.2':
-    resolution: {integrity: sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-body-length-node@4.2.3':
-    resolution: {integrity: sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==}
+  '@smithy/types@4.16.0':
+    resolution: {integrity: sha512-aVUabzlBBmY0PfvVgLKQSOGFIL5/7R54JE3uD9a5Ay/jSED61SkuAcCYENNXJzYUvJ1NPrWO0P+rAXHCkbBUKw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-buffer-from@2.2.0':
     resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/util-buffer-from@4.2.2':
-    resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-config-provider@4.2.2':
-    resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-defaults-mode-browser@4.3.44':
-    resolution: {integrity: sha512-eZg6XzaCbVr2S5cAErU5eGBDaOVTuTo1I65i4tQcHENRcZ8rMWhQy1DaIYUSLyZjsfXvmCqZrstSMYyGFocvHA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-defaults-mode-node@4.2.48':
-    resolution: {integrity: sha512-FqOKTlqSaoV3nzO55pMs5NBnZX8EhoI0DGmn9kbYeXWppgHD6dchyuj2HLqp4INJDJbSrj6OFYJkAh/WhSzZPg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-endpoints@3.3.3':
-    resolution: {integrity: sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-hex-encoding@4.2.2':
-    resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-middleware@4.2.12':
-    resolution: {integrity: sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-retry@4.2.13':
-    resolution: {integrity: sha512-qQQsIvL0MGIbUjeSrg0/VlQ3jGNKyM3/2iU3FPNgy01z+Sp4OvcaxbgIoFOTvB61ZoohtutuOvOcgmhbD0katQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-stream@4.5.21':
-    resolution: {integrity: sha512-KzSg+7KKywLnkoKejRtIBXDmwBfjGvg1U1i/etkC7XSWUyFCoLno1IohV2c74IzQqdhX5y3uE44r/8/wuK+A7Q==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-uri-escape@4.2.2':
-    resolution: {integrity: sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/util-utf8@2.3.0':
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
-
-  '@smithy/util-utf8@4.2.2':
-    resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/uuid@1.1.2':
-    resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
-    engines: {node: '>=18.0.0'}
 
   '@standard-community/standard-json@0.3.5':
     resolution: {integrity: sha512-4+ZPorwDRt47i+O7RjyuaxHRK/37QY/LmgxlGrRrSTLYoFatEOzvqIc85GTlM18SFZ5E91C+v0o/M37wZPpUHA==}
@@ -1109,6 +1045,9 @@ packages:
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/send@0.17.6':
     resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
 
@@ -1213,6 +1152,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -1272,6 +1215,9 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   body-parser@1.20.4:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -1289,6 +1235,9 @@ packages:
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1389,6 +1338,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -1431,6 +1384,10 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
   dotenv@17.4.1:
     resolution: {integrity: sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==}
     engines: {node: '>=12'}
@@ -1438,6 +1395,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -1587,13 +1547,6 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fast-xml-builder@1.1.4:
-    resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
-
-  fast-xml-parser@5.5.8:
-    resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
-    hasBin: true
-
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1602,6 +1555,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -1630,6 +1587,10 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -1650,8 +1611,20 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gaxios@7.2.0:
+    resolution: {integrity: sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+
   get-east-asian-width@1.5.0:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
@@ -1673,13 +1646,28 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
+  google-auth-library@10.9.0:
+    resolution: {integrity: sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
@@ -1696,6 +1684,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
   hono-openapi@1.3.0:
     resolution: {integrity: sha512-xDvCWpWEIv0weEmnl3EjRQzqbHIO8LnfzMuYOCmbuyE5aes6aXxLg4vM3ybnoZD5TiTUkA6PuRQPJs3R7WRBig==}
@@ -1716,9 +1707,21 @@ packages:
     resolution: {integrity: sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==}
     engines: {node: '>=16.9.0'}
 
+  hosted-git-info@9.0.3:
+    resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
@@ -1809,6 +1812,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
@@ -1822,6 +1829,9 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -1848,6 +1858,12 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -1912,6 +1928,11 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@18.0.5:
+    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2085,6 +2106,10 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
@@ -2114,6 +2139,15 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
@@ -2136,6 +2170,18 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
+
+  openai@6.26.0:
+    resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   openai@6.33.0:
     resolution: {integrity: sha512-xAYN1W3YsDXJWA5F277135YfkEk6H7D3D6vWwRhJ3OEkzRgcyK8z/P5P9Gyi/wB4N8kK9kM5ZjprfvyHagKmpw==}
@@ -2176,6 +2222,10 @@ packages:
     resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
     engines: {node: '>=8'}
 
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
   p-retry@7.1.1:
     resolution: {integrity: sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==}
     engines: {node: '>=20'}
@@ -2196,13 +2246,12 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  partial-json@0.1.7:
+    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
-
-  path-expression-matcher@1.2.0:
-    resolution: {integrity: sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==}
-    engines: {node: '>=14.0.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -2214,6 +2263,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
@@ -2241,6 +2294,9 @@ packages:
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
+
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
   protobufjs@7.5.4:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
@@ -2317,6 +2373,14 @@ packages:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
@@ -2339,6 +2403,11 @@ packages:
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2387,6 +2456,9 @@ packages:
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -2437,9 +2509,6 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
-
-  strnum@2.2.2:
-    resolution: {integrity: sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -2496,6 +2565,9 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
+  typebox@1.1.38:
+    resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
+
   typescript-eslint@8.58.0:
     resolution: {integrity: sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2510,6 +2582,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+    engines: {node: '>=22.19.0'}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -2559,6 +2635,10 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -2592,6 +2672,11 @@ packages:
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -2686,6 +2771,12 @@ snapshots:
     optionalDependencies:
       zod: 4.3.6
 
+  '@anthropic-ai/sdk@0.91.1(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
+
   '@arizeai/openinference-core@2.0.5':
     dependencies:
       '@arizeai/openinference-semantic-conventions': 2.1.7
@@ -2714,11 +2805,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@arizeai/openinference-instrumentation-bedrock@0.4.8(@aws-sdk/client-bedrock-runtime@3.1020.0)':
+  '@arizeai/openinference-instrumentation-bedrock@0.4.8(@aws-sdk/client-bedrock-runtime@3.1048.0)':
     dependencies:
       '@arizeai/openinference-core': 2.0.5
       '@arizeai/openinference-semantic-conventions': 2.1.7
-      '@aws-sdk/client-bedrock-runtime': 3.1020.0
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation': 0.46.0(@opentelemetry/api@1.9.1)
@@ -2771,18 +2862,12 @@ snapshots:
     transitivePeerDependencies:
       - '@opentelemetry/semantic-conventions'
 
-  '@aws-crypto/crc32@5.2.0':
-    dependencies:
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
-      tslib: 2.8.1
-
   '@aws-crypto/sha256-browser@5.2.0':
     dependencies:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.974.0
       '@aws-sdk/util-locate-window': 3.965.5
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -2790,7 +2875,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.974.0
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -2799,357 +2884,271 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.974.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
-  '@aws-sdk/client-bedrock-runtime@3.1020.0':
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/credential-provider-node': 3.972.28
-      '@aws-sdk/eventstream-handler-node': 3.972.12
-      '@aws-sdk/middleware-eventstream': 3.972.8
-      '@aws-sdk/middleware-host-header': 3.972.8
-      '@aws-sdk/middleware-logger': 3.972.8
-      '@aws-sdk/middleware-recursion-detection': 3.972.9
-      '@aws-sdk/middleware-user-agent': 3.972.27
-      '@aws-sdk/middleware-websocket': 3.972.14
-      '@aws-sdk/region-config-resolver': 3.972.10
-      '@aws-sdk/token-providers': 3.1020.0
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-endpoints': 3.996.5
-      '@aws-sdk/util-user-agent-browser': 3.972.8
-      '@aws-sdk/util-user-agent-node': 3.973.13
-      '@smithy/config-resolver': 4.4.13
-      '@smithy/core': 3.23.13
-      '@smithy/eventstream-serde-browser': 4.2.12
-      '@smithy/eventstream-serde-config-resolver': 4.3.12
-      '@smithy/eventstream-serde-node': 4.2.12
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/hash-node': 4.2.12
-      '@smithy/invalid-dependency': 4.2.12
-      '@smithy/middleware-content-length': 4.2.12
-      '@smithy/middleware-endpoint': 4.4.28
-      '@smithy/middleware-retry': 4.4.46
-      '@smithy/middleware-serde': 4.2.16
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/node-http-handler': 4.5.1
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.8
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.44
-      '@smithy/util-defaults-mode-node': 4.2.48
-      '@smithy/util-endpoints': 3.3.3
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.13
-      '@smithy/util-stream': 4.5.21
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/core@3.973.26':
-    dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/xml-builder': 3.972.16
-      '@smithy/core': 3.23.13
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/signature-v4': 5.3.12
-      '@smithy/smithy-client': 4.12.8
-      '@smithy/types': 4.13.1
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-utf8': 4.2.2
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.66
+      '@aws-sdk/eventstream-handler-node': 3.972.26
+      '@aws-sdk/middleware-eventstream': 3.972.22
+      '@aws-sdk/middleware-websocket': 3.972.39
+      '@aws-sdk/token-providers': 3.1048.0
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/fetch-http-handler': 5.6.4
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.16.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-env@3.972.24':
+  '@aws-sdk/core@3.975.1':
     dependencies:
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/types': 4.13.1
+      '@aws-sdk/types': 3.974.0
+      '@aws-sdk/xml-builder': 3.972.34
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.29.2
+      '@smithy/signature-v4': 5.6.3
+      '@smithy/types': 4.16.0
+      bowser: 2.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-http@3.972.26':
+  '@aws-sdk/credential-provider-env@3.972.57':
     dependencies:
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/types': 3.973.6
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/node-http-handler': 4.5.1
-      '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.8
-      '@smithy/types': 4.13.1
-      '@smithy/util-stream': 4.5.21
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-ini@3.972.27':
+  '@aws-sdk/credential-provider-http@3.972.59':
     dependencies:
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/credential-provider-env': 3.972.24
-      '@aws-sdk/credential-provider-http': 3.972.26
-      '@aws-sdk/credential-provider-login': 3.972.27
-      '@aws-sdk/credential-provider-process': 3.972.24
-      '@aws-sdk/credential-provider-sso': 3.972.27
-      '@aws-sdk/credential-provider-web-identity': 3.972.27
-      '@aws-sdk/nested-clients': 3.996.17
-      '@aws-sdk/types': 3.973.6
-      '@smithy/credential-provider-imds': 4.2.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-login@3.972.27':
-    dependencies:
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/nested-clients': 3.996.17
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-node@3.972.28':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.24
-      '@aws-sdk/credential-provider-http': 3.972.26
-      '@aws-sdk/credential-provider-ini': 3.972.27
-      '@aws-sdk/credential-provider-process': 3.972.24
-      '@aws-sdk/credential-provider-sso': 3.972.27
-      '@aws-sdk/credential-provider-web-identity': 3.972.27
-      '@aws-sdk/types': 3.973.6
-      '@smithy/credential-provider-imds': 4.2.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-process@3.972.24':
-    dependencies:
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/fetch-http-handler': 5.6.4
+      '@smithy/node-http-handler': 4.9.4
+      '@smithy/types': 4.16.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-sso@3.972.27':
+  '@aws-sdk/credential-provider-ini@3.973.1':
     dependencies:
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/nested-clients': 3.996.17
-      '@aws-sdk/token-providers': 3.1020.0
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-provider-web-identity@3.972.27':
-    dependencies:
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/nested-clients': 3.996.17
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/eventstream-handler-node@3.972.12':
-    dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/eventstream-codec': 4.2.12
-      '@smithy/types': 4.13.1
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-env': 3.972.57
+      '@aws-sdk/credential-provider-http': 3.972.59
+      '@aws-sdk/credential-provider-login': 3.972.63
+      '@aws-sdk/credential-provider-process': 3.972.57
+      '@aws-sdk/credential-provider-sso': 3.973.1
+      '@aws-sdk/credential-provider-web-identity': 3.972.63
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/credential-provider-imds': 4.4.7
+      '@smithy/types': 4.16.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-eventstream@3.972.8':
+  '@aws-sdk/credential-provider-login@3.972.63':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-host-header@3.972.8':
+  '@aws-sdk/credential-provider-node@3.972.66':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@aws-sdk/credential-provider-env': 3.972.57
+      '@aws-sdk/credential-provider-http': 3.972.59
+      '@aws-sdk/credential-provider-ini': 3.973.1
+      '@aws-sdk/credential-provider-process': 3.972.57
+      '@aws-sdk/credential-provider-sso': 3.973.1
+      '@aws-sdk/credential-provider-web-identity': 3.972.63
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/credential-provider-imds': 4.4.7
+      '@smithy/types': 4.16.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-logger@3.972.8':
+  '@aws-sdk/credential-provider-process@3.972.57':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-recursion-detection@3.972.9':
+  '@aws-sdk/credential-provider-sso@3.973.1':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/token-providers': 3.1083.0
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-user-agent@3.972.27':
+  '@aws-sdk/credential-provider-web-identity@3.972.63':
     dependencies:
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-endpoints': 3.996.5
-      '@smithy/core': 3.23.13
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-retry': 4.2.13
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-websocket@3.972.14':
+  '@aws-sdk/eventstream-handler-node@3.972.26':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-format-url': 3.972.8
-      '@smithy/eventstream-codec': 4.2.12
-      '@smithy/eventstream-serde-browser': 4.2.12
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/signature-v4': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-utf8': 4.2.2
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
       tslib: 2.8.1
 
-  '@aws-sdk/nested-clients@3.996.17':
+  '@aws-sdk/middleware-eventstream@3.972.22':
     dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/middleware-host-header': 3.972.8
-      '@aws-sdk/middleware-logger': 3.972.8
-      '@aws-sdk/middleware-recursion-detection': 3.972.9
-      '@aws-sdk/middleware-user-agent': 3.972.27
-      '@aws-sdk/region-config-resolver': 3.972.10
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-endpoints': 3.996.5
-      '@aws-sdk/util-user-agent-browser': 3.972.8
-      '@aws-sdk/util-user-agent-node': 3.973.13
-      '@smithy/config-resolver': 4.4.13
-      '@smithy/core': 3.23.13
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/hash-node': 4.2.12
-      '@smithy/invalid-dependency': 4.2.12
-      '@smithy/middleware-content-length': 4.2.12
-      '@smithy/middleware-endpoint': 4.4.28
-      '@smithy/middleware-retry': 4.4.46
-      '@smithy/middleware-serde': 4.2.16
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/node-http-handler': 4.5.1
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.8
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.44
-      '@smithy/util-defaults-mode-node': 4.2.48
-      '@smithy/util-endpoints': 3.3.3
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.13
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/region-config-resolver@3.972.10':
-    dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/config-resolver': 4.4.13
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
       tslib: 2.8.1
 
-  '@aws-sdk/token-providers@3.1020.0':
+  '@aws-sdk/middleware-websocket@3.972.39':
     dependencies:
-      '@aws-sdk/core': 3.973.26
-      '@aws-sdk/nested-clients': 3.996.17
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/types@3.973.6':
-    dependencies:
-      '@smithy/types': 4.13.1
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/fetch-http-handler': 5.6.4
+      '@smithy/signature-v4': 5.6.3
+      '@smithy/types': 4.16.0
       tslib: 2.8.1
 
-  '@aws-sdk/util-endpoints@3.996.5':
+  '@aws-sdk/nested-clients@3.997.31':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-endpoints': 3.3.3
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/signature-v4-multi-region': 3.996.39
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/fetch-http-handler': 5.6.4
+      '@smithy/node-http-handler': 4.9.4
+      '@smithy/types': 4.16.0
       tslib: 2.8.1
 
-  '@aws-sdk/util-format-url@3.972.8':
+  '@aws-sdk/signature-v4-multi-region@3.996.39':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/querystring-builder': 4.2.12
-      '@smithy/types': 4.13.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/signature-v4': 5.6.3
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1048.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1083.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.0':
+    dependencies:
+      '@smithy/types': 4.16.0
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.5':
     dependencies:
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-browser@3.972.8':
+  '@aws-sdk/xml-builder@3.972.34':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/types': 4.13.1
-      bowser: 2.14.1
+      '@smithy/types': 4.16.0
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-node@3.973.13':
-    dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.27
-      '@aws-sdk/types': 3.973.6
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-config-provider': 4.2.2
-      tslib: 2.8.1
-
-  '@aws-sdk/xml-builder@3.972.16':
-    dependencies:
-      '@smithy/types': 4.13.1
-      fast-xml-parser: 5.5.8
-      tslib: 2.8.1
-
-  '@aws/lambda-invoke-store@0.2.4': {}
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@babel/runtime@7.29.2': {}
 
   '@cfworker/json-schema@4.1.1': {}
+
+  '@earendil-works/pi-agent-core@0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      ignore: 7.0.5
+      typebox: 1.1.38
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.3.6)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.26.0(ws@8.20.0)(zod@4.3.6)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-coding-agent@0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@earendil-works/pi-ai': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@earendil-works/pi-tui': 0.80.6
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      semver: 7.8.0
+      typebox: 1.1.38
+      undici: 8.5.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-tui@0.80.6':
+    dependencies:
+      get-east-asian-width: 1.6.0
+      marked: 18.0.5
 
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
@@ -3229,9 +3228,9 @@ snapshots:
   '@esbuild/win32-x64@0.27.4':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
     dependencies:
-      eslint: 9.39.4
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -3274,6 +3273,19 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))':
+    dependencies:
+      google-auth-library: 10.9.0
+      p-retry: 4.6.2
+      protobufjs: 7.5.4
+      ws: 8.20.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   '@hono/node-server@1.19.12(hono@4.12.10)':
     dependencies:
@@ -3318,7 +3330,51 @@ snapshots:
     dependencies:
       '@lukeed/csprng': 1.1.0
 
-  '@mastra/core@1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6)':
+  '@mariozechner/clipboard-darwin-arm64@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-universal@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-x64@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard@0.3.9':
+    optionalDependencies:
+      '@mariozechner/clipboard-darwin-arm64': 0.3.9
+      '@mariozechner/clipboard-darwin-universal': 0.3.9
+      '@mariozechner/clipboard-darwin-x64': 0.3.9
+      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-arm64-musl': 0.3.9
+      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-x64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-x64-musl': 0.3.9
+      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.9
+      '@mariozechner/clipboard-win32-x64-msvc': 0.3.9
+    optional: true
+
+  '@mastra/core@1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(typebox@1.1.38)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(typebox@1.1.38)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.1.38)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6)':
     dependencies:
       '@a2a-js/sdk': 0.2.5
       '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@3.0.20(zod@4.3.6)'
@@ -3338,7 +3394,7 @@ snapshots:
       execa: 9.6.1
       gray-matter: 4.0.3
       hono: 4.12.10
-      hono-openapi: 1.3.0(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(hono@4.12.10)(openapi-types@12.1.3)
+      hono-openapi: 1.3.0(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(typebox@1.1.38)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(typebox@1.1.38)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.1.38)(zod@4.3.6))(@types/json-schema@7.0.15)(hono@4.12.10)(openapi-types@12.1.3)
       ignore: 7.0.5
       js-tiktoken: 1.0.21
       json-schema: 0.4.0
@@ -3362,9 +3418,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@mastra/observability@1.7.2(@mastra/core@1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6))':
+  '@mastra/observability@1.7.2(@mastra/core@1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(typebox@1.1.38)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(typebox@1.1.38)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.1.38)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6))':
     dependencies:
-      '@mastra/core': 1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6)
+      '@mastra/core': 1.22.0(@cfworker/json-schema@4.1.1)(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(typebox@1.1.38)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(typebox@1.1.38)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.1.38)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6)
 
   '@mastra/schema-compat@1.2.7(zod@4.3.6)':
     dependencies:
@@ -3373,6 +3429,18 @@ snapshots:
       zod-from-json-schema: 0.5.2
       zod-from-json-schema-v3: zod-from-json-schema@0.0.5
       zod-to-json-schema: 3.25.2(zod@4.3.6)
+
+  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/semantic-conventions': 1.40.0
+      ws: 8.20.0
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
@@ -3452,6 +3520,8 @@ snapshots:
   '@opentelemetry/api-logs@0.57.2':
     dependencies:
       '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.0': {}
 
   '@opentelemetry/api@1.9.1': {}
 
@@ -3576,6 +3646,8 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
+  '@silvia-odwyer/photon-node@0.3.4': {}
+
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@sindresorhus/slugify@2.2.1':
@@ -3587,221 +3659,46 @@ snapshots:
     dependencies:
       escape-string-regexp: 5.0.0
 
-  '@smithy/config-resolver@4.4.13':
+  '@smithy/core@3.29.2':
     dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-config-provider': 4.2.2
-      '@smithy/util-endpoints': 3.3.3
-      '@smithy/util-middleware': 4.2.12
+      '@smithy/types': 4.16.0
       tslib: 2.8.1
 
-  '@smithy/core@3.23.13':
+  '@smithy/credential-provider-imds@4.4.7':
     dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-stream': 4.5.21
-      '@smithy/util-utf8': 4.2.2
-      '@smithy/uuid': 1.1.2
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
       tslib: 2.8.1
 
-  '@smithy/credential-provider-imds@4.2.12':
+  '@smithy/fetch-http-handler@5.6.4':
     dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      tslib: 2.8.1
-
-  '@smithy/eventstream-codec@4.2.12':
-    dependencies:
-      '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.13.1
-      '@smithy/util-hex-encoding': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-browser@4.2.12':
-    dependencies:
-      '@smithy/eventstream-serde-universal': 4.2.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-config-resolver@4.3.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-node@4.2.12':
-    dependencies:
-      '@smithy/eventstream-serde-universal': 4.2.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/eventstream-serde-universal@4.2.12':
-    dependencies:
-      '@smithy/eventstream-codec': 4.2.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/fetch-http-handler@5.3.15':
-    dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/querystring-builder': 4.2.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-base64': 4.3.2
-      tslib: 2.8.1
-
-  '@smithy/hash-node@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      '@smithy/util-buffer-from': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/invalid-dependency@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
       tslib: 2.8.1
 
   '@smithy/is-array-buffer@2.2.0':
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/is-array-buffer@4.2.2':
+  '@smithy/node-http-handler@4.7.3':
     dependencies:
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
       tslib: 2.8.1
 
-  '@smithy/middleware-content-length@4.2.12':
+  '@smithy/node-http-handler@4.9.4':
     dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
       tslib: 2.8.1
 
-  '@smithy/middleware-endpoint@4.4.28':
+  '@smithy/signature-v4@5.6.3':
     dependencies:
-      '@smithy/core': 3.23.13
-      '@smithy/middleware-serde': 4.2.16
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-middleware': 4.2.12
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.16.0
       tslib: 2.8.1
 
-  '@smithy/middleware-retry@4.4.46':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/service-error-classification': 4.2.12
-      '@smithy/smithy-client': 4.12.8
-      '@smithy/types': 4.13.1
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.13
-      '@smithy/uuid': 1.1.2
-      tslib: 2.8.1
-
-  '@smithy/middleware-serde@4.2.16':
-    dependencies:
-      '@smithy/core': 3.23.13
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/middleware-stack@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/node-config-provider@4.3.12':
-    dependencies:
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/node-http-handler@4.5.1':
-    dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/querystring-builder': 4.2.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/property-provider@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/protocol-http@5.3.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/querystring-builder@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      '@smithy/util-uri-escape': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/querystring-parser@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/service-error-classification@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-
-  '@smithy/shared-ini-file-loader@4.4.7':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/signature-v4@5.3.12':
-    dependencies:
-      '@smithy/is-array-buffer': 4.2.2
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-uri-escape': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/smithy-client@4.12.8':
-    dependencies:
-      '@smithy/core': 3.23.13
-      '@smithy/middleware-endpoint': 4.4.28
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-stream': 4.5.21
-      tslib: 2.8.1
-
-  '@smithy/types@4.13.1':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/url-parser@4.2.12':
-    dependencies:
-      '@smithy/querystring-parser': 4.2.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/util-base64@4.3.2':
-    dependencies:
-      '@smithy/util-buffer-from': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/util-body-length-browser@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-body-length-node@4.2.3':
+  '@smithy/types@4.16.0':
     dependencies:
       tslib: 2.8.1
 
@@ -3810,97 +3707,28 @@ snapshots:
       '@smithy/is-array-buffer': 2.2.0
       tslib: 2.8.1
 
-  '@smithy/util-buffer-from@4.2.2':
-    dependencies:
-      '@smithy/is-array-buffer': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/util-config-provider@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-defaults-mode-browser@4.3.44':
-    dependencies:
-      '@smithy/property-provider': 4.2.12
-      '@smithy/smithy-client': 4.12.8
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/util-defaults-mode-node@4.2.48':
-    dependencies:
-      '@smithy/config-resolver': 4.4.13
-      '@smithy/credential-provider-imds': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/smithy-client': 4.12.8
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/util-endpoints@3.3.3':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/util-hex-encoding@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-middleware@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/util-retry@4.2.13':
-    dependencies:
-      '@smithy/service-error-classification': 4.2.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/util-stream@4.5.21':
-    dependencies:
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/node-http-handler': 4.5.1
-      '@smithy/types': 4.13.1
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-buffer-from': 4.2.2
-      '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/util-uri-escape@4.2.2':
-    dependencies:
-      tslib: 2.8.1
-
   '@smithy/util-utf8@2.3.0':
     dependencies:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
 
-  '@smithy/util-utf8@4.2.2':
-    dependencies:
-      '@smithy/util-buffer-from': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/uuid@1.1.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)':
+  '@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(typebox@1.1.38)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/json-schema': 7.0.15
       quansync: 0.2.11
     optionalDependencies:
+      typebox: 1.1.38
       zod: 4.3.6
       zod-to-json-schema: 3.25.2(zod@4.3.6)
 
-  '@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6)':
+  '@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(typebox@1.1.38)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.1.38)(zod@4.3.6)':
     dependencies:
-      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)
+      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(typebox@1.1.38)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)
       '@standard-schema/spec': 1.1.0
       openapi-types: 12.1.3
     optionalDependencies:
+      typebox: 1.1.38
       zod: 4.3.6
 
   '@standard-schema/spec@1.1.0': {}
@@ -3958,6 +3786,8 @@ snapshots:
 
   '@types/range-parser@1.2.7': {}
 
+  '@types/retry@0.12.0': {}
+
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
@@ -3981,15 +3811,15 @@ snapshots:
     dependencies:
       '@types/node': 20.19.37
 
-  '@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.58.0(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.58.0
-      '@typescript-eslint/type-utils': 8.58.0(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.58.0(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.58.0
-      eslint: 9.39.4
+      eslint: 9.39.4(jiti@2.7.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -3997,14 +3827,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.58.0(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.58.0
       '@typescript-eslint/types': 8.58.0
       '@typescript-eslint/typescript-estree': 8.58.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.58.0
       debug: 4.4.3
-      eslint: 9.39.4
+      eslint: 9.39.4(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -4027,13 +3857,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.58.0(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.58.0
       '@typescript-eslint/typescript-estree': 8.58.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.58.0(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 9.39.4
+      eslint: 9.39.4(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -4056,13 +3886,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.58.0(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.58.0
       '@typescript-eslint/types': 8.58.0
       '@typescript-eslint/typescript-estree': 8.58.0(typescript@5.9.3)
-      eslint: 9.39.4
+      eslint: 9.39.4(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -4093,6 +3923,8 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  agent-base@7.1.4: {}
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
@@ -4144,6 +3976,8 @@ snapshots:
 
   base64-js@1.5.1: {}
 
+  bignumber.js@9.3.1: {}
+
   body-parser@1.20.4:
     dependencies:
       bytes: 3.1.2
@@ -4185,6 +4019,8 @@ snapshots:
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
+
+  buffer-equal-constant-time@1.0.1: {}
 
   bytes@3.1.2: {}
 
@@ -4277,6 +4113,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  data-uri-to-buffer@4.0.1: {}
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -4303,6 +4141,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  diff@8.0.4: {}
+
   dotenv@17.4.1: {}
 
   dunder-proto@1.0.1:
@@ -4310,6 +4150,10 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -4373,9 +4217,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@9.39.4:
+  eslint@9.39.4(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.2
       '@eslint/config-helpers': 0.4.2
@@ -4409,6 +4253,8 @@ snapshots:
       minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.7.0
     transitivePeerDependencies:
       - supports-color
 
@@ -4547,19 +4393,14 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fast-xml-builder@1.1.4:
-    dependencies:
-      path-expression-matcher: 1.2.0
-
-  fast-xml-parser@5.5.8:
-    dependencies:
-      fast-xml-builder: 1.1.4
-      path-expression-matcher: 1.2.0
-      strnum: 2.2.2
-
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   figures@6.1.0:
     dependencies:
@@ -4604,6 +4445,10 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
@@ -4615,7 +4460,25 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  gaxios@7.2.0:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.2.0
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   get-east-asian-width@1.5.0: {}
+
+  get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -4648,9 +4511,30 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   globals@14.0.0: {}
 
+  google-auth-library@10.9.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.2.0
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
   gopd@1.2.0: {}
+
+  graceful-fs@4.2.11: {}
 
   gray-matter@4.0.3:
     dependencies:
@@ -4667,16 +4551,22 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono-openapi@1.3.0(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(hono@4.12.10)(openapi-types@12.1.3):
+  highlight.js@10.7.3: {}
+
+  hono-openapi@1.3.0(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(typebox@1.1.38)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(typebox@1.1.38)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.1.38)(zod@4.3.6))(@types/json-schema@7.0.15)(hono@4.12.10)(openapi-types@12.1.3):
     dependencies:
-      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)
-      '@standard-community/standard-openapi': 0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6)
+      '@standard-community/standard-json': 0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(typebox@1.1.38)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)
+      '@standard-community/standard-openapi': 0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(typebox@1.1.38)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(typebox@1.1.38)(zod@4.3.6)
       '@types/json-schema': 7.0.15
       openapi-types: 12.1.3
     optionalDependencies:
       hono: 4.12.10
 
   hono@4.12.10: {}
+
+  hosted-git-info@9.0.3:
+    dependencies:
+      lru-cache: 11.2.7
 
   http-errors@2.0.1:
     dependencies:
@@ -4685,6 +4575,20 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   human-signals@8.0.1: {}
 
@@ -4750,6 +4654,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  jiti@2.7.0: {}
+
   jose@6.2.2: {}
 
   js-tiktoken@1.0.21:
@@ -4764,6 +4670,10 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
 
   json-buffer@3.0.1: {}
 
@@ -4783,6 +4693,17 @@ snapshots:
   json-schema@0.4.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -4848,6 +4769,8 @@ snapshots:
   lru-cache@11.2.7: {}
 
   markdown-table@3.0.4: {}
+
+  marked@18.0.5: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -5178,6 +5101,8 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.13
 
+  minipass@7.1.3: {}
+
   module-details-from-path@1.0.4: {}
 
   ms@2.0.0: {}
@@ -5193,6 +5118,14 @@ snapshots:
   negotiator@0.6.3: {}
 
   negotiator@1.0.0: {}
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   npm-run-path@6.0.0:
     dependencies:
@@ -5214,6 +5147,11 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  openai@6.26.0(ws@8.20.0)(zod@4.3.6):
+    optionalDependencies:
+      ws: 8.20.0
+      zod: 4.3.6
 
   openai@6.33.0(ws@8.20.0)(zod@4.3.6):
     optionalDependencies:
@@ -5248,6 +5186,11 @@ snapshots:
       eventemitter3: 4.0.7
       p-timeout: 3.2.0
 
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
   p-retry@7.1.1:
     dependencies:
       is-network-error: 1.3.1
@@ -5264,15 +5207,20 @@ snapshots:
 
   parseurl@1.3.3: {}
 
-  path-exists@4.0.0: {}
+  partial-json@0.1.7: {}
 
-  path-expression-matcher@1.2.0: {}
+  path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.2.7
+      minipass: 7.1.3
 
   path-to-regexp@0.1.13: {}
 
@@ -5289,6 +5237,12 @@ snapshots:
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
+
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
 
   protobufjs@7.5.4:
     dependencies:
@@ -5393,6 +5347,10 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
+  retry@0.12.0: {}
+
+  retry@0.13.1: {}
+
   rfdc@1.4.1: {}
 
   router@2.2.0:
@@ -5417,6 +5375,8 @@ snapshots:
   secure-json-parse@2.7.0: {}
 
   semver@7.7.4: {}
+
+  semver@7.8.0: {}
 
   send@0.19.2:
     dependencies:
@@ -5508,6 +5468,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  signal-exit@3.0.7: {}
+
   signal-exit@4.1.0: {}
 
   simple-wcswidth@1.1.2: {}
@@ -5548,8 +5510,6 @@ snapshots:
   strip-final-newline@4.0.0: {}
 
   strip-json-comments@3.1.1: {}
-
-  strnum@2.2.2: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -5600,13 +5560,15 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript-eslint@8.58.0(eslint@9.39.4)(typescript@5.9.3):
+  typebox@1.1.38: {}
+
+  typescript-eslint@8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.58.0(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.58.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.58.0(eslint@9.39.4)(typescript@5.9.3)
-      eslint: 9.39.4
+      '@typescript-eslint/utils': 8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -5614,6 +5576,8 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  undici@8.5.0: {}
 
   unicorn-magic@0.3.0: {}
 
@@ -5670,6 +5634,8 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  web-streams-polyfill@3.3.3: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -5689,6 +5655,8 @@ snapshots:
   xxhash-wasm@1.1.0: {}
 
   yaml@2.8.3: {}
+
+  yaml@2.9.0: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary

- add TraceRoot-owned instrumentation for `@earendil-works/pi-coding-agent`, emitting AGENT → LLM → TOOL spans for apps that embed the pi SDK directly
- anchor the AGENT root span on each `AgentSession.prompt()` call, so a full turn — auto-retries, compaction, mid-stream `steer()`/`followUp()` — stays in one trace and re-parents under any active host span
- dual-write model/token usage as both OpenTelemetry `gen_ai.*` and OpenInference `llm.*`, matching `claude-agent-sdk` so pi spans render identically
- ship in-tree as a single `src/pi.ts` (sibling to `claude-agent-sdk.ts`), wired through `instrumentModules.piCodingAgent` — no standalone package, no private exporter pipeline
- add 63 regression cases across two `pi-*` test files (span lifecycle, event ordering, retry/dispose/sweep, capture flags, truncation)

This PR is pi-only src.

## Usage

```ts
import { TraceRoot } from '@traceroot-ai/traceroot';
import * as pi from '@earendil-works/pi-coding-agent';

// Bare module ref — capture defaults on:
TraceRoot.initialize({ instrumentModules: { piCodingAgent: pi } });

// Or opt out of content capture:
TraceRoot.initialize({
  instrumentModules: {
    piCodingAgent: { module: pi, config: { captureContent: false, captureToolIo: false } },
  },
});
```

Instrumentation patches `AgentSession.prototype`, so any session the host constructs is traced automatically — no per-session wiring. There is no `apiKey`/`baseUrl` here: pi traces through the provider `TraceRoot.initialize()` already registered.

## What gets traced

A `prompt()` call produces one trace, AGENT → LLM → TOOL (tools nest under the LLM turn that requested them):

| Span | `openinference.span.kind` | Key attributes |
|---|---|---|
| `AgentSession.prompt` | `AGENT` (root) | `session.id`, `input.value`/`output.value` (when `captureContent`), `traceroot.pi.retry_count` |
| `<model>` | `LLM` | `gen_ai.request.model` + `llm.model_name`, `gen_ai.usage.input_tokens`/`output_tokens` + `llm.token_count.prompt`/`completion`/`total` (incl. cache read/write), `output.value` |
| `<tool>` | `TOOL` | `gen_ai.tool.name`, `gen_ai.tool.call.id`, `input.value`/`output.value` (when `captureToolIo`) |

- **One trace per turn.** Root opens on `prompt()`, closes when its promise settles; retries/compaction/follow-ups stay under it. `traceroot.pi.retry_count` records auto-retries.
- **Error scoping.** A failed tool marks only its TOOL span ERROR; a failed LLM turn marks only the LLM span — parents stay OK.

## Design

- **In-tree, single file**, mirroring `claude-agent-sdk.ts` in structure and attribute shape. `instrumentModules.piCodingAgent` accepts a bare module ref or the `{ module, config }` wrapper.
- **Prototype patching.** Patches `AgentSession.prototype.prompt/steer/followUp/dispose` (the prototype, not the frozen ESM namespace). Install is fail-loud on a bad SDK shape, idempotent on re-entry, and rolls back all patches on partial failure. `steer()`/`followUp()` are patched only so `subscribe()` runs once — either can be a session's first call.
- **Tracer resolved at use.** The tracer is resolved at each span-open rather than captured at wrap time, so pi spans always route to whichever provider is registered at that moment. Worth flagging that this alone does not survive a `shutdown()`/`initialize()` cycle on `main` today — `shutdown()` never releases the OTel global slots, so the second `initialize()`'s `register()` silently loses and the global keeps delegating to the old, already-shut-down provider. pi re-resolves correctly; there is just nothing new to resolve to. That is a `shutdown()` bug, not a pi bug, and is deliberately out of scope here; pi needs no further change when it is fixed.
- **Lifecycle sweep.** A per-session state machine force-closes dangling spans from a crashed attempt (`traceroot.pi.force_closed`) on `agent_start`, `turn_end`, `agent_end`, mid-run rejection, and `dispose()`; a session reused after `dispose()` re-subscribes on its next `prompt()`.
- **Payload safety.** Tool I/O is JSON-serialized with a 32 KB size cap and a 2,048-entry breadth cap, truncated with a plain slice; tool span names are command/basename only, never full paths.

## Files changed

New: `src/pi.ts`, `tests/pi.test.ts`, `tests/pi-lifecycle-edge-cases.test.ts`, `tests/pi-test-helpers.ts`.

Modified: `src/instrumentation.ts` (one import + one call, symmetric with claude/openai), `src/types.ts` (`PiCodingAgentInstrumentation`, `instrumentModules.piCodingAgent`), `src/index.ts` (type re-exports), `package.json` (two devDependencies).

No shared configuration or existing integration is touched: `tsconfig.json`, `src/constants.ts`, `src/claude-agent-sdk.ts` and `src/traceroot.ts` all stay at upstream.

On the lockfile: `pnpm-lock.yaml` shows a large diff that is not specific to this PR. `@arizeai/openinference-instrumentation-bedrock` peer-depends on `@aws-sdk/client-bedrock-runtime: ^3.0.0`, so pnpm re-resolves that caret — and the AWS SDK's transitive tree with it — on any `package.json` edit. Regenerating the lockfile on `main` with an unrelated one-line manifest change produces the same churn. CI installs with `--frozen-lockfile`, which checks lockfile-manifest consistency rather than resolution freshness, so this is safe to take as-is; happy to hand-prune it to just the two new devDependencies if you'd rather keep the diff minimal.

## Testing

- `npm run build` / typecheck — clean
- unit: 63 `it()` cases across the two `pi-*` files (span shape, context parenting, retry/dispose/sweep, capture-flag boundaries, truncation); full package suite 227/227 green
- retry behavior (`retry_count`, ERROR→OK LLM child on retry) is covered by a mocked stream — not reliably reproducible on a live happy-path run
- **live e2e** against Traceroot cloud with this branch's build: real `AgentSession` running the pi incident-response example (traceroot#1547) on `gpt-5.4`, exported HTTP 200

## End-to-end tests
<img width="1273" height="957" alt="Screenshot 2026-07-24 at 7 06 18 PM" src="https://github.com/user-attachments/assets/8c46eef2-62e5-464e-9513-2813cf21d0f7" />
Test 1 - (https://github.com/traceroot-ai/traceroot/pull/1547)

<img width="1095" height="515" alt="Screenshot 2026-07-24 at 7 06 53 PM" src="https://github.com/user-attachments/assets/7d2b983c-e40c-4a20-a80b-d4c86ac48c90" />
Test 2

