### PR TITLE
feat(traceroot): traceId forcing API on startSpan()/observe() + acceptance tests

### DIFF
--- a/packages/traceroot/package.json
+++ b/packages/traceroot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traceroot-ai/traceroot",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "TraceRoot TypeScript SDK for AI observability",
   "keywords": [
     "traceroot",

--- a/packages/traceroot/src/observe.ts
+++ b/packages/traceroot/src/observe.ts
@@ -129,14 +129,13 @@ async function _observeRegular<A extends unknown[], T>(
   };
 
   if (forcedId !== undefined && shouldForceTraceId(forcedId)) {
-    // ROOT_CONTEXT: an ambient active span would otherwise parent this span and the
-    // generator would never be asked for a trace id.
-    return withForcedTraceId(forcedId, () =>
-      tracer.startActiveSpan(name, {}, ROOT_CONTEXT, (span) => {
-        warnIfForcingFailed(forcedId, span);
-        return run(span);
-      }),
-    );
+    // Force the id around span CREATION only, then run the callback inside the span's
+    // context. Wrapping the whole callback would leave the forced id visible (via
+    // AsyncLocalStorage, which survives await) to any root a user creates inside fn.
+    // ROOT_CONTEXT base: an ambient active span would otherwise parent this root.
+    const span = withForcedTraceId(forcedId, () => tracer.startSpan(name, undefined, ROOT_CONTEXT));
+    warnIfForcingFailed(forcedId, span);
+    return context.with(trace.setSpan(ROOT_CONTEXT, span), () => run(span));
   }
   return tracer.startActiveSpan(name, run);
 }

--- a/packages/traceroot/src/observe.ts
+++ b/packages/traceroot/src/observe.ts
@@ -3,7 +3,12 @@ import { context, ROOT_CONTEXT, Span as OtelSpan, SpanStatusCode, trace } from '
 import { OUTPUT_VALUE } from '@arizeai/openinference-semantic-conventions';
 import { applyCommonAttributes, trySerialize } from './attributes';
 import { ObserveOptions } from './types';
-import { shouldForceTraceId, withForcedTraceId, assertValidTraceId } from './trace-id';
+import {
+  assertValidTraceId,
+  shouldForceTraceId,
+  warnIfForcingFailed,
+  withForcedTraceId,
+} from './trace-id';
 
 // Cached once after the first call; the tracer name never changes.
 let _tracer: ReturnType<typeof trace.getTracer> | undefined;
@@ -126,7 +131,12 @@ async function _observeRegular<A extends unknown[], T>(
   if (forcedId !== undefined && shouldForceTraceId(forcedId)) {
     // ROOT_CONTEXT: an ambient active span would otherwise parent this span and the
     // generator would never be asked for a trace id.
-    return withForcedTraceId(forcedId, () => tracer.startActiveSpan(name, {}, ROOT_CONTEXT, run));
+    return withForcedTraceId(forcedId, () =>
+      tracer.startActiveSpan(name, {}, ROOT_CONTEXT, (span) => {
+        warnIfForcingFailed(forcedId, span);
+        return run(span);
+      }),
+    );
   }
   return tracer.startActiveSpan(name, run);
 }
@@ -148,10 +158,11 @@ async function* _observeAsyncGenerator<A extends unknown[], T>(
   _tracer ??= trace.getTracer('traceroot-ts');
   const tracer = _tracer;
   const forcedId = options.traceId;
-  const span =
-    forcedId !== undefined && shouldForceTraceId(forcedId)
-      ? withForcedTraceId(forcedId, () => tracer.startSpan(name, undefined, ROOT_CONTEXT))
-      : tracer.startSpan(name);
+  const force = forcedId !== undefined && shouldForceTraceId(forcedId);
+  const span = force
+    ? withForcedTraceId(forcedId, () => tracer.startSpan(name, undefined, ROOT_CONTEXT))
+    : tracer.startSpan(name);
+  if (force) warnIfForcingFailed(forcedId, span);
 
   if (!span.isRecording()) {
     if (!_hasWarnedUninit) {

--- a/packages/traceroot/src/observe.ts
+++ b/packages/traceroot/src/observe.ts
@@ -1,8 +1,9 @@
 // src/observe.ts
-import { context, SpanStatusCode, trace } from '@opentelemetry/api';
+import { context, ROOT_CONTEXT, Span as OtelSpan, SpanStatusCode, trace } from '@opentelemetry/api';
 import { OUTPUT_VALUE } from '@arizeai/openinference-semantic-conventions';
 import { applyCommonAttributes, trySerialize } from './attributes';
 import { ObserveOptions } from './types';
+import { shouldForceTraceId, withForcedTraceId, assertValidTraceId } from './trace-id';
 
 // Cached once after the first call; the tracer name never changes.
 let _tracer: ReturnType<typeof trace.getTracer> | undefined;
@@ -63,6 +64,7 @@ export function observe<A extends unknown[], T>(
   ...args: A
 ): Promise<T> | AsyncGenerator<T> {
   const name = options.name ?? (fn.name || 'anonymous');
+  if (options.traceId !== undefined) assertValidTraceId(options.traceId);
   _tracer ??= trace.getTracer('traceroot-ts');
 
   if (isAsyncGeneratorFunction(fn)) {
@@ -84,8 +86,10 @@ async function _observeRegular<A extends unknown[], T>(
     if (!TraceRoot.isInitialized()) TraceRoot.initialize();
   }
   _tracer ??= trace.getTracer('traceroot-ts');
+  const tracer = _tracer;
+  const forcedId = options.traceId;
 
-  return _tracer.startActiveSpan(name, async (span) => {
+  const run = async (span: OtelSpan) => {
     if (!span.isRecording()) {
       if (!_hasWarnedUninit) {
         _hasWarnedUninit = true;
@@ -117,7 +121,14 @@ async function _observeRegular<A extends unknown[], T>(
     } finally {
       span.end();
     }
-  });
+  };
+
+  if (forcedId !== undefined && shouldForceTraceId(forcedId)) {
+    // ROOT_CONTEXT: an ambient active span would otherwise parent this span and the
+    // generator would never be asked for a trace id.
+    return withForcedTraceId(forcedId, () => tracer.startActiveSpan(name, {}, ROOT_CONTEXT, run));
+  }
+  return tracer.startActiveSpan(name, run);
 }
 
 /**
@@ -135,7 +146,12 @@ async function* _observeAsyncGenerator<A extends unknown[], T>(
     if (!TraceRoot.isInitialized()) TraceRoot.initialize();
   }
   _tracer ??= trace.getTracer('traceroot-ts');
-  const span = _tracer.startSpan(name);
+  const tracer = _tracer;
+  const forcedId = options.traceId;
+  const span =
+    forcedId !== undefined && shouldForceTraceId(forcedId)
+      ? withForcedTraceId(forcedId, () => tracer.startSpan(name, undefined, ROOT_CONTEXT))
+      : tracer.startSpan(name);
 
   if (!span.isRecording()) {
     if (!_hasWarnedUninit) {

--- a/packages/traceroot/src/spans.ts
+++ b/packages/traceroot/src/spans.ts
@@ -1,9 +1,10 @@
 // src/spans.ts — imperative span handle API
-import { context, trace, SpanStatusCode, Span as OtelSpan } from '@opentelemetry/api';
+import { context, trace, SpanStatusCode, Span as OtelSpan, ROOT_CONTEXT } from '@opentelemetry/api';
 import { applyCommonAttributes, applyModel, applyUsage, applyIO, trySerialize } from './attributes';
 import { SPAN_METADATA } from './constants';
 import { StartSpanOptions, SpanUpdate } from './types';
 import { TraceRoot } from './traceroot';
+import { shouldForceTraceId, withForcedTraceId } from './trace-id';
 
 export interface Span {
   readonly spanId: string;
@@ -70,10 +71,26 @@ export function startSpan(options: StartSpanOptions): Span {
   }
   _tracer ??= trace.getTracer('traceroot-ts');
 
-  const parentOtel = options.parent ? (options.parent as TracerootSpan).otelSpan : undefined;
-  const ctx = parentOtel ? trace.setSpan(context.active(), parentOtel) : context.active();
+  if (options.traceId !== undefined && options.parent !== undefined) {
+    throw new TypeError(
+      '[TraceRoot] startSpan: traceId forces a new root and is mutually exclusive with parent.',
+    );
+  }
+  const tracer = _tracer;
+  const forcedId = options.traceId;
 
-  const otel = _tracer.startSpan(options.name, undefined, ctx);
+  let otel: OtelSpan;
+  if (forcedId !== undefined && shouldForceTraceId(forcedId)) {
+    // ROOT_CONTEXT, not context.active(): an ambient active span would parent this
+    // span and the generator would never be asked for a trace id.
+    otel = withForcedTraceId(forcedId, () =>
+      tracer.startSpan(options.name, undefined, ROOT_CONTEXT),
+    );
+  } else {
+    const parentOtel = options.parent ? (options.parent as TracerootSpan).otelSpan : undefined;
+    const ctx = parentOtel ? trace.setSpan(context.active(), parentOtel) : context.active();
+    otel = tracer.startSpan(options.name, undefined, ctx);
+  }
   if (!otel.isRecording() && !_hasWarnedUninit) {
     _hasWarnedUninit = true;
     console.warn(

--- a/packages/traceroot/src/spans.ts
+++ b/packages/traceroot/src/spans.ts
@@ -4,14 +4,16 @@ import { applyCommonAttributes, applyModel, applyUsage, applyIO, trySerialize } 
 import { SPAN_METADATA } from './constants';
 import { StartSpanOptions, SpanUpdate } from './types';
 import { TraceRoot } from './traceroot';
-import { shouldForceTraceId, withForcedTraceId } from './trace-id';
+import { shouldForceTraceId, warnIfForcingFailed, withForcedTraceId } from './trace-id';
 
 export interface Span {
   readonly spanId: string;
   readonly traceId: string;
   update(attrs: SpanUpdate): this;
   end(): void;
-  startSpan(options: Omit<StartSpanOptions, 'parent'>): Span;
+  // traceId is excluded: a child handle always parents to `this`, so forcing a
+  // trace id through it can never work — reject it at the type level.
+  startSpan(options: Omit<StartSpanOptions, 'parent' | 'traceId'>): Span;
   setError(err: unknown): this;
 }
 
@@ -40,7 +42,7 @@ class TracerootSpan implements Span {
   end(): void {
     this.otelSpan.end();
   }
-  startSpan(options: Omit<StartSpanOptions, 'parent'>): Span {
+  startSpan(options: Omit<StartSpanOptions, 'parent' | 'traceId'>): Span {
     return startSpan({ ...options, parent: this });
   }
   setError(err: unknown): this {
@@ -86,6 +88,7 @@ export function startSpan(options: StartSpanOptions): Span {
     otel = withForcedTraceId(forcedId, () =>
       tracer.startSpan(options.name, undefined, ROOT_CONTEXT),
     );
+    warnIfForcingFailed(forcedId, otel);
   } else {
     const parentOtel = options.parent ? (options.parent as TracerootSpan).otelSpan : undefined;
     const ctx = parentOtel ? trace.setSpan(context.active(), parentOtel) : context.active();

--- a/packages/traceroot/src/trace-id.ts
+++ b/packages/traceroot/src/trace-id.ts
@@ -15,6 +15,7 @@ const INVALID_TRACE_ID = '00000000000000000000000000000000';
 const _forcedTraceId = new AsyncLocalStorage<string>();
 let _internalMode = false;
 let _hasWarnedForceFailed = false;
+let _hasWarnedPublicIgnore = false;
 
 /** Throws TypeError unless `traceId` is a lowercase 32-hex string (not the zero sentinel). */
 export function assertValidTraceId(traceId: string): void {
@@ -57,9 +58,14 @@ export function withForcedTraceId<T>(traceId: string, fn: () => T): T {
 export function shouldForceTraceId(traceId: string): boolean {
   assertValidTraceId(traceId);
   if (!_internalMode) {
-    console.warn(
-      '[TraceRoot] traceId forcing is only honored in internal export mode; ignoring forced id.',
-    );
+    // Warn once per process: a misconfigured caller passing traceId on every
+    // span would otherwise spam the log with an identical message.
+    if (!_hasWarnedPublicIgnore) {
+      _hasWarnedPublicIgnore = true;
+      console.warn(
+        '[TraceRoot] traceId forcing is only honored in internal export mode; ignoring forced id.',
+      );
+    }
     return false;
   }
   return true;
@@ -94,4 +100,5 @@ export function _setInternalMode(v: boolean): void {
 /** @internal — reset warn-once state between tests. */
 export function _resetTraceIdState(): void {
   _hasWarnedForceFailed = false;
+  _hasWarnedPublicIgnore = false;
 }

--- a/packages/traceroot/src/trace-id.ts
+++ b/packages/traceroot/src/trace-id.ts
@@ -6,6 +6,7 @@
 // traceroot.ts — because observe.ts must read it and traceroot.ts already imports
 // from observe.ts; a static import in the other direction would be a require cycle.
 import { AsyncLocalStorage } from 'node:async_hooks';
+import type { Span } from '@opentelemetry/api';
 import { IdGenerator, RandomIdGenerator } from '@opentelemetry/sdk-trace-base';
 
 const HEX32 = /^[0-9a-f]{32}$/;
@@ -13,6 +14,7 @@ const INVALID_TRACE_ID = '00000000000000000000000000000000';
 
 const _forcedTraceId = new AsyncLocalStorage<string>();
 let _internalMode = false;
+let _hasWarnedForceFailed = false;
 
 /** Throws TypeError unless `traceId` is a lowercase 32-hex string (not the zero sentinel). */
 export function assertValidTraceId(traceId: string): void {
@@ -63,6 +65,23 @@ export function shouldForceTraceId(traceId: string): boolean {
   return true;
 }
 
+/**
+ * Warn (once per process) when a span that should carry a forced trace id came out
+ * with a different one. This happens when the globally registered tracer provider
+ * does not use ContextIdGenerator — e.g. the application registered its own OTel
+ * provider before TraceRoot.initialize(), whose register() then lost the race.
+ * Spans are still recorded, just with random trace ids.
+ */
+export function warnIfForcingFailed(expected: string, span: Span): void {
+  if (span.spanContext().traceId === expected || _hasWarnedForceFailed) return;
+  _hasWarnedForceFailed = true;
+  console.warn(
+    '[TraceRoot] forced traceId was not applied: the global tracer provider does not use ' +
+      "TraceRoot's id generator (was another provider registered before TraceRoot.initialize()?). " +
+      'Spans will get random trace ids.',
+  );
+}
+
 export function isInternalMode(): boolean {
   return _internalMode;
 }
@@ -70,4 +89,9 @@ export function isInternalMode(): boolean {
 /** @internal — set by TraceRoot.initialize()/shutdown() and test resets. */
 export function _setInternalMode(v: boolean): void {
   _internalMode = v;
+}
+
+/** @internal — reset warn-once state between tests. */
+export function _resetTraceIdState(): void {
+  _hasWarnedForceFailed = false;
 }

--- a/packages/traceroot/src/traceroot.ts
+++ b/packages/traceroot/src/traceroot.ts
@@ -122,8 +122,6 @@ export class TraceRoot {
       'x-traceroot-sdk-version': SDK_VERSION,
     };
     const target = resolveExportTarget(baseUrl, apiKey, sdkHeaders, options.internalExport);
-    _exportTarget = target;
-    _setInternalMode(target.internal);
 
     const exporter = new OTLPTraceExporter({
       url: target.url,
@@ -213,6 +211,11 @@ export class TraceRoot {
 
     wireInstrumentations(options.instrumentModules);
 
+    // Flip trusted-mode state only now that every fallible step above has
+    // succeeded — a failed init must not leave forced-trace-id behavior
+    // (or a stale _exportTarget) enabled while isInitialized() is false.
+    _exportTarget = target;
+    _setInternalMode(target.internal);
     _isInitialized = true;
     process.once('beforeExit', () => {
       void _provider?.forceFlush();
@@ -231,12 +234,17 @@ export class TraceRoot {
   }
 
   static async shutdown(): Promise<void> {
-    await _provider?.shutdown();
-    _isInitialized = false;
-    _provider = undefined;
-    _exportTarget = undefined;
-    _setInternalMode(false);
-    _resetObserveState();
+    try {
+      await _provider?.shutdown();
+    } finally {
+      // Reset even when shutdown() rejects (e.g. a flush failure) — otherwise
+      // the SDK is left claiming to be initialized with internal mode still on.
+      _isInitialized = false;
+      _provider = undefined;
+      _exportTarget = undefined;
+      _setInternalMode(false);
+      _resetObserveState();
+    }
   }
 }
 

--- a/packages/traceroot/src/traceroot.ts
+++ b/packages/traceroot/src/traceroot.ts
@@ -92,6 +92,12 @@ export class TraceRoot {
       return;
     }
 
+    if (options.internalExport && !options.internalExport.path.startsWith('/')) {
+      throw new TypeError(
+        `[TraceRoot] internalExport.path must start with '/', got: ${JSON.stringify(options.internalExport.path)}`,
+      );
+    }
+
     const apiKey = options.apiKey ?? process.env['TRACEROOT_API_KEY'];
     if (!apiKey && !options.internalExport) {
       console.warn(

--- a/packages/traceroot/src/traceroot.ts
+++ b/packages/traceroot/src/traceroot.ts
@@ -25,7 +25,7 @@ import {
   gitContextFromFiles,
   _resetGitContextCache,
 } from './git_context';
-import { ContextIdGenerator, _setInternalMode } from './trace-id';
+import { ContextIdGenerator, _resetTraceIdState, _setInternalMode } from './trace-id';
 
 const DEFAULT_BASE_URL = 'https://app.traceroot.ai';
 
@@ -246,6 +246,7 @@ export function _resetForTesting(): void {
   _provider = undefined;
   _exportTarget = undefined;
   _setInternalMode(false);
+  _resetTraceIdState();
   _resetObserveState();
   _resetGitContextCache();
   trace.disable();

--- a/packages/traceroot/src/traceroot.ts
+++ b/packages/traceroot/src/traceroot.ts
@@ -30,6 +30,7 @@ import { ContextIdGenerator, _resetTraceIdState, _setInternalMode } from './trac
 const DEFAULT_BASE_URL = 'https://app.traceroot.ai';
 
 let _isInitialized = false;
+let _tracingActive = false;
 let _provider: NodeTracerProvider | undefined;
 let _exportTarget: ExportTarget | undefined;
 
@@ -79,6 +80,17 @@ export class TraceRoot {
 
   static isInitialized(): boolean {
     return _isInitialized;
+  }
+
+  /**
+   * True only when initialize() completed AND this SDK's tracer provider actually won
+   * the global OpenTelemetry registration. False when never initialized, after
+   * shutdown(), or when another provider was already registered and ours was rejected
+   * (spans flow elsewhere and trace-id forcing does not take effect). Lets callers
+   * detect a lost registration directly instead of probing span behavior.
+   */
+  static isTracingActive(): boolean {
+    return _isInitialized && _tracingActive;
   }
 
   static initialize(options: InitializeOptions = {}): void {
@@ -215,7 +227,44 @@ export class TraceRoot {
     );
     _provider.register();
 
-    wireInstrumentations(options.instrumentModules);
+    // register() calls trace.setGlobalTracerProvider() internally, which is a no-op
+    // (logs via diag, returns false — never throws) if another OTel provider was
+    // already registered. Detect that by checking whether our provider actually became
+    // the global delegate: if not, spans flow through the other provider and trace-id
+    // forcing silently does nothing. Surface it loudly and record it for isTracingActive().
+    const globalProvider = trace.getTracerProvider();
+    const delegate =
+      'getDelegate' in globalProvider &&
+      typeof (globalProvider as { getDelegate: () => unknown }).getDelegate === 'function'
+        ? (globalProvider as { getDelegate: () => unknown }).getDelegate()
+        : globalProvider;
+    _tracingActive = delegate === _provider;
+    if (!_tracingActive) {
+      console.error(
+        '[TraceRoot] tracer-provider registration was rejected: another OpenTelemetry ' +
+          'provider is already registered globally (registered before TraceRoot.initialize()). ' +
+          'Spans flow through that provider and trace-id forcing will not take effect. ' +
+          'Initialize TraceRoot before any other OpenTelemetry SDK.',
+      );
+    }
+
+    // Wire instrumentations under a rollback guard: if this throws, the global is
+    // already taken by our provider but the init did not complete. Undo the
+    // registration and drop the provider so the NEXT initialize() starts clean —
+    // otherwise it would build a second provider whose register() loses to this one,
+    // leaving flush()/shutdown() operating on a provider that never received spans
+    // (silent data loss).
+    try {
+      wireInstrumentations(options.instrumentModules);
+    } catch (err) {
+      trace.disable();
+      context.disable();
+      propagation.disable();
+      void _provider.shutdown().catch(() => {});
+      _provider = undefined;
+      _tracingActive = false;
+      throw err;
+    }
 
     // Flip trusted-mode state only now that every fallible step above has
     // succeeded — a failed init must not leave forced-trace-id behavior
@@ -246,10 +295,17 @@ export class TraceRoot {
       // Reset even when shutdown() rejects (e.g. a flush failure) — otherwise
       // the SDK is left claiming to be initialized with internal mode still on.
       _isInitialized = false;
+      _tracingActive = false;
       _provider = undefined;
       _exportTarget = undefined;
       _setInternalMode(false);
       _resetObserveState();
+
+      // Release the global tracer/context/propagation registration so a later
+      // initialize() re-registers cleanly instead of losing to this dead provider.
+      trace.disable();
+      context.disable();
+      propagation.disable();
     }
   }
 }
@@ -257,6 +313,7 @@ export class TraceRoot {
 /** @internal */
 export function _resetForTesting(): void {
   _isInitialized = false;
+  _tracingActive = false;
   _provider = undefined;
   _exportTarget = undefined;
   _setInternalMode(false);

--- a/packages/traceroot/src/types.ts
+++ b/packages/traceroot/src/types.ts
@@ -140,6 +140,13 @@ export interface StartSpanOptions {
   modelParameters?: Record<string, unknown>;
   /** Arbitrary span attributes (see {@link SpanUpdate.attributes}). */
   attributes?: Record<string, string | number | boolean>;
+  /**
+   * Force this root span's trace id to an explicit lowercase 32-hex string.
+   * Honored ONLY in internal export mode; ignored (with a warning) otherwise.
+   * Starts a root — mutually exclusive with `parent` (throws if both are given).
+   * Malformed ids throw.
+   */
+  traceId?: string;
   /** Explicit parent handle. Default: the current active span. */
   parent?: import('./spans').Span;
 }

--- a/packages/traceroot/src/types.ts
+++ b/packages/traceroot/src/types.ts
@@ -32,6 +32,12 @@ export interface ObserveOptions {
    * Equivalent to calling updateCurrentTrace({ userId }) inside fn.
    */
   userId?: string;
+  /**
+   * Force this root span's trace id to an explicit lowercase 32-hex string.
+   * Honored ONLY in internal export mode; ignored (with a warning) otherwise.
+   * Malformed ids throw synchronously.
+   */
+  traceId?: string;
 }
 
 export interface InitializeOptions {

--- a/packages/traceroot/tests/initialize.test.ts
+++ b/packages/traceroot/tests/initialize.test.ts
@@ -12,6 +12,7 @@ import {
 import { TraceRootSpanProcessor } from '../src/processor';
 import { isInternalMode, withForcedTraceId } from '../src/trace-id';
 import { trace } from '@opentelemetry/api';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 
 describe('TraceRoot.initialize()', () => {
   afterEach(() => {
@@ -443,5 +444,59 @@ describe('internal export mode init', () => {
     const unforced = withForcedTraceId(FORCED, () => trace.getTracer('t').startSpan('root'));
     assert.notEqual(unforced.spanContext().traceId, FORCED);
     unforced.end();
+  });
+});
+
+describe('TraceRoot.isTracingActive()', () => {
+  afterEach(() => {
+    _resetForTesting();
+  });
+
+  it('is false before any initialize()', () => {
+    assert.equal(TraceRoot.isTracingActive(), false);
+  });
+
+  it('is true after a clean initialize() (no foreign provider)', () => {
+    TraceRoot.initialize({ apiKey: 'test-key', disableBatch: true });
+    assert.equal(TraceRoot.isTracingActive(), true);
+  });
+
+  it('is false after shutdown()', async () => {
+    TraceRoot.initialize({ apiKey: 'test-key', disableBatch: true });
+    await TraceRoot.shutdown();
+    assert.equal(TraceRoot.isTracingActive(), false);
+  });
+
+  it('reports and warns loudly when another OTel provider already won global registration', () => {
+    const foreign = new NodeTracerProvider();
+    foreign.register();
+
+    const errors: string[] = [];
+    const restore = console.error;
+    console.error = (...args: unknown[]) => {
+      errors.push(args.join(' '));
+    };
+    try {
+      TraceRoot.initialize({
+        internalExport: { path: '/x', projectId: 'p' },
+      });
+      assert.equal(TraceRoot.isInitialized(), true);
+      assert.equal(TraceRoot.isTracingActive(), false);
+      assert.equal(errors.length, 1);
+      assert.ok(errors[0].includes('tracer-provider registration was rejected'));
+    } finally {
+      console.error = restore;
+      // _resetForTesting() disables the global registration, releasing both
+      // our provider and the foreign one.
+      _resetForTesting();
+    }
+  });
+
+  it('re-registers cleanly after shutdown() then a second initialize()', async () => {
+    TraceRoot.initialize({ apiKey: 'test-key', disableBatch: true });
+    assert.equal(TraceRoot.isTracingActive(), true);
+    await TraceRoot.shutdown();
+    TraceRoot.initialize({ apiKey: 'test-key-2', disableBatch: true });
+    assert.equal(TraceRoot.isTracingActive(), true);
   });
 });

--- a/packages/traceroot/tests/initialize.test.ts
+++ b/packages/traceroot/tests/initialize.test.ts
@@ -414,14 +414,11 @@ describe('internal export mode init', () => {
 
   it('throws TypeError when internalExport.path is missing its leading slash, leaving no state behind', () => {
     try {
-      assert.throws(
-        () => {
-          TraceRoot.initialize({
-            internalExport: { path: 'api/v1/internal/traces', projectId: 'p' },
-          });
-        },
-        TypeError,
-      );
+      assert.throws(() => {
+        TraceRoot.initialize({
+          internalExport: { path: 'api/v1/internal/traces', projectId: 'p' },
+        });
+      }, TypeError);
       assert.equal(TraceRoot.isInitialized(), false);
       assert.equal(isInternalMode(), false);
     } finally {

--- a/packages/traceroot/tests/initialize.test.ts
+++ b/packages/traceroot/tests/initialize.test.ts
@@ -335,6 +335,18 @@ describe('resolveExportTarget()', () => {
     });
     assert.equal(t.headers['x-traceroot-sdk-name'], 'traceroot-ts');
   });
+
+  it('preserves multiple custom headers alongside SDK headers', () => {
+    const t = resolveExportTarget('https://h', undefined, sdkHeaders, {
+      path: '/i',
+      projectId: 'p',
+      headers: { 'X-Internal-Secret': 's', 'X-Trace-Origin': 'worker', 'X-Region': 'us-east-1' },
+    });
+    assert.equal(t.headers['X-Internal-Secret'], 's');
+    assert.equal(t.headers['X-Trace-Origin'], 'worker');
+    assert.equal(t.headers['X-Region'], 'us-east-1');
+    assert.equal(t.headers['x-traceroot-sdk-version'], '9.9.9');
+  });
 });
 
 describe('internal export mode init', () => {

--- a/packages/traceroot/tests/initialize.test.ts
+++ b/packages/traceroot/tests/initialize.test.ts
@@ -412,6 +412,23 @@ describe('internal export mode init', () => {
     );
   });
 
+  it('throws TypeError when internalExport.path is missing its leading slash, leaving no state behind', () => {
+    try {
+      assert.throws(
+        () => {
+          TraceRoot.initialize({
+            internalExport: { path: 'api/v1/internal/traces', projectId: 'p' },
+          });
+        },
+        TypeError,
+      );
+      assert.equal(TraceRoot.isInitialized(), false);
+      assert.equal(isInternalMode(), false);
+    } finally {
+      _resetForTesting();
+    }
+  });
+
   it('installs the forcing generator in internal mode only (defense in depth)', () => {
     // Internal init: the globally registered provider carries ContextIdGenerator,
     // so a root created inside a forced scope gets the forced id. Default batching

--- a/packages/traceroot/tests/internal-export-wire.test.ts
+++ b/packages/traceroot/tests/internal-export-wire.test.ts
@@ -9,6 +9,7 @@ import { createRequire } from 'node:module';
 import { gunzipSync } from 'node:zlib';
 import { TraceRoot, _resetForTesting } from '../src/traceroot';
 import { startSpan, _resetSpansState } from '../src/spans';
+import { isInternalMode } from '../src/trace-id';
 
 const FORCED = 'feedfacefeedfacefeedfacefeedface';
 
@@ -159,6 +160,35 @@ describe('flush() failure contract', () => {
       // The process (and tracer) keeps working after the rejection.
       const again = startSpan({ name: 'still-alive' });
       assert.doesNotThrow(() => again.end());
+    } finally {
+      // Shut the provider down (flushing may fail against the closing server — ignore)
+      // so no batch timer holds buffered spans aimed at a closed port.
+      await TraceRoot.shutdown().catch(() => {});
+      _resetForTesting();
+      _resetSpansState(); // drop the cached module tracer so the next test re-resolves it
+      server.close();
+      server.closeAllConnections?.();
+    }
+  });
+
+  it('shutdown() rejects but still resets isInitialized()/isInternalMode() state', async () => {
+    const { port, server } = await startCaptureServer(403);
+    try {
+      TraceRoot.initialize({
+        baseUrl: `http://127.0.0.1:${port}`,
+        internalExport: {
+          path: '/api/v1/internal/traces',
+          projectId: 'p',
+          headers: { 'X-Internal-Secret': 'wrong' },
+        },
+      });
+      const root = startSpan({ name: 'denied', traceId: FORCED });
+      root.end();
+      // shutdown() flushes on the way out; a denied export makes it reject —
+      // the state cleanup below must still happen despite the rejection.
+      await assert.rejects(TraceRoot.shutdown());
+      assert.equal(TraceRoot.isInitialized(), false);
+      assert.equal(isInternalMode(), false);
     } finally {
       // Shut the provider down (flushing may fail against the closing server — ignore)
       // so no batch timer holds buffered spans aimed at a closed port.

--- a/packages/traceroot/tests/internal-export-wire.test.ts
+++ b/packages/traceroot/tests/internal-export-wire.test.ts
@@ -1,0 +1,172 @@
+// Wire-level contract tests for internal export mode: what actually leaves the
+// process over HTTP. The resolved-target unit tests once passed while the real
+// request was broken (the OTLP exporter strips query strings from its endpoint
+// URL), so these assert on a captured request instead of derived strings.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { createRequire } from 'node:module';
+import { gunzipSync } from 'node:zlib';
+import { TraceRoot, _resetForTesting } from '../src/traceroot';
+import { startSpan, _resetSpansState } from '../src/spans';
+
+const FORCED = 'feedfacefeedfacefeedfacefeedface';
+
+// The OTLP protobuf request decoder is not exported by the exporter package;
+// reach the transformer's generated root through the exporter's own module
+// resolution (test-only — production code never touches these internals).
+const exporterRequire = createRequire(
+  createRequire(__filename).resolve('@opentelemetry/exporter-trace-otlp-proto'),
+);
+const transformerRequire = createRequire(
+  exporterRequire.resolve('@opentelemetry/otlp-transformer'),
+);
+const protoRoot = transformerRequire('@opentelemetry/otlp-transformer/build/src/generated/root');
+const ExportTraceServiceRequest =
+  protoRoot.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+
+interface ProtoSpan {
+  name: string;
+  traceId: Uint8Array;
+  parentSpanId?: Uint8Array;
+}
+interface DecodedRequest {
+  resourceSpans: { scopeSpans?: { spans?: ProtoSpan[] }[] }[];
+}
+
+interface CapturedRequest {
+  url: string;
+  headers: http.IncomingHttpHeaders;
+  body: Buffer;
+}
+
+/** Start a local capture server responding with `statusCode` to every request. */
+function startCaptureServer(statusCode: number): Promise<{
+  port: number;
+  server: http.Server;
+  nextRequest: () => Promise<CapturedRequest>;
+}> {
+  let waiter: ((c: CapturedRequest) => void) | undefined;
+  const pending: CapturedRequest[] = [];
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => {
+      const captured = { url: req.url ?? '', headers: req.headers, body: Buffer.concat(chunks) };
+      if (waiter) {
+        waiter(captured);
+        waiter = undefined;
+      } else {
+        pending.push(captured);
+      }
+      res.statusCode = statusCode;
+      res.end();
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as { port: number };
+      resolve({
+        port,
+        server,
+        // Rejects after 5s so a silent-no-export regression fails loudly
+        // instead of hanging the suite (node:test has no default timeout).
+        nextRequest: () =>
+          pending.length > 0
+            ? Promise.resolve(pending.shift() as CapturedRequest)
+            : new Promise<CapturedRequest>((resolveReq, reject) => {
+                waiter = resolveReq;
+                const timer = setTimeout(
+                  () => reject(new Error('no export request arrived within 5s')),
+                  5000,
+                );
+                timer.unref();
+              }),
+      });
+    });
+  });
+}
+
+describe('internal export wire contract', () => {
+  it('sends the bare path, X-Project-Id + custom headers, and a decodable forced-root body', async () => {
+    const { port, server, nextRequest } = await startCaptureServer(200);
+    try {
+      TraceRoot.initialize({
+        baseUrl: `http://127.0.0.1:${port}`,
+        internalExport: {
+          path: '/api/v1/internal/traces',
+          projectId: 'proj-wire',
+          headers: { 'X-Internal-Secret': 'sekrit' },
+        },
+      });
+      const root = startSpan({ name: 'run', traceId: FORCED });
+      root.end();
+      await TraceRoot.flush();
+
+      const req = await nextRequest();
+      assert.equal(req.url, '/api/v1/internal/traces', 'exact path, no query string');
+      assert.equal(req.headers['x-project-id'], 'proj-wire');
+      assert.equal(req.headers['x-internal-secret'], 'sekrit');
+      assert.equal(Object.prototype.hasOwnProperty.call(req.headers, 'authorization'), false);
+
+      assert.equal(
+        req.headers['content-encoding'],
+        'gzip',
+        'gzip compression is part of the contract',
+      );
+      const decoded = ExportTraceServiceRequest.decode(
+        gunzipSync(req.body),
+      ) as unknown as DecodedRequest;
+      const spans = decoded.resourceSpans.flatMap((rs) =>
+        (rs.scopeSpans ?? []).flatMap((ss) => ss.spans ?? []),
+      );
+      const run = spans.find((s) => s.name === 'run');
+      assert.ok(run, 'exported request contains the root span');
+      assert.equal(Buffer.from(run.traceId).toString('hex'), FORCED);
+      assert.equal(
+        (run.parentSpanId ?? new Uint8Array()).length,
+        0,
+        'forced root has no parent on the wire',
+      );
+    } finally {
+      // Shut the provider down (flushing may fail against the closing server — ignore)
+      // so no batch timer holds buffered spans aimed at a closed port.
+      await TraceRoot.shutdown().catch(() => {});
+      _resetForTesting();
+      _resetSpansState(); // drop the cached module tracer so the next test re-resolves it
+      server.close();
+      server.closeAllConnections?.();
+    }
+  });
+});
+
+describe('flush() failure contract', () => {
+  it('rejects when the ingest route denies the export, leaving the process unharmed', async () => {
+    const { port, server } = await startCaptureServer(403);
+    try {
+      TraceRoot.initialize({
+        baseUrl: `http://127.0.0.1:${port}`,
+        internalExport: {
+          path: '/api/v1/internal/traces',
+          projectId: 'p',
+          headers: { 'X-Internal-Secret': 'wrong' },
+        },
+      });
+      const root = startSpan({ name: 'denied', traceId: FORCED });
+      root.end();
+      // The SDK does not swallow export failures — the consumer decides.
+      await assert.rejects(TraceRoot.flush());
+      // The process (and tracer) keeps working after the rejection.
+      const again = startSpan({ name: 'still-alive' });
+      assert.doesNotThrow(() => again.end());
+    } finally {
+      // Shut the provider down (flushing may fail against the closing server — ignore)
+      // so no batch timer holds buffered spans aimed at a closed port.
+      await TraceRoot.shutdown().catch(() => {});
+      _resetForTesting();
+      _resetSpansState(); // drop the cached module tracer so the next test re-resolves it
+      server.close();
+      server.closeAllConnections?.();
+    }
+  });
+});

--- a/packages/traceroot/tests/observe.test.ts
+++ b/packages/traceroot/tests/observe.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { SpanStatusCode } from '@opentelemetry/api';
+import { context, propagation, SpanStatusCode, trace } from '@opentelemetry/api';
 import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { observe } from '../src/observe';
 import { updateCurrentSpan } from '../src/context';
-import { _resetForTesting } from '../src/traceroot';
+import { _resetForTesting, TraceRoot } from '../src/traceroot';
+import { ContextIdGenerator } from '../src/trace-id';
 
 // Attribute keys
 const SPAN_KIND_ATTR = 'openinference.span.kind';
@@ -324,5 +325,115 @@ describe('observe()', () => {
       process.env['TRACEROOT_API_KEY'] = prev;
       _resetForTesting();
     }
+  });
+});
+
+describe('observe() trace-id forcing', () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+  const A = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const B = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    // Forcing generator must be on the globally registered provider; initialize()
+    // below only flips internal-mode state (its register() is a silent no-op).
+    provider = new NodeTracerProvider({ idGenerator: new ContextIdGenerator() });
+    provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+    provider.register();
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+    exporter.reset();
+    _resetForTesting();
+    trace.disable();
+    context.disable();
+    propagation.disable();
+  });
+
+  it('internal mode: forces the root id; root exports with no parent', async () => {
+    TraceRoot.initialize({
+      disableBatch: true,
+      internalExport: { path: '/api/v1/internal/traces', projectId: 'p' },
+    });
+    await observe({ name: 'run', traceId: A }, async () => 'ok');
+    const root = exporter.getFinishedSpans().find((s) => s.name === 'run');
+    assert.ok(root);
+    assert.equal(root.spanContext().traceId, A);
+    assert.equal(root.parentSpanId, undefined);
+  });
+
+  it('concurrency: interleaved forced observe() calls keep their own ids', async () => {
+    TraceRoot.initialize({
+      disableBatch: true,
+      internalExport: { path: '/api/v1/internal/traces', projectId: 'p' },
+    });
+    const mk = (id: string) =>
+      observe({ name: `run-${id}`, traceId: id }, async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        return id;
+      });
+    await Promise.all([mk(A), mk(B)]);
+    const spans = exporter.getFinishedSpans();
+    assert.equal(spans.find((s) => s.name === `run-${A}`)?.spanContext().traceId, A);
+    assert.equal(spans.find((s) => s.name === `run-${B}`)?.spanContext().traceId, B);
+  });
+
+  it('forces the trace id for async-generator functions too', async () => {
+    TraceRoot.initialize({
+      disableBatch: true,
+      internalExport: { path: '/api/v1/internal/traces', projectId: 'p' },
+    });
+    async function* gen(): AsyncGenerator<number> {
+      yield 1;
+      yield 2;
+    }
+    const items: number[] = [];
+    for await (const v of observe({ name: 'gen-run', traceId: A }, gen)) {
+      items.push(v);
+    }
+    assert.deepEqual(items, [1, 2]);
+    const root = exporter.getFinishedSpans().find((s) => s.name === 'gen-run');
+    assert.ok(root);
+    assert.equal(root.spanContext().traceId, A);
+    assert.equal(root.parentSpanId, undefined);
+  });
+
+  it('public mode: warns and does not force', async () => {
+    const messages: string[] = [];
+    const restore = console.warn;
+    console.warn = (...a: unknown[]) => {
+      messages.push(a.map(String).join(' '));
+    };
+    try {
+      TraceRoot.initialize({ apiKey: 'k', disableBatch: true });
+      await observe({ name: 'run', traceId: A }, async () => 'ok');
+    } finally {
+      console.warn = restore;
+    }
+    const root = exporter.getFinishedSpans().find((s) => s.name === 'run');
+    assert.ok(root);
+    assert.notEqual(root.spanContext().traceId, A);
+    assert.ok(messages.some((m) => m.includes('internal export mode')));
+  });
+
+  it('throws synchronously on a malformed forced id (regular fn)', () => {
+    TraceRoot.initialize({
+      disableBatch: true,
+      internalExport: { path: '/api/v1/internal/traces', projectId: 'p' },
+    });
+    assert.throws(() => observe({ name: 'run', traceId: 'bad' }, async () => 'ok'), TypeError);
+  });
+
+  it('throws synchronously on a malformed forced id (async-generator fn)', () => {
+    TraceRoot.initialize({
+      disableBatch: true,
+      internalExport: { path: '/api/v1/internal/traces', projectId: 'p' },
+    });
+    async function* gen(): AsyncGenerator<number> {
+      yield 1;
+    }
+    assert.throws(() => observe({ name: 'gen', traceId: 'bad' }, gen), TypeError);
   });
 });

--- a/packages/traceroot/tests/self-tracing.test.ts
+++ b/packages/traceroot/tests/self-tracing.test.ts
@@ -1,0 +1,290 @@
+// Acceptance-level tests for self-tracing: internal export mode, deterministic
+// trace-id forcing, and the global source marker working TOGETHER, the way a
+// trusted worker drives them: one long-lived internal-mode tracer, concurrent
+// runs with trace_id = run_id, a child span per run, and the marker on every span.
+import { after, afterEach, before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { context, propagation, SpanStatusCode, trace } from '@opentelemetry/api';
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { TraceRoot, _resetForTesting } from '../src/traceroot';
+import { TraceRootSpanProcessor } from '../src/processor';
+import { ContextIdGenerator } from '../src/trace-id';
+import { startSpan, usingSpan, _resetSpansState } from '../src/spans';
+import { observe } from '../src/observe';
+
+const RUN_A = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const RUN_B = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+/**
+ * Register an in-memory pipeline that mirrors initialize()'s stack
+ * (ContextIdGenerator + TraceRootSpanProcessor) and flip internal mode via a
+ * real initialize() call. initialize()'s own register() loses the race to the
+ * already-registered test provider (OTel keeps the first global and logs diag
+ * errors for the duplicate registration) — spans still flow through the
+ * in-memory provider while initialize() flips internal-mode state. No OTLP
+ * export ever happens in these tests.
+ */
+function registerHarness(globalAttributes: Record<string, string | number | boolean>): {
+  exporter: InMemorySpanExporter;
+  provider: NodeTracerProvider;
+} {
+  const exporter = new InMemorySpanExporter();
+  const provider = new NodeTracerProvider({ idGenerator: new ContextIdGenerator() });
+  provider.addSpanProcessor(
+    new TraceRootSpanProcessor(new SimpleSpanProcessor(exporter), {
+      environment: 'prod',
+      globalAttributes,
+    }),
+  );
+  provider.register();
+  TraceRoot.initialize({
+    disableBatch: true,
+    internalExport: { path: '/api/v1/internal/traces', projectId: 'p' },
+  });
+  return { exporter, provider };
+}
+
+async function teardownHarness(provider: NodeTracerProvider): Promise<void> {
+  await provider.shutdown();
+  _resetForTesting();
+  _resetSpansState();
+  trace.disable();
+  context.disable();
+  propagation.disable();
+}
+
+describe('self-tracing acceptance (worker scenario)', () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  before(() => {
+    ({ exporter, provider } = registerHarness({ 'traceroot.source': 'detector' }));
+  });
+
+  afterEach(() => {
+    exporter.reset();
+  });
+
+  after(async () => {
+    await teardownHarness(provider);
+  });
+
+  it('two concurrent runs: trace_id = run_id, marker on every span, parentless roots', async () => {
+    const runDetector = (runId: string) =>
+      observe({ name: 'detector-run', traceId: runId }, async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        return observe({ name: 'judge-llm', type: 'llm' }, async () => 'verdict');
+      });
+    await Promise.all([runDetector(RUN_A), runDetector(RUN_B)]);
+
+    const spans = exporter.getFinishedSpans();
+    assert.equal(spans.length, 4);
+    for (const s of spans) {
+      assert.equal(s.attributes['traceroot.source'], 'detector');
+    }
+    for (const runId of [RUN_A, RUN_B]) {
+      const group = spans.filter((s) => s.spanContext().traceId === runId);
+      assert.equal(group.length, 2, `expected root+child for run ${runId}`);
+      const root = group.find((s) => s.name === 'detector-run');
+      const child = group.find((s) => s.name === 'judge-llm');
+      assert.ok(root && child);
+      assert.equal(root.parentSpanId, undefined);
+      assert.equal(child.parentSpanId, root.spanContext().spanId);
+    }
+  });
+
+  it('adapter shape: startSpan root with forced id + child handle, marker everywhere', () => {
+    const root = startSpan({ name: 'run', traceId: RUN_A });
+    const child = root.startSpan({ name: 'judge' });
+    child.end();
+    root.end();
+
+    const spans = exporter.getFinishedSpans();
+    const rootSpan = spans.find((s) => s.name === 'run');
+    const childSpan = spans.find((s) => s.name === 'judge');
+    assert.ok(rootSpan && childSpan);
+    assert.equal(rootSpan.spanContext().traceId, RUN_A);
+    assert.equal(childSpan.spanContext().traceId, RUN_A);
+    assert.equal(rootSpan.parentSpanId, undefined);
+    assert.equal(childSpan.parentSpanId, rootSpan.spanContext().spanId);
+    assert.equal(rootSpan.attributes['traceroot.source'], 'detector');
+    assert.equal(childSpan.attributes['traceroot.source'], 'detector');
+  });
+
+  it('forced root carries root path attributes (path=[name], ids_path=[])', () => {
+    const root = startSpan({ name: 'run', traceId: RUN_A });
+    root.end();
+    const [s] = exporter.getFinishedSpans();
+    assert.deepEqual(s.attributes['traceroot.span.path'], ['run']);
+    assert.deepEqual(s.attributes['traceroot.span.ids_path'], []);
+  });
+
+  it('grandchildren inherit the forced trace id and full span path', async () => {
+    await observe({ name: 'root', traceId: RUN_A }, async () =>
+      observe({ name: 'child' }, async () => observe({ name: 'grandchild' }, async () => 'ok')),
+    );
+    const spans = exporter.getFinishedSpans();
+    assert.equal(spans.length, 3);
+    for (const s of spans) {
+      assert.equal(s.spanContext().traceId, RUN_A);
+    }
+    const grandchild = spans.find((s) => s.name === 'grandchild');
+    assert.ok(grandchild);
+    assert.deepEqual(grandchild.attributes['traceroot.span.path'], ['root', 'child', 'grandchild']);
+  });
+
+  it('observe() nests under a forced startSpan root via usingSpan', async () => {
+    const root = startSpan({ name: 'run', traceId: RUN_A });
+    await usingSpan(root, () => observe({ name: 'step' }, async () => 'ok'));
+    root.end();
+    const step = exporter.getFinishedSpans().find((s) => s.name === 'step');
+    assert.ok(step);
+    assert.equal(step.spanContext().traceId, RUN_A);
+    assert.equal(step.parentSpanId, root.spanId);
+  });
+
+  it('children created inside a forced async-generator run inherit the id', async () => {
+    async function* gen(): AsyncGenerator<number> {
+      yield await observe({ name: 'inner' }, async () => 1);
+    }
+    const items: number[] = [];
+    for await (const v of observe({ name: 'gen-run', traceId: RUN_A }, gen)) {
+      items.push(v);
+    }
+    assert.deepEqual(items, [1]);
+    const spans = exporter.getFinishedSpans();
+    const genRoot = spans.find((s) => s.name === 'gen-run');
+    const inner = spans.find((s) => s.name === 'inner');
+    assert.ok(genRoot && inner);
+    assert.equal(inner.spanContext().traceId, RUN_A);
+    assert.equal(inner.parentSpanId, genRoot.spanContext().spanId);
+  });
+
+  it('a failing run still exports its forced root with ERROR status', async () => {
+    await assert.rejects(
+      () =>
+        observe({ name: 'run', traceId: RUN_A }, async () => {
+          throw new Error('boom');
+        }),
+      /boom/,
+    );
+    const s = exporter.getFinishedSpans().find((x) => x.name === 'run');
+    assert.ok(s);
+    assert.equal(s.spanContext().traceId, RUN_A);
+    assert.equal(s.status.code, SpanStatusCode.ERROR);
+    assert.equal(s.parentSpanId, undefined);
+  });
+
+  it('an unforced root created after a forced one gets a random trace id (no leakage)', () => {
+    const forced = startSpan({ name: 'forced', traceId: RUN_A });
+    forced.end();
+    const normal = startSpan({ name: 'normal' });
+    normal.end();
+    assert.match(normal.traceId, /^[0-9a-f]{32}$/);
+    assert.notEqual(normal.traceId, RUN_A);
+  });
+
+  it('re-emitting the same run id forces the same trace id with fresh span ids', () => {
+    const first = startSpan({ name: 'run', traceId: RUN_A });
+    first.end();
+    const second = startSpan({ name: 'run', traceId: RUN_A });
+    second.end();
+    const [a, b] = exporter.getFinishedSpans();
+    assert.equal(a.spanContext().traceId, RUN_A);
+    assert.equal(b.spanContext().traceId, RUN_A);
+    assert.notEqual(a.spanContext().spanId, b.spanContext().spanId);
+  });
+
+  it('forced roots get fresh random 16-hex span ids', () => {
+    const root = startSpan({ name: 'run', traceId: RUN_A });
+    root.end();
+    assert.match(root.spanId, /^[0-9a-f]{16}$/);
+  });
+
+  it('environment is dual-written on forced spans', () => {
+    const root = startSpan({ name: 'run', traceId: RUN_A });
+    root.end();
+    const [s] = exporter.getFinishedSpans();
+    assert.equal(s.attributes['deployment.environment'], 'prod');
+    assert.equal(s.attributes['traceroot.environment'], 'prod');
+  });
+});
+
+describe('forcing lifecycle across shutdown()', () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  before(() => {
+    ({ exporter, provider } = registerHarness({ 'traceroot.source': 'detector' }));
+  });
+
+  after(async () => {
+    await teardownHarness(provider);
+  });
+
+  it('forcing stops being honored after shutdown()', async () => {
+    await TraceRoot.shutdown();
+    const messages: string[] = [];
+    const restore = console.warn;
+    console.warn = (...a: unknown[]) => {
+      messages.push(a.map(String).join(' '));
+    };
+    let root;
+    try {
+      root = startSpan({ name: 'after', traceId: RUN_A });
+    } finally {
+      console.warn = restore;
+    }
+    assert.notEqual(root.traceId, RUN_A);
+    assert.ok(messages.some((m) => m.includes('internal export mode')));
+    root.end();
+    exporter.reset();
+  });
+});
+
+describe('globalAttributes precedence', () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  before(() => {
+    ({ exporter, provider } = registerHarness({
+      'traceroot.span.path': 'clobber-attempt',
+      'deployment.environment': 'caller-override',
+      'traceroot.tier': 2,
+      'traceroot.flag': true,
+    }));
+  });
+
+  afterEach(() => {
+    exporter.reset();
+  });
+
+  after(async () => {
+    await teardownHarness(provider);
+  });
+
+  it('cannot clobber structural traceroot.span.* keys (SDK-owned)', () => {
+    const root = startSpan({ name: 'run' });
+    root.end();
+    const [s] = exporter.getFinishedSpans();
+    assert.deepEqual(s.attributes['traceroot.span.path'], ['run']);
+  });
+
+  it('caller globals win over the environment writes (documented behavior)', () => {
+    const root = startSpan({ name: 'run' });
+    root.end();
+    const [s] = exporter.getFinishedSpans();
+    assert.equal(s.attributes['deployment.environment'], 'caller-override');
+    // The dual-write key was not targeted by the caller and keeps the SDK value.
+    assert.equal(s.attributes['traceroot.environment'], 'prod');
+  });
+
+  it('number and boolean attribute values survive the real pipeline', () => {
+    const root = startSpan({ name: 'run' });
+    root.end();
+    const [s] = exporter.getFinishedSpans();
+    assert.equal(s.attributes['traceroot.tier'], 2);
+    assert.equal(s.attributes['traceroot.flag'], true);
+  });
+});

--- a/packages/traceroot/tests/self-tracing.test.ts
+++ b/packages/traceroot/tests/self-tracing.test.ts
@@ -243,6 +243,49 @@ describe('forcing lifecycle across shutdown()', () => {
   });
 });
 
+describe('forcing failure detection (foreign global provider)', () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+
+  before(() => {
+    exporter = new InMemorySpanExporter();
+    // A provider the APPLICATION registered first — default id generator, no
+    // ContextIdGenerator — so TraceRoot's provider never becomes global and
+    // forced ids cannot be applied.
+    provider = new NodeTracerProvider();
+    provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+    provider.register();
+    TraceRoot.initialize({
+      disableBatch: true,
+      internalExport: { path: '/api/v1/internal/traces', projectId: 'p' },
+    });
+  });
+
+  after(async () => {
+    await teardownHarness(provider);
+  });
+
+  it('warns once when the forced id is not applied, and spans still record', async () => {
+    const messages: string[] = [];
+    const restore = console.warn;
+    console.warn = (...a: unknown[]) => {
+      messages.push(a.map(String).join(' '));
+    };
+    let root;
+    try {
+      root = startSpan({ name: 'run', traceId: RUN_A });
+      root.end();
+      await observe({ name: 'run2', traceId: RUN_B }, async () => 'ok');
+    } finally {
+      console.warn = restore;
+    }
+    assert.notEqual(root.traceId, RUN_A);
+    const warned = messages.filter((m) => m.includes('forced traceId was not applied'));
+    assert.equal(warned.length, 1, 'warn-once across both entry points');
+    assert.equal(exporter.getFinishedSpans().length, 2, 'spans still recorded');
+  });
+});
+
 describe('globalAttributes precedence', () => {
   let exporter: InMemorySpanExporter;
   let provider: NodeTracerProvider;

--- a/packages/traceroot/tests/self-tracing.test.ts
+++ b/packages/traceroot/tests/self-tracing.test.ts
@@ -9,7 +9,7 @@ import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-tr
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { TraceRoot, _resetForTesting } from '../src/traceroot';
 import { TraceRootSpanProcessor } from '../src/processor';
-import { ContextIdGenerator } from '../src/trace-id';
+import { ContextIdGenerator, _resetTraceIdState } from '../src/trace-id';
 import { startSpan, usingSpan, _resetSpansState } from '../src/spans';
 import { observe } from '../src/observe';
 
@@ -225,6 +225,7 @@ describe('forcing lifecycle across shutdown()', () => {
 
   it('forcing stops being honored after shutdown()', async () => {
     await TraceRoot.shutdown();
+    _resetTraceIdState(); // order-independence: the warn-once flag may be set by earlier tests
     const messages: string[] = [];
     const restore = console.warn;
     console.warn = (...a: unknown[]) => {

--- a/packages/traceroot/tests/self-tracing.test.ts
+++ b/packages/traceroot/tests/self-tracing.test.ts
@@ -4,7 +4,7 @@
 // runs with trace_id = run_id, a child span per run, and the marker on every span.
 import { after, afterEach, before, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { context, propagation, SpanStatusCode, trace } from '@opentelemetry/api';
+import { context, propagation, ROOT_CONTEXT, SpanStatusCode, trace } from '@opentelemetry/api';
 import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { TraceRoot, _resetForTesting } from '../src/traceroot';
@@ -208,6 +208,27 @@ describe('self-tracing acceptance (worker scenario)', () => {
     const [s] = exporter.getFinishedSpans();
     assert.equal(s.attributes['deployment.environment'], 'prod');
     assert.equal(s.attributes['traceroot.environment'], 'prod');
+  });
+
+  it('forced id does not leak to a detached root created inside the callback', async () => {
+    let innerTraceId = '';
+    await observe({ name: 'detector-run', traceId: RUN_A }, async () => {
+      // A root detached to ROOT_CONTEXT inside the callback, on the same async chain.
+      // It must get its OWN random id — the forced id is scoped to the outer root's
+      // creation, not the whole callback.
+      await context.with(ROOT_CONTEXT, () =>
+        observe({ name: 'inner' }, async () => {
+          innerTraceId = trace.getActiveSpan()!.spanContext().traceId;
+        }),
+      );
+    });
+
+    assert.notEqual(innerTraceId, RUN_A, 'inner detached root must not inherit the forced id');
+    assert.match(innerTraceId, /^[0-9a-f]{32}$/);
+    // The outer forced root still carries the forced id.
+    const outer = exporter.getFinishedSpans().find((s) => s.name === 'detector-run');
+    assert.ok(outer);
+    assert.equal(outer.spanContext().traceId, RUN_A);
   });
 });
 

--- a/packages/traceroot/tests/spans.test.ts
+++ b/packages/traceroot/tests/spans.test.ts
@@ -445,6 +445,20 @@ describe('startSpan() trace-id forcing', () => {
     parent.end();
   });
 
+  it('child handles reject traceId at the type level (and at runtime)', () => {
+    TraceRoot.initialize({
+      disableBatch: true,
+      internalExport: { path: '/api/v1/internal/traces', projectId: 'p' },
+    });
+    const parent = startSpan({ name: 'parent' });
+    assert.throws(
+      // @ts-expect-error traceId is excluded from child-handle startSpan options
+      () => parent.startSpan({ name: 'child', traceId: FORCED }),
+      TypeError,
+    );
+    parent.end();
+  });
+
   it('throws on a malformed forced id', () => {
     TraceRoot.initialize({
       disableBatch: true,

--- a/packages/traceroot/tests/spans.test.ts
+++ b/packages/traceroot/tests/spans.test.ts
@@ -2,13 +2,14 @@ import { afterEach, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { trace } from '@opentelemetry/api';
+import { context, propagation, trace } from '@opentelemetry/api';
 import { applyUsage, applyModel } from '../src/attributes';
 import { startSpan, usingSpan, _resetSpansState } from '../src/spans';
-import { _resetForTesting } from '../src/traceroot';
+import { _resetForTesting, TraceRoot } from '../src/traceroot';
 import { observe, _resetObserveState } from '../src/observe';
 import { getCurrentSpan, updateCurrentSpan } from '../src/context';
 import * as tr from '../src/index';
+import { ContextIdGenerator } from '../src/trace-id';
 
 describe('attribute mapping', () => {
   let exporter: InMemorySpanExporter;
@@ -351,5 +352,104 @@ describe('branch coverage: getCurrentSpan + applyUsage edges', () => {
     assert.equal(s.attributes['llm.token_count.prompt'], 10);
     assert.equal(s.attributes['llm.token_count.prompt_details.cache_read'], 10);
     assert.equal(s.attributes['llm.token_count.completion'], undefined);
+  });
+});
+
+describe('startSpan() trace-id forcing', () => {
+  let exporter: InMemorySpanExporter;
+  let provider: NodeTracerProvider;
+  const FORCED = '11111111111111111111111111111111';
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    // The forcing generator must be on the GLOBALLY REGISTERED provider. The later
+    // TraceRoot.initialize() calls only flip internal-mode state — their register()
+    // is a silent no-op because this provider is already the global one.
+    provider = new NodeTracerProvider({ idGenerator: new ContextIdGenerator() });
+    provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+    provider.register();
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+    exporter.reset();
+    _resetForTesting();
+    _resetSpansState();
+    trace.disable();
+    context.disable();
+    propagation.disable();
+  });
+
+  it('internal mode: forces the root id, children inherit, root exports with no parent', () => {
+    TraceRoot.initialize({
+      disableBatch: true,
+      internalExport: { path: '/api/v1/internal/traces', projectId: 'p' },
+    });
+    const root = startSpan({ name: 'run', traceId: FORCED });
+    assert.equal(root.traceId, FORCED);
+    const child = root.startSpan({ name: 'judge' });
+    assert.equal(child.traceId, FORCED);
+    child.end();
+    root.end();
+
+    const exported = exporter.getFinishedSpans().find((s) => s.name === 'run');
+    assert.ok(exported);
+    assert.equal(exported.spanContext().traceId, FORCED);
+    // Genuine root on the wire — the receiving route keys rootness on absent parent.
+    assert.equal(exported.parentSpanId, undefined);
+  });
+
+  it('forces a fresh root even when called under an active span', () => {
+    TraceRoot.initialize({
+      disableBatch: true,
+      internalExport: { path: '/api/v1/internal/traces', projectId: 'p' },
+    });
+    const ambient = startSpan({ name: 'ambient' });
+    usingSpan(ambient, () => {
+      const root = startSpan({ name: 'run', traceId: FORCED });
+      assert.equal(root.traceId, FORCED);
+      root.end();
+    });
+    ambient.end();
+    const exported = exporter.getFinishedSpans().find((s) => s.name === 'run');
+    assert.ok(exported);
+    assert.equal(exported.parentSpanId, undefined);
+    assert.notEqual(ambient.traceId, FORCED);
+  });
+
+  it('public mode: passing traceId warns and does NOT force', () => {
+    const messages: string[] = [];
+    const restore = console.warn;
+    console.warn = (...a: unknown[]) => {
+      messages.push(a.map(String).join(' '));
+    };
+    let root;
+    try {
+      TraceRoot.initialize({ apiKey: 'k', disableBatch: true });
+      root = startSpan({ name: 'run', traceId: FORCED });
+    } finally {
+      console.warn = restore;
+    }
+    assert.notEqual(root.traceId, FORCED);
+    assert.ok(messages.some((m) => m.includes('internal export mode')));
+    root.end();
+  });
+
+  it('throws when traceId and parent are both provided', () => {
+    TraceRoot.initialize({
+      disableBatch: true,
+      internalExport: { path: '/api/v1/internal/traces', projectId: 'p' },
+    });
+    const parent = startSpan({ name: 'parent' });
+    assert.throws(() => startSpan({ name: 'child', traceId: FORCED, parent }), TypeError);
+    parent.end();
+  });
+
+  it('throws on a malformed forced id', () => {
+    TraceRoot.initialize({
+      disableBatch: true,
+      internalExport: { path: '/api/v1/internal/traces', projectId: 'p' },
+    });
+    assert.throws(() => startSpan({ name: 'run', traceId: 'bad' }), TypeError);
   });
 });

--- a/packages/traceroot/tests/trace-id.test.ts
+++ b/packages/traceroot/tests/trace-id.test.ts
@@ -108,3 +108,34 @@ describe('shouldForceTraceId() gating', () => {
     assert.equal(isInternalMode(), true);
   });
 });
+
+describe('assertValidTraceId() edge cases', () => {
+  it('rejects ids with surrounding whitespace', () => {
+    assert.throws(() => assertValidTraceId(` ${'a'.repeat(31)}`), TypeError);
+    assert.throws(() => assertValidTraceId(`${'a'.repeat(31)} `), TypeError);
+  });
+
+  it('rejects 0x-prefixed ids', () => {
+    assert.throws(() => assertValidTraceId(`0x${'a'.repeat(30)}`), TypeError);
+  });
+});
+
+describe('withForcedTraceId() nesting', () => {
+  const A = 'a'.repeat(32);
+  const B = 'b'.repeat(32);
+
+  it('innermost nested forced scope wins', () => {
+    const g = new ContextIdGenerator();
+    const got = withForcedTraceId(A, () => withForcedTraceId(B, () => g.generateTraceId()));
+    assert.equal(got, B);
+  });
+
+  it('outer forced scope is restored after the inner scope exits', () => {
+    const g = new ContextIdGenerator();
+    const got = withForcedTraceId(A, () => {
+      withForcedTraceId(B, () => g.generateTraceId());
+      return g.generateTraceId();
+    });
+    assert.equal(got, A);
+  });
+});

--- a/packages/traceroot/tests/trace-id.test.ts
+++ b/packages/traceroot/tests/trace-id.test.ts
@@ -6,6 +6,7 @@ import {
   isInternalMode,
   shouldForceTraceId,
   withForcedTraceId,
+  _resetTraceIdState,
   _setInternalMode,
 } from '../src/trace-id';
 
@@ -75,6 +76,7 @@ describe('ContextIdGenerator', () => {
 describe('shouldForceTraceId() gating', () => {
   afterEach(() => {
     _setInternalMode(false);
+    _resetTraceIdState();
   });
 
   it('returns true in internal mode', () => {
@@ -100,6 +102,22 @@ describe('shouldForceTraceId() gating', () => {
 
   it('validates before gating: malformed id throws even outside internal mode', () => {
     assert.throws(() => shouldForceTraceId('nope'), TypeError);
+  });
+
+  it('warns only once for repeated ignored forced ids', () => {
+    const messages: string[] = [];
+    const restore = console.warn;
+    console.warn = (...a: unknown[]) => {
+      messages.push(a.map(String).join(' '));
+    };
+    try {
+      shouldForceTraceId(VALID);
+      shouldForceTraceId(VALID);
+      shouldForceTraceId(VALID);
+    } finally {
+      console.warn = restore;
+    }
+    assert.equal(messages.filter((m) => m.includes('internal export mode')).length, 1);
   });
 
   it('isInternalMode() reflects the setter', () => {


### PR DESCRIPTION
Closes #115. Part 2 of the #116 ← #117 ← #118 stack — base is `feat/self-tracing-internal-mode` (#116's branch), so the diff shows exactly this PR's own 10-commit delta (`traceId` in both entry points, acceptance tests, wire-level transport test, and review-response fixes: initialize/shutdown lifecycle hardening and `internalExport.path` validation).

Exposes deterministic trace-id forcing as a public option on both span entry points, adds an acceptance suite exercising all #115 features together, and bumps the version for the release downstream consumers pin.

## `traceId` on `startSpan()` and `observe()`

Both accept `traceId: <lowercase 32-hex>` to start a **root** span with that exact trace id (so `trace_id` can equal an external run id). Honored only in internal export mode (public mode warns and behaves fully normally); malformed ids throw `TypeError` in any mode — synchronously for both `observe()` overloads. `traceId` is mutually exclusive with `parent`. Forced roots are created against `ROOT_CONTEXT` inside the `AsyncLocalStorage` scope, so concurrent runs cannot swap ids and the exported root carries **no `parentSpanId`** — a genuine root on the wire, asserted in the tests.

## Lost-registration detection

`initialize()` now detects when its tracer provider fails to win the global OTel registration (another provider registered first) — the case that would silently disable trace-id forcing. It logs a `[TraceRoot]` ERROR and exposes the state via a new **`TraceRoot.isTracingActive()`** returning true only when initialized AND our provider actually holds the global registration. Also hardened: a failed `wireInstrumentations()` now rolls back the registration (no half-initialized provider a later `initialize()` would silently lose to), and `shutdown()` releases the global registration so shutdown-then-reinit re-registers cleanly.

## Acceptance suite

`tests/self-tracing.test.ts` drives the real pipeline (provider + generator + processor + in-memory exporter) the way a trusted worker will: two concurrent runs with forced ids and nested children, adapter-shaped `startSpan` usage, deep nesting incl. async-generator children, error paths (failing run still exports its forced root), id-leakage and re-emission guards, and attribute-precedence semantics.

## Release

Carries an intermediate bump to 0.1.8, which is **never published**: the stack releases once, as **`v0.2.0`**, after #118 lands (see the release note there and the merge checklist on #116). Downstream consumers pin `0.2.0`.

Suite: 232 passing (including lifecycle/validation regression tests and a wire-level test that captures the real OTLP request — exact path, headers, gzip body decoded to the forced-id root — and a pin that flush() rejects when the route denies an export), typecheck clean, lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


