### PR TITLE
feat: emit traceroot.span.starts_path with ancestor start times

### DIFF
--- a/packages/mastra/src/exporter.ts
+++ b/packages/mastra/src/exporter.ts
@@ -41,6 +41,7 @@ const TR_ATTRIBUTES = {
   // Span path keys must match TraceRootSpanProcessor (packages/traceroot/src/processor.ts).
   SPAN_PATH: 'traceroot.span.path',
   SPAN_IDS_PATH: 'traceroot.span.ids_path',
+  SPAN_STARTS_PATH: 'traceroot.span.starts_path',
   SDK_NAME: 'traceroot.sdk.name',
   SDK_VERSION: 'traceroot.sdk.version',
   METADATA_PREFIX: 'traceroot.metadata',
@@ -145,6 +146,16 @@ export class TraceRootExporter extends BaseExporter {
   private _namePathBySpanId = new Map<string, string[]>();
   private _idsPathBySpanId = new Map<string, string[]>();
 
+  // Span start times map: M[X] stores the start times of the chain root→X INCLUDING X itself.
+  // Unlike idsPathBySpanId (which stores ancestors only), this map stores including self,
+  // so emitted starts_path(S) = M[parentSpanId] (ancestors), stored M[S] = [...M[parent], S.ownStartNs].
+  // This asymmetry is necessary because trackSpanStart(span) only receives the current span
+  // and has no direct access to the parent object, so it cannot read the parent's startTime.
+  // Mastra's Date provides millisecond precision; we encode as ms→ns: `${ms * 1000000}` via
+  // string concatenation to avoid Number.MAX_SAFE_INTEGER overflow (epoch-ns ≈ 1.7e18 > 9e15).
+  // Keyed by spanId; populated on SPAN_STARTED, consumed on SPAN_ENDED, deleted after export.
+  private _startsPathBySpanId = new Map<string, string[]>();
+
   private resource?: Resource;
   private scope?: InstrumentationScope;
   private processor?: BatchSpanProcessor | SimpleSpanProcessor;
@@ -232,6 +243,7 @@ export class TraceRootExporter extends BaseExporter {
     const parentSpanId = span.parentSpanId;
     const parentNamePath = parentSpanId ? this._namePathBySpanId.get(parentSpanId) : undefined;
     const parentIdsPath = parentSpanId ? this._idsPathBySpanId.get(parentSpanId) : undefined;
+    const parentStartsPath = parentSpanId ? this._startsPathBySpanId.get(parentSpanId) : undefined;
 
     const namePath: string[] = parentNamePath ? [...parentNamePath, span.name] : [span.name];
     const normalizedParentSpanId =
@@ -242,8 +254,27 @@ export class TraceRootExporter extends BaseExporter {
         : [normalizedParentSpanId]
       : [];
 
+    // Compute start times path: M[X] = start times of chain root→X INCLUDING X itself.
+    // The map stores including self (asymmetric with idsPath which stores ancestors only),
+    // so emitted starts_path(S) = M[S].slice(0, -1) (ancestors), stored M[S] = [...M[parent], S.ownStartNs].
+    // We store including self so children can access the parent's time when constructing their chain.
+    // Gate on parentNamePath to match the ids_path logic exactly:
+    // if parent is untracked (parentNamePath undefined), store only self.
+    // Mastra Date is millisecond precision; encode as nanoseconds via string concatenation:
+    // ms→ns = ms * 1_000_000, expressed as `${ms}000000` to avoid overflow.
+    const ownStartNs = `${span.startTime.getTime()}000000`;
+    // Store the full chain including self: [...M[parent], self]
+    // For root (parentNamePath falsy): store [ownStartNs]
+    // For child (parentNamePath truthy): store [...parentStartsPath, ownStartNs]
+    const startsPathWithSelf: string[] = parentNamePath
+      ? parentStartsPath
+        ? [...parentStartsPath, ownStartNs]
+        : [ownStartNs]
+      : [ownStartNs];
+
     this._namePathBySpanId.set(span.id, namePath);
     this._idsPathBySpanId.set(span.id, idsPath);
+    this._startsPathBySpanId.set(span.id, startsPathWithSelf);
   }
 
   private async handleSpanEnded(span: AnyExportedSpan): Promise<void> {
@@ -257,11 +288,15 @@ export class TraceRootExporter extends BaseExporter {
     state.lastTouched = Date.now();
 
     // Capture paths before the finally block cleans the maps.
+    // startsPathFull stores the full chain including self; we emit ancestors only.
     const namePath = this._namePathBySpanId.get(span.id);
     const idsPath = this._idsPathBySpanId.get(span.id);
+    const startsPathFull = this._startsPathBySpanId.get(span.id);
+    // Emit ancestors only (drop the last element which is self)
+    const startsPath = startsPathFull ? startsPathFull.slice(0, -1) : undefined;
 
     try {
-      const otelSpan = this.convertToOtelSpan(span, namePath, idsPath);
+      const otelSpan = this.convertToOtelSpan(span, namePath, idsPath, startsPath);
       this.processor.onEnd(otelSpan);
 
       if (this.resolvedConfig.realtime) {
@@ -281,6 +316,7 @@ export class TraceRootExporter extends BaseExporter {
       }
       this._namePathBySpanId.delete(span.id);
       this._idsPathBySpanId.delete(span.id);
+      this._startsPathBySpanId.delete(span.id);
     }
   }
 
@@ -295,6 +331,7 @@ export class TraceRootExporter extends BaseExporter {
         for (const orphanId of state.knownSpanIds) {
           this._namePathBySpanId.delete(orphanId);
           this._idsPathBySpanId.delete(orphanId);
+          this._startsPathBySpanId.delete(orphanId);
         }
         this.traceMap.delete(traceId);
       }
@@ -325,6 +362,7 @@ export class TraceRootExporter extends BaseExporter {
     span: AnyExportedSpan,
     namePath?: string[],
     idsPath?: string[],
+    startsPath?: string[],
   ): ReadableSpan {
     const resource = this.getResource();
     const instrumentationScope = this.getScope();
@@ -356,7 +394,7 @@ export class TraceRootExporter extends BaseExporter {
       startTime,
       endTime,
       status,
-      attributes: buildTraceRootAttributes(span, namePath, idsPath),
+      attributes: buildTraceRootAttributes(span, namePath, idsPath, startsPath),
       links,
       events,
       duration,
@@ -420,6 +458,7 @@ export class TraceRootExporter extends BaseExporter {
       this.traceMap.clear();
       this._namePathBySpanId.clear();
       this._idsPathBySpanId.clear();
+      this._startsPathBySpanId.clear();
       await super.shutdown();
     }
   }
@@ -433,6 +472,7 @@ function buildTraceRootAttributes(
   span: AnyExportedSpan,
   namePath?: string[],
   idsPath?: string[],
+  startsPath?: string[],
 ): Attributes {
   const attrs: Attributes = {};
 
@@ -486,6 +526,7 @@ function buildTraceRootAttributes(
   // Mirrors the Map-based path propagation in TraceRootSpanProcessor (PR #71).
   if (namePath !== undefined) attrs[TR_ATTRIBUTES.SPAN_PATH] = namePath;
   if (idsPath !== undefined) attrs[TR_ATTRIBUTES.SPAN_IDS_PATH] = idsPath;
+  if (startsPath !== undefined) attrs[TR_ATTRIBUTES.SPAN_STARTS_PATH] = startsPath;
 
   return attrs;
 }

--- a/packages/mastra/tests/exporter-starts-path.test.ts
+++ b/packages/mastra/tests/exporter-starts-path.test.ts
@@ -1,0 +1,543 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { SpanType, TracingEventType } from '@mastra/core/observability';
+import type { AnyExportedSpan } from '@mastra/core/observability';
+import type { SpanExporter, ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { TraceRootExporter } from '../src/exporter';
+
+// ---------------------------------------------------------------------------
+// Capturing exporter — injected via _spanExporter to avoid OTLP network calls
+// ---------------------------------------------------------------------------
+
+class CapturingExporter implements SpanExporter {
+  readonly spans: ReadableSpan[] = [];
+  export(spans: ReadableSpan[], cb: (result: { code: number }) => void): void {
+    this.spans.push(...spans);
+    cb({ code: 0 });
+  }
+  async shutdown(): Promise<void> {}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let _seq = 2000;
+function uid(): string {
+  return (++_seq).toString(16).padStart(16, '0');
+}
+
+function makeRig() {
+  const capture = new CapturingExporter();
+  const exporter = new TraceRootExporter({
+    apiKey: 'test-key',
+    disableBatch: true,
+    _spanExporter: capture,
+  });
+  exporter.init({ config: { serviceName: 'test' } } as Parameters<typeof exporter.init>[0]);
+  return { exporter, capture };
+}
+
+function makeSpan(opts: {
+  id?: string;
+  traceId?: string;
+  parentSpanId?: string;
+  name?: string;
+  type?: SpanType;
+  isEvent?: boolean;
+  startTime?: Date;
+}): AnyExportedSpan {
+  const now = opts.startTime ?? new Date();
+  return {
+    id: opts.id ?? uid(),
+    traceId: opts.traceId ?? uid(),
+    parentSpanId: opts.parentSpanId,
+    name: opts.name ?? 'span',
+    type: opts.type ?? SpanType.AGENT_RUN,
+    isEvent: opts.isEvent ?? false,
+    isRootSpan: !opts.parentSpanId,
+    startTime: now,
+    endTime: new Date(now.getTime() + 10),
+    input: undefined,
+    output: undefined,
+    metadata: undefined,
+    errorInfo: undefined,
+    attributes: undefined,
+    requestContext: undefined,
+  } as unknown as AnyExportedSpan;
+}
+
+async function startSpan(exporter: TraceRootExporter, span: AnyExportedSpan): Promise<void> {
+  await (
+    exporter as unknown as { _exportTracingEvent(e: unknown): Promise<void> }
+  )._exportTracingEvent({
+    type: TracingEventType.SPAN_STARTED,
+    exportedSpan: span,
+  });
+}
+
+async function endSpan(exporter: TraceRootExporter, span: AnyExportedSpan): Promise<void> {
+  await (
+    exporter as unknown as { _exportTracingEvent(e: unknown): Promise<void> }
+  )._exportTracingEvent({
+    type: TracingEventType.SPAN_ENDED,
+    exportedSpan: span,
+  });
+}
+
+async function runSpan(exporter: TraceRootExporter, span: AnyExportedSpan): Promise<void> {
+  await startSpan(exporter, span);
+  await endSpan(exporter, span);
+}
+
+function getAttrs(capture: CapturingExporter, index?: number): Record<string, unknown> {
+  const i = index ?? capture.spans.length - 1;
+  return (capture.spans[i]?.attributes ?? {}) as Record<string, unknown>;
+}
+
+function startsPathMap(exporter: TraceRootExporter) {
+  const e = exporter as unknown as {
+    _startsPathBySpanId: Map<string, string[]>;
+  };
+  return e._startsPathBySpanId;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Basic starts_path computation
+// ---------------------------------------------------------------------------
+
+describe('starts_path computation', () => {
+  it('root span: starts_path=[]', async () => {
+    const { exporter, capture } = makeRig();
+    const traceId = uid();
+    const root = makeSpan({ traceId, name: 'agent-run' });
+    await runSpan(exporter, root);
+    const attrs = getAttrs(capture);
+    assert.deepEqual(attrs['traceroot.span.starts_path'], []);
+  });
+
+  it('child span: starts_path=[root.startTimeNs]', async () => {
+    const { exporter, capture } = makeRig();
+    const traceId = uid();
+    const rootTime = new Date('2025-01-15T10:30:45.123Z');
+    const root = makeSpan({ traceId, name: 'agent-run', startTime: rootTime });
+    const child = makeSpan({ traceId, parentSpanId: root.id, name: 'model-gen' });
+    await startSpan(exporter, root);
+    await startSpan(exporter, child);
+    await endSpan(exporter, child);
+    const attrs = getAttrs(capture);
+    assert.deepEqual(attrs['traceroot.span.starts_path'], [`${rootTime.getTime()}000000`]);
+  });
+
+  it('grandchild span: starts_path=[root.startTimeNs, child.startTimeNs]', async () => {
+    const { exporter, capture } = makeRig();
+    const traceId = uid();
+    const rootTime = new Date('2025-01-15T10:30:45.123Z');
+    const childTime = new Date('2025-01-15T10:30:46.456Z');
+    const root = makeSpan({ traceId, name: 'agent-run', startTime: rootTime });
+    const child = makeSpan({
+      traceId,
+      parentSpanId: root.id,
+      name: 'model-gen',
+      startTime: childTime,
+    });
+    const grandchild = makeSpan({
+      traceId,
+      parentSpanId: child.id,
+      name: 'model-step',
+    });
+    await startSpan(exporter, root);
+    await startSpan(exporter, child);
+    await startSpan(exporter, grandchild);
+    await endSpan(exporter, grandchild);
+    const attrs = getAttrs(capture);
+    assert.deepEqual(attrs['traceroot.span.starts_path'], [
+      `${rootTime.getTime()}000000`,
+      `${childTime.getTime()}000000`,
+    ]);
+  });
+
+  it('siblings get independent starts_path', async () => {
+    const { exporter, capture } = makeRig();
+    const traceId = uid();
+    const rootTime = new Date('2025-01-15T10:30:45.000Z');
+    const root = makeSpan({ traceId, name: 'agent-run', startTime: rootTime });
+    const s1 = makeSpan({ traceId, parentSpanId: root.id, name: 'step-1' });
+    const s2 = makeSpan({ traceId, parentSpanId: root.id, name: 'step-2' });
+    await startSpan(exporter, root);
+    await startSpan(exporter, s1);
+    await startSpan(exporter, s2);
+    await endSpan(exporter, s1);
+    await endSpan(exporter, s2);
+    // Both siblings should have the same root start time in their starts_path
+    assert.deepEqual(getAttrs(capture, 0)['traceroot.span.starts_path'], [
+      `${rootTime.getTime()}000000`,
+    ]);
+    assert.deepEqual(getAttrs(capture, 1)['traceroot.span.starts_path'], [
+      `${rootTime.getTime()}000000`,
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. ms→ns encoding correctness
+// ---------------------------------------------------------------------------
+
+describe('ms→ns encoding', () => {
+  it('encodes milliseconds to nanoseconds as string: ms * 1_000_000', async () => {
+    const { exporter, capture } = makeRig();
+    const traceId = uid();
+    const rootTime = new Date('2025-01-15T10:30:45.789Z'); // 789 ms
+    const root = makeSpan({ traceId, name: 'root', startTime: rootTime });
+    const child = makeSpan({ traceId, parentSpanId: root.id, name: 'child' });
+    await startSpan(exporter, root);
+    await startSpan(exporter, child);
+    await endSpan(exporter, child);
+    const attrs = getAttrs(capture);
+    const startsPath = attrs['traceroot.span.starts_path'] as string[];
+    const rootStartMs = rootTime.getTime();
+    const expectedNs = `${rootStartMs}000000`;
+    assert.equal(startsPath[0], expectedNs, 'should encode as string: ms + 6 zeros');
+  });
+
+  it('produces 19-digit decimal string (epoch-ns)', async () => {
+    const { exporter, capture } = makeRig();
+    const traceId = uid();
+    const rootTime = new Date(); // current time
+    const root = makeSpan({ traceId, name: 'root', startTime: rootTime });
+    const child = makeSpan({ traceId, parentSpanId: root.id, name: 'child' });
+    await startSpan(exporter, root);
+    await startSpan(exporter, child);
+    await endSpan(exporter, child);
+    const attrs = getAttrs(capture);
+    const startsPath = attrs['traceroot.span.starts_path'] as string[];
+    assert.ok(startsPath.length > 0);
+    const nsString = startsPath[0];
+    // epoch-ns is ~1.7e18, so ~19 digits
+    assert.ok(nsString.match(/^\d{19}$/), `${nsString} should be exactly 19 decimal digits`);
+  });
+
+  it('is always a string, never a number', async () => {
+    const { exporter, capture } = makeRig();
+    const traceId = uid();
+    const root = makeSpan({ traceId, name: 'root' });
+    const child = makeSpan({ traceId, parentSpanId: root.id, name: 'child' });
+    await startSpan(exporter, root);
+    await startSpan(exporter, child);
+    await endSpan(exporter, child);
+    const attrs = getAttrs(capture);
+    const startsPath = attrs['traceroot.span.starts_path'] as string[];
+    assert.ok(typeof startsPath[0] === 'string');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Gating logic: starts_path mirrors ids_path gate
+// ---------------------------------------------------------------------------
+
+describe('gating: starts_path mirrors ids_path', () => {
+  it('orphaned child (unknown parent): starts_path=[]', async () => {
+    const { exporter, capture } = makeRig();
+    const traceId = uid();
+    const orphan = makeSpan({ traceId, parentSpanId: uid(), name: 'orphan' });
+    await runSpan(exporter, orphan);
+    const attrs = getAttrs(capture);
+    assert.deepEqual(attrs['traceroot.span.starts_path'], []);
+    // Verify ids_path is also [] (they should gate the same way)
+    assert.deepEqual(attrs['traceroot.span.ids_path'], []);
+  });
+
+  it('starts_path.length === ids_path.length always', async () => {
+    const { exporter, capture } = makeRig();
+    const traceId = uid();
+    const root = makeSpan({ traceId, name: 'root' });
+    const child = makeSpan({ traceId, parentSpanId: root.id, name: 'child' });
+    const grandchild = makeSpan({ traceId, parentSpanId: child.id, name: 'grandchild' });
+    const untracked = makeSpan({ traceId, parentSpanId: uid(), name: 'untracked' });
+
+    await startSpan(exporter, root);
+    await startSpan(exporter, child);
+    await startSpan(exporter, grandchild);
+    await runSpan(exporter, untracked);
+
+    await endSpan(exporter, grandchild);
+    await endSpan(exporter, child);
+
+    // Check all exported spans: length invariant must hold
+    for (let i = 0; i < capture.spans.length; i++) {
+      const attrs = getAttrs(capture, i);
+      const startsPath = attrs['traceroot.span.starts_path'] as string[] | undefined;
+      const idsPath = attrs['traceroot.span.ids_path'] as string[] | undefined;
+      if (startsPath !== undefined && idsPath !== undefined) {
+        assert.equal(
+          startsPath.length,
+          idsPath.length,
+          `at index ${i}: starts_path.length should equal ids_path.length`,
+        );
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Cleanup at all three sites
+// ---------------------------------------------------------------------------
+
+describe('memory cleanup for starts_path', () => {
+  it('map is empty after span ends (handleSpanEnded finally)', async () => {
+    const { exporter } = makeRig();
+    const traceId = uid();
+    const root = makeSpan({ traceId, name: 'root' });
+    await runSpan(exporter, root);
+    const map = startsPathMap(exporter);
+    assert.equal(map.size, 0, 'map should be empty after span ends');
+  });
+
+  it('nested spans clean up map progressively on each end', async () => {
+    const { exporter } = makeRig();
+    const traceId = uid();
+    const root = makeSpan({ traceId, name: 'root' });
+    const child = makeSpan({ traceId, parentSpanId: root.id, name: 'child' });
+    await startSpan(exporter, root);
+    await startSpan(exporter, child);
+
+    const map = startsPathMap(exporter);
+    assert.equal(map.size, 2, 'both spans in map after start');
+
+    await endSpan(exporter, child);
+    assert.equal(map.size, 1, 'child cleaned after end');
+
+    await endSpan(exporter, root);
+    assert.equal(map.size, 0, 'root cleaned after end');
+  });
+
+  it('shutdown clears map even for in-flight spans', async () => {
+    const { exporter } = makeRig();
+    const traceId = uid();
+    const root = makeSpan({ traceId, name: 'root' });
+    await startSpan(exporter, root);
+    const map = startsPathMap(exporter);
+    assert.equal(map.size, 1);
+    await exporter.shutdown();
+    assert.equal(map.size, 0, 'map cleared by shutdown');
+  });
+
+  it('TTL eviction cleans up stale starts_path entries', async () => {
+    const { exporter } = makeRig();
+
+    // Create 65 orphaned traces (above SWEEP_THRESHOLD=64)
+    for (let i = 0; i < 65; i++) {
+      await startSpan(exporter, makeSpan({ name: `orphan-${i}` }));
+    }
+
+    const mapBefore = startsPathMap(exporter);
+    assert.equal(mapBefore.size, 65);
+
+    // Backdate all traces past TTL
+    const longAgo = Date.now() - 10 * 60 * 1000;
+    const reach = exporter as unknown as {
+      traceMap: Map<string, { lastTouched: number }>;
+    };
+    for (const state of reach.traceMap.values()) {
+      state.lastTouched = longAgo;
+    }
+
+    // Trigger sweep
+    await startSpan(exporter, makeSpan({ name: 'fresh' }));
+
+    const mapAfter = startsPathMap(exporter);
+    assert.equal(mapAfter.size, 1, 'stale entries swept, only fresh span remains');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Co-existence with path and ids_path
+// ---------------------------------------------------------------------------
+
+describe('starts_path co-existence with path and ids_path', () => {
+  it('all three path attrs present together on child span', async () => {
+    const { exporter, capture } = makeRig();
+    const traceId = uid();
+    const root = makeSpan({ traceId, name: 'agent-run' });
+    const child = makeSpan({ traceId, parentSpanId: root.id, name: 'model-gen' });
+    await startSpan(exporter, root);
+    await startSpan(exporter, child);
+    await endSpan(exporter, child);
+    const attrs = getAttrs(capture);
+    assert.ok(Array.isArray(attrs['traceroot.span.path']));
+    assert.ok(Array.isArray(attrs['traceroot.span.ids_path']));
+    assert.ok(Array.isArray(attrs['traceroot.span.starts_path']));
+  });
+
+  it('root span: path and ids_path non-empty, starts_path empty', async () => {
+    const { exporter, capture } = makeRig();
+    const traceId = uid();
+    const root = makeSpan({ traceId, name: 'root' });
+    await runSpan(exporter, root);
+    const attrs = getAttrs(capture);
+    assert.deepEqual(attrs['traceroot.span.path'], ['root']);
+    assert.deepEqual(attrs['traceroot.span.ids_path'], []);
+    assert.deepEqual(attrs['traceroot.span.starts_path'], []);
+  });
+
+  it('event span: no starts_path attr', async () => {
+    const { exporter, capture } = makeRig();
+    const traceId = uid();
+    const root = makeSpan({ traceId, name: 'root' });
+    const evt = makeSpan({ traceId, parentSpanId: root.id, name: 'chunk', isEvent: true });
+    await startSpan(exporter, root);
+    await startSpan(exporter, evt);
+    await endSpan(exporter, evt);
+    const attrs = getAttrs(capture);
+    assert.equal(attrs['traceroot.span.starts_path'], undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Out-of-order ending
+// ---------------------------------------------------------------------------
+
+describe('out-of-order ending preserves starts_path', () => {
+  it('child starts_path survives parent ending first', async () => {
+    const { exporter, capture } = makeRig();
+    const traceId = uid();
+    const rootTime = new Date('2025-01-15T10:30:45.000Z');
+    const parent = makeSpan({ traceId, name: 'parent', startTime: rootTime });
+    const child = makeSpan({ traceId, parentSpanId: parent.id, name: 'child' });
+
+    await startSpan(exporter, parent);
+    await startSpan(exporter, child);
+    await endSpan(exporter, parent); // parent ends first
+    await endSpan(exporter, child); // child ends after
+
+    // child should still have correct starts_path
+    assert.deepEqual(getAttrs(capture, 1)['traceroot.span.starts_path'], [
+      `${rootTime.getTime()}000000`,
+    ]);
+  });
+
+  it('grandchild starts_path survives parent and grandparent ending first', async () => {
+    const { exporter, capture } = makeRig();
+    const traceId = uid();
+    const rootTime = new Date('2025-01-15T10:30:45.100Z');
+    const midTime = new Date('2025-01-15T10:30:46.200Z');
+    const root = makeSpan({ traceId, name: 'root', startTime: rootTime });
+    const mid = makeSpan({
+      traceId,
+      parentSpanId: root.id,
+      name: 'mid',
+      startTime: midTime,
+    });
+    const leaf = makeSpan({ traceId, parentSpanId: mid.id, name: 'leaf' });
+
+    await startSpan(exporter, root);
+    await startSpan(exporter, mid);
+    await startSpan(exporter, leaf);
+    await endSpan(exporter, root);
+    await endSpan(exporter, mid);
+    await endSpan(exporter, leaf);
+
+    const leafAttrs = getAttrs(capture, 2);
+    assert.deepEqual(leafAttrs['traceroot.span.starts_path'], [
+      `${rootTime.getTime()}000000`,
+      `${midTime.getTime()}000000`,
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Deep nesting
+// ---------------------------------------------------------------------------
+
+describe('deep nesting with starts_path', () => {
+  it('10-level hierarchy: leaf gets correct starts_path with 9 ancestors', async () => {
+    const { exporter, capture } = makeRig();
+    const traceId = uid();
+    const times: Date[] = [];
+    const spans: AnyExportedSpan[] = [];
+
+    for (let i = 0; i < 10; i++) {
+      const time = new Date(Date.now() + i * 1000); // each 1s apart
+      times.push(time);
+      spans.push(
+        makeSpan({ traceId, parentSpanId: spans[i - 1]?.id, name: `level-${i}`, startTime: time }),
+      );
+    }
+
+    for (const span of spans) await startSpan(exporter, span);
+    await endSpan(exporter, spans[9]);
+
+    const attrs = getAttrs(capture);
+    const startsPath = attrs['traceroot.span.starts_path'] as string[];
+    assert.equal(startsPath.length, 9, 'should have 9 ancestor start times');
+    for (let i = 0; i < 9; i++) {
+      assert.equal(startsPath[i], `${times[i].getTime()}000000`);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. SPAN_ENDED without SPAN_STARTED
+// ---------------------------------------------------------------------------
+
+describe('SPAN_ENDED without SPAN_STARTED', () => {
+  it('orphaned end has no starts_path attr', async () => {
+    const { exporter, capture } = makeRig();
+    const span = makeSpan({ name: 'unstarted' });
+    await endSpan(exporter, span);
+    const attrs = getAttrs(capture);
+    assert.equal(attrs['traceroot.span.starts_path'], undefined);
+  });
+
+  it('map is empty after orphaned end', async () => {
+    const { exporter } = makeRig();
+    const span = makeSpan({ name: 'unstarted' });
+    await endSpan(exporter, span);
+    const map = startsPathMap(exporter);
+    assert.equal(map.size, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Mastra span tree: AGENT_RUN → MODEL_GENERATION → MODEL_STEP
+// ---------------------------------------------------------------------------
+
+describe('Mastra span tree with starts_path', () => {
+  it('AGENT_RUN → MODEL_GENERATION → MODEL_STEP gets correct starts_path chain', async () => {
+    const { exporter, capture } = makeRig();
+    const traceId = uid();
+    const agentTime = new Date('2025-01-15T10:30:45.000Z');
+    const modelTime = new Date('2025-01-15T10:30:46.500Z');
+
+    const agentRun = makeSpan({
+      traceId,
+      name: 'myAgent',
+      type: SpanType.AGENT_RUN,
+      startTime: agentTime,
+    });
+    const modelGen = makeSpan({
+      traceId,
+      parentSpanId: agentRun.id,
+      name: 'model-generation',
+      type: SpanType.MODEL_GENERATION,
+      startTime: modelTime,
+    });
+    const modelStep = makeSpan({
+      traceId,
+      parentSpanId: modelGen.id,
+      name: 'model-step',
+      type: SpanType.MODEL_STEP,
+    });
+
+    await startSpan(exporter, agentRun);
+    await startSpan(exporter, modelGen);
+    await startSpan(exporter, modelStep);
+    await endSpan(exporter, modelStep);
+
+    const attrs = getAttrs(capture);
+    assert.deepEqual(attrs['traceroot.span.starts_path'], [
+      `${agentTime.getTime()}000000`,
+      `${modelTime.getTime()}000000`,
+    ]);
+  });
+});

--- a/packages/traceroot/src/processor.ts
+++ b/packages/traceroot/src/processor.ts
@@ -30,6 +30,11 @@ export class TraceRootSpanProcessor implements SpanProcessor {
   // what OpenInference produces for LangGraph-instrumented node spans.
   private readonly _idsPathBySpanId = new Map<string, string[]>();
   private readonly _namePathBySpanId = new Map<string, string[]>();
+  // Keyed by spanId. Stores the full ancestor chain start times INCLUDING self.
+  // Used to emit starts_path on children (ancestors only), mirroring ids_path behavior.
+  // Unlike ids_path, this must store self because parent may be a NonRecordingSpan
+  // with no reachable startTime attribute — map-based lookup is the only path to root.
+  private readonly _startsPathBySpanId = new Map<string, string[]>();
 
   constructor(
     inner: SpanProcessor, // ← WIDENED
@@ -87,6 +92,64 @@ export class TraceRootSpanProcessor implements SpanProcessor {
       (parentSpanId && this._idsPathBySpanId.get(parentSpanId)) ||
       (parentSpan?.attributes?.['traceroot.span.ids_path'] as string[] | undefined);
 
+    // Read startTime (OTel HrTime = [seconds, nanoseconds]). Like name and parentSpanId,
+    // startTime is a stable internal SDK field not on the public @opentelemetry/api interface.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const spanStartTime: [number, number] | undefined = (span as any).startTime as
+      | [number, number]
+      | undefined;
+
+    // Encode HrTime to epoch nanoseconds as a string to avoid Number precision loss.
+    // MAX_SAFE_INTEGER (~9.0e15) < current epoch-ns (~1.7e18), so arithmetic is unsafe.
+    // STRING concatenation preserves all 19 digits: seconds (10 digits) + nanos (9 digits).
+    let spanStartTimeNs: string = '';
+    if (spanStartTime && spanStartTime.length >= 2) {
+      const [seconds, nanos] = spanStartTime;
+      spanStartTimeNs = `${seconds}${String(nanos).padStart(9, '0')}`;
+    }
+
+    // Fetch parent's full start chain (root→parent, INCLUDING parent's own start).
+    // Prefer the map (for NonRecordingSpan parents) over span attributes.
+    // CRITICAL: map and attribute values are asymmetric:
+    //   - map[P] = [root_start, ..., parent_start]         (incl-self)
+    //   - attribute = [root_start, ...]                     (ancestors only, excl-self)
+    // If attribute fallback fires (parent ended/deleted from map), reconstruct the
+    // incl-self value by appending the parent's own encoded start time.
+    // If parent's startTime is not readable, treat fallback as unavailable to avoid
+    // emitting a misaligned array that would break frontend index-pairing with ids_path.
+    let parentStartsPath: string[] | undefined = parentSpanId
+      ? this._startsPathBySpanId.get(parentSpanId)
+      : undefined;
+    if (!parentStartsPath && parentSpan) {
+      // Validate at runtime: `attributes` is an untrusted boundary. Any instrumented
+      // application can set `traceroot.span.starts_path` to any AttributeValue, and the
+      // `as string[]` cast that used to sit here is erased at compile time — it checks
+      // nothing. Spreading a non-iterable (number, null, object) throws a TypeError
+      // inside onStart, which runs synchronously within the caller's startSpan(), so the
+      // exception surfaces as a crash in application code rather than a dropped span.
+      // Require a homogeneous string array so we also never propagate a value that
+      // violates the emitted contract downstream.
+      const rawAncestors = parentSpan.attributes?.['traceroot.span.starts_path'];
+      const attributeAncestors: string[] | undefined =
+        Array.isArray(rawAncestors) && rawAncestors.every((entry) => typeof entry === 'string')
+          ? (rawAncestors as string[])
+          : undefined;
+      if (attributeAncestors !== undefined) {
+        // Reconstruct full chain by appending parent's own start time
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const parentStartTime: [number, number] | undefined = (parentSpan as any).startTime as
+          | [number, number]
+          | undefined;
+        if (parentStartTime && parentStartTime.length >= 2) {
+          const [parentSeconds, parentNanos] = parentStartTime;
+          const parentStartTimeNs = `${parentSeconds}${String(parentNanos).padStart(9, '0')}`;
+          parentStartsPath = [...attributeAncestors, parentStartTimeNs];
+        }
+        // If parent's startTime is not readable, treat fallback as unavailable (safer than
+        // emitting a misaligned array that would pair wrong starts with wrong ancestor ids)
+      }
+    }
+
     const spanPath: string[] = parentPath ? [...parentPath, spanName] : [spanName];
     // Gate on parentPath (not just parentSpanId) so path and ids_path stay in sync:
     // if path resolution failed (map miss + NonRecordingSpan), treat this span as a
@@ -98,8 +161,23 @@ export class TraceRootSpanProcessor implements SpanProcessor {
           : [parentSpanId]
         : [];
 
+    // Build starts_path for emission (ancestors only, matching ids_path gating exactly).
+    // Invariant: starts_path.length must equal ids_path.length. This means:
+    // - If ids_path is [], emit []. If parent resolution failed and ids_path = [], emit [].
+    // - If ids_path has items, emit parentStartsPath (which has len(parentIds) items).
+    // We store the full chain (root→self) in the map for descendants, but emit ancestors only.
+    let spanStartsPath: string[] = parentPath && parentSpanId ? parentStartsPath || [] : [];
+
+    // EXPLICIT ALIGNMENT GUARD: defend the frontend's index-pairing assumption against
+    // any future divergence between ids_path and starts_path code paths. If lengths don't
+    // match, degrade to [] to prevent applying wrong starts to wrong ancestor ids.
+    if (spanStartsPath.length !== spanIdsPath.length) {
+      spanStartsPath = [];
+    }
+
     span.setAttribute('traceroot.span.path', spanPath);
     span.setAttribute('traceroot.span.ids_path', spanIdsPath);
+    span.setAttribute('traceroot.span.starts_path', spanStartsPath);
 
     // Store paths so descendant spans can inherit them via map lookup.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -108,6 +186,12 @@ export class TraceRootSpanProcessor implements SpanProcessor {
     if (spanId) {
       this._namePathBySpanId.set(spanId, spanPath);
       this._idsPathBySpanId.set(spanId, spanIdsPath);
+      // Append this span's start time to get the full chain (root→self) for descendant lookup.
+      // If start time encoding failed (unlikely), store just the ancestors so map still works.
+      const fullStartsChain: string[] = spanStartTimeNs
+        ? [...spanStartsPath, spanStartTimeNs]
+        : spanStartsPath;
+      this._startsPathBySpanId.set(spanId, fullStartsChain);
     }
 
     // Cast required: inner processor expects the internal sdk-trace-base Span,
@@ -123,6 +207,7 @@ export class TraceRootSpanProcessor implements SpanProcessor {
     const spanId = span.spanContext().spanId;
     this._idsPathBySpanId.delete(spanId);
     this._namePathBySpanId.delete(spanId);
+    this._startsPathBySpanId.delete(spanId);
     this.inner.onEnd(span);
   }
 

--- a/packages/traceroot/tests/processor.test.ts
+++ b/packages/traceroot/tests/processor.test.ts
@@ -263,4 +263,488 @@ describe('TraceRootSpanProcessor', () => {
       assert.deepEqual(c2.attributes['traceroot.span.ids_path'], [rootId!, midId!]);
     });
   });
+
+  describe('starts_path propagation', () => {
+    it('root span gets empty starts_path', async () => {
+      const tracer = trace.getTracer('test');
+      await new Promise<void>((resolve) => {
+        tracer.startActiveSpan('root', (span) => {
+          span.end();
+          resolve();
+        });
+      });
+      const [span] = exporter.getFinishedSpans();
+      assert.deepEqual(span.attributes['traceroot.span.starts_path'], []);
+    });
+
+    it('child starts_path includes parent start time in epoch nanoseconds', async () => {
+      const tracer = trace.getTracer('test');
+      let rootStartTime: [number, number] | undefined;
+      await new Promise<void>((resolve) => {
+        tracer.startActiveSpan('root', (root) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          rootStartTime = (root as any).startTime;
+          tracer.startActiveSpan('child', (child) => {
+            child.end();
+            root.end();
+            resolve();
+          });
+        });
+      });
+      const [child] = exporter.getFinishedSpans();
+      const childStartsPath = child.attributes['traceroot.span.starts_path'] as string[];
+      assert.ok(Array.isArray(childStartsPath), 'starts_path should be an array');
+      assert.equal(childStartsPath.length, 1, 'child of root should have 1 item in starts_path');
+
+      // Verify the exact encoding: epoch nanoseconds as string with no precision loss
+      if (rootStartTime && rootStartTime.length >= 2) {
+        const [seconds, nanos] = rootStartTime;
+        const expectedNs = `${seconds}${String(nanos).padStart(9, '0')}`;
+        assert.equal(
+          childStartsPath[0],
+          expectedNs,
+          'starts_path[0] should be epoch nanoseconds (19 digits max)',
+        );
+        // Verify string has no float rounding: exactly 10+9=19 digits (or less if seconds is < 10 digits)
+        assert.equal(
+          childStartsPath[0].length,
+          expectedNs.length,
+          'nanosecond encoding should preserve exact digit count',
+        );
+      }
+    });
+
+    it('deeply nested span accumulates full ancestor start time chain', async () => {
+      const tracer = trace.getTracer('test');
+      const startTimes: Array<[number, number]> = [];
+      await new Promise<void>((resolve) => {
+        tracer.startActiveSpan('root', (root) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          startTimes.push((root as any).startTime);
+          tracer.startActiveSpan('mid', (mid) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            startTimes.push((mid as any).startTime);
+            tracer.startActiveSpan('leaf', (leaf) => {
+              leaf.end();
+              mid.end();
+              root.end();
+              resolve();
+            });
+          });
+        });
+      });
+      const [leaf] = exporter.getFinishedSpans();
+      const leafStartsPath = leaf.attributes['traceroot.span.starts_path'] as string[];
+      assert.equal(leafStartsPath.length, 2, 'leaf should have 2 ancestors');
+
+      // Verify each encoded start time matches the expected format
+      for (let i = 0; i < startTimes.length; i++) {
+        const [seconds, nanos] = startTimes[i];
+        const expectedNs = `${seconds}${String(nanos).padStart(9, '0')}`;
+        assert.equal(
+          leafStartsPath[i],
+          expectedNs,
+          `starts_path[${i}] should match encoded ancestor start time`,
+        );
+      }
+    });
+
+    it('starts_path length always equals ids_path length', async () => {
+      const tracer = trace.getTracer('test');
+      await new Promise<void>((resolve) => {
+        tracer.startActiveSpan('root', (root) => {
+          tracer.startActiveSpan('mid', (mid) => {
+            tracer.startActiveSpan('leaf', (leaf) => {
+              leaf.end();
+              mid.end();
+              root.end();
+              resolve();
+            });
+          });
+        });
+      });
+      const spans = exporter.getFinishedSpans();
+      for (const span of spans) {
+        const idsPath = span.attributes['traceroot.span.ids_path'] as string[];
+        const startsPath = span.attributes['traceroot.span.starts_path'] as string[];
+        assert.equal(
+          startsPath.length,
+          idsPath.length,
+          `${span.name}: starts_path.length (${startsPath.length}) must equal ids_path.length (${idsPath.length})`,
+        );
+      }
+    });
+
+    it('remote parent child inherits starts_path from map', async () => {
+      const tracer = trace.getTracer('test');
+      let rootStartTime: [number, number] | undefined;
+      let midStartTime: [number, number] | undefined;
+      let midId: string;
+
+      await new Promise<void>((resolve) => {
+        tracer.startActiveSpan('root', (root) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          rootStartTime = (root as any).startTime;
+          tracer.startActiveSpan('mid', (mid) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            midStartTime = (mid as any).startTime;
+            midId = mid.spanContext().spanId;
+
+            // Simulate OpenInference: remote parent with no attributes
+            const remoteCtx = trace.setSpanContext(context.active(), {
+              traceId: mid.spanContext().traceId,
+              spanId: midId,
+              traceFlags: TraceFlags.SAMPLED,
+              isRemote: true,
+            });
+            const leaf = tracer.startSpan('leaf', {}, remoteCtx);
+            leaf.end();
+            mid.end();
+            root.end();
+            resolve();
+          });
+        });
+      });
+
+      const leaf = exporter.getFinishedSpans().find((s) => s.name === 'leaf')!;
+      const leafStartsPath = leaf.attributes['traceroot.span.starts_path'] as string[];
+      assert.equal(leafStartsPath.length, 2, 'leaf should inherit full ancestor chain via map');
+
+      // Verify correct encoding of both ancestor times
+      if (rootStartTime && rootStartTime.length >= 2) {
+        const [rootSeconds, rootNanos] = rootStartTime;
+        const expectedRootNs = `${rootSeconds}${String(rootNanos).padStart(9, '0')}`;
+        assert.equal(leafStartsPath[0], expectedRootNs, 'starts_path[0] should be root start time');
+      }
+      if (midStartTime && midStartTime.length >= 2) {
+        const [midSeconds, midNanos] = midStartTime;
+        const expectedMidNs = `${midSeconds}${String(midNanos).padStart(9, '0')}`;
+        assert.equal(leafStartsPath[1], expectedMidNs, 'starts_path[1] should be mid start time');
+      }
+    });
+
+    it('multiple remote children inherit same starts_path', async () => {
+      const tracer = trace.getTracer('test');
+      let rootStartTime: [number, number] | undefined;
+      let midStartTime: [number, number] | undefined;
+      let midId: string;
+
+      await new Promise<void>((resolve) => {
+        tracer.startActiveSpan('root', (root) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          rootStartTime = (root as any).startTime;
+          tracer.startActiveSpan('mid', (mid) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            midStartTime = (mid as any).startTime;
+            midId = mid.spanContext().spanId;
+            const remoteCtx = trace.setSpanContext(context.active(), {
+              traceId: mid.spanContext().traceId,
+              spanId: midId,
+              traceFlags: TraceFlags.SAMPLED,
+              isRemote: true,
+            });
+            const child1 = tracer.startSpan('child1', {}, remoteCtx);
+            const child2 = tracer.startSpan('child2', {}, remoteCtx);
+            child1.end();
+            child2.end();
+            mid.end();
+            root.end();
+            resolve();
+          });
+        });
+      });
+
+      const finished = exporter.getFinishedSpans();
+      const c1 = finished.find((s) => s.name === 'child1')!;
+      const c2 = finished.find((s) => s.name === 'child2')!;
+
+      const c1Starts = c1.attributes['traceroot.span.starts_path'] as string[];
+      const c2Starts = c2.attributes['traceroot.span.starts_path'] as string[];
+
+      assert.equal(c1Starts.length, 2, 'child1 should have 2 ancestors');
+      assert.equal(c2Starts.length, 2, 'child2 should have 2 ancestors');
+      assert.deepEqual(c1Starts, c2Starts, 'both children should have identical starts_path');
+
+      // Verify they match expected times
+      if (rootStartTime && rootStartTime.length >= 2) {
+        const [rootSeconds, rootNanos] = rootStartTime;
+        const expectedRootNs = `${rootSeconds}${String(rootNanos).padStart(9, '0')}`;
+        assert.equal(
+          c1Starts[0],
+          expectedRootNs,
+          'child1 starts_path[0] should be root start time',
+        );
+        assert.equal(
+          c2Starts[0],
+          expectedRootNs,
+          'child2 starts_path[0] should be root start time',
+        );
+      }
+      if (midStartTime && midStartTime.length >= 2) {
+        const [midSeconds, midNanos] = midStartTime;
+        const expectedMidNs = `${midSeconds}${String(midNanos).padStart(9, '0')}`;
+        assert.equal(c1Starts[1], expectedMidNs, 'child1 starts_path[1] should be mid start time');
+        assert.equal(c2Starts[1], expectedMidNs, 'child2 starts_path[1] should be mid start time');
+      }
+    });
+
+    it('span start times are encoded as 19-digit epoch nanoseconds with no precision loss', async () => {
+      const tracer = trace.getTracer('test');
+      await new Promise<void>((resolve) => {
+        tracer.startActiveSpan('root', (root) => {
+          tracer.startActiveSpan('child', (child) => {
+            child.end();
+            root.end();
+            resolve();
+          });
+        });
+      });
+      const [child] = exporter.getFinishedSpans();
+      const childStartsPath = child.attributes['traceroot.span.starts_path'] as string[];
+      if (childStartsPath.length > 0) {
+        const encoded = childStartsPath[0];
+        // Verify it's a numeric string (all digits)
+        assert.match(
+          encoded,
+          /^\d+$/,
+          'encoded nanosecond should be all digits (no decimal point)',
+        );
+        // Verify the length is reasonable (should be ~19 digits for current epoch, less for seconds < 10 digits)
+        assert.ok(
+          encoded.length >= 18 && encoded.length <= 19,
+          'encoded nanosecond should be 18-19 digits',
+        );
+      }
+    });
+
+    it('attribute fallback reconstructs full chain with parent not in second processor map', async () => {
+      // Test the attribute fallback scenario: a real parent span stamped with attributes
+      // under one processor, then a child started under a SECOND processor that has no
+      // parent in its map. The child must reconstruct the full starts chain from the
+      // parent's attributes + parent's own startTime (attribute fallback branch).
+      //
+      // This is reachable: (a) parent ended and deleted from map, (b) multi-processor
+      // scenario, (c) parent from an older SDK version streamed to child from another source.
+
+      const tracer = trace.getTracer('test');
+      let rootSpan: any;
+
+      // Create parent under the FIRST processor (gets stamped with traceroot.span.* attributes)
+      await new Promise<void>((resolve) => {
+        tracer.startActiveSpan('root', (root) => {
+          rootSpan = root;
+          root.end();
+          resolve();
+        });
+      });
+
+      // Verify parent got the attributes from FIRST processor
+      const [parentExported] = exporter.getFinishedSpans();
+      assert.ok(
+        parentExported.attributes['traceroot.span.path'],
+        'parent should have path attribute',
+      );
+      assert.ok(
+        parentExported.attributes['traceroot.span.ids_path'],
+        'parent should have ids_path attribute',
+      );
+      assert.ok(
+        parentExported.attributes['traceroot.span.starts_path'],
+        'parent should have starts_path attribute',
+      );
+
+      // Create a SECOND processor that doesn't have the parent in its map
+      const secondExporter = new InMemorySpanExporter();
+      const secondInner = new SimpleSpanProcessor(secondExporter);
+      const secondProvider = new NodeTracerProvider();
+      secondProvider.addSpanProcessor(new TraceRootSpanProcessor(secondInner));
+
+      // Start child under SECOND processor with parent passed via trace.setSpan
+      // (NOT trace.setSpanContext — that produces NonRecordingSpan with no attributes)
+      const secondTracer = secondProvider.getTracer('test');
+      await new Promise<void>((resolve) => {
+        const parentCtx = trace.setSpan(context.active(), rootSpan);
+        const child = secondTracer.startSpan('child', {}, parentCtx);
+        child.end();
+        resolve();
+      });
+
+      const childSpans = secondExporter.getFinishedSpans();
+      assert.equal(childSpans.length, 1, 'should have exported one child');
+      const child = childSpans[0];
+
+      const childIdsPath = child.attributes['traceroot.span.ids_path'] as string[];
+      const childStartsPath = child.attributes['traceroot.span.starts_path'] as string[];
+
+      // CRITICAL: both paths must be non-empty (parent resolved via attribute fallback)
+      // and lengths must match (alignment guard + fallback working)
+      assert.ok(
+        childIdsPath.length > 0,
+        'child ids_path should be non-empty (parent resolved via fallback)',
+      );
+      assert.equal(
+        childStartsPath.length,
+        childIdsPath.length,
+        'attribute fallback: starts_path.length must equal ids_path.length',
+      );
+
+      // The parent's own start time must be the LAST element of starts_path
+      // (reconstructed from parent's startTime by fallback logic)
+      if (rootSpan && rootSpan.startTime && rootSpan.startTime.length >= 2) {
+        const [rootSeconds, rootNanos] = rootSpan.startTime;
+        const expectedRootNs = `${rootSeconds}${String(rootNanos).padStart(9, '0')}`;
+        assert.equal(
+          childStartsPath[childStartsPath.length - 1],
+          expectedRootNs,
+          'last element of starts_path should be parent own start (reconstructed via attribute fallback)',
+        );
+      }
+
+      await secondProvider.shutdown();
+      secondExporter.reset();
+    });
+
+    it('malformed parent starts_path attribute never throws inside onStart', async () => {
+      // `attributes` is an untrusted boundary: an instrumented app can set
+      // traceroot.span.starts_path to any AttributeValue. Before the Array.isArray
+      // check, a non-iterable value (number, null, object) threw a TypeError inside
+      // onStart — which runs synchronously inside the caller's startSpan(), so the
+      // throw escaped into application code instead of merely dropping a span.
+      // A bare string did not throw but spread into single characters, and only the
+      // length-alignment guard kept that from being emitted.
+      //
+      // Every malformed shape must now degrade to [] without throwing.
+      const malformed: [string, unknown][] = [
+        ['number', 12345],
+        ['null', null],
+        ['object', {}],
+        ['bare string', 'not-an-array'],
+        ['mixed array', ['1752259320784000000', 42]],
+      ];
+
+      for (const [label, badValue] of malformed) {
+        const parentExporter = new InMemorySpanExporter();
+        const parentProvider = new NodeTracerProvider();
+        parentProvider.addSpanProcessor(new SimpleSpanProcessor(parentExporter)); // NO TraceRootSpanProcessor
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let craftedParentSpan: any;
+        await new Promise<void>((resolve) => {
+          parentProvider.getTracer('test').startActiveSpan('parent', (parent) => {
+            craftedParentSpan = parent;
+            parent.setAttributes({
+              'traceroot.span.path': ['root'],
+              'traceroot.span.ids_path': ['aaaaaaaaaaaaaaaa'],
+            });
+            // Assign directly: setAttribute would reject some of these shapes before
+            // they ever reach the processor, and we need the raw value in place.
+            craftedParentSpan.attributes['traceroot.span.starts_path'] = badValue;
+            parent.end();
+            resolve();
+          });
+        });
+
+        const childExporter = new InMemorySpanExporter();
+        const childProvider = new NodeTracerProvider();
+        childProvider.addSpanProcessor(
+          new TraceRootSpanProcessor(new SimpleSpanProcessor(childExporter)),
+        );
+        const childContext = trace.setSpan(context.active(), craftedParentSpan);
+
+        assert.doesNotThrow(() => {
+          const child = childProvider.getTracer('test').startSpan('child', {}, childContext);
+          child.end();
+        }, `malformed starts_path (${label}) must not throw inside onStart`);
+
+        const child = childExporter.getFinishedSpans()[0];
+        assert.deepEqual(
+          child.attributes['traceroot.span.starts_path'],
+          [],
+          `malformed starts_path (${label}) must degrade to []`,
+        );
+
+        await childProvider.shutdown();
+        await parentProvider.shutdown();
+      }
+    });
+
+    it('alignment guard degrades starts_path to [] when parent lacks starts_path attribute (old SDK)', async () => {
+      // Test the explicit alignment guard: when a parent has traceroot.span.path
+      // (gate opens, ids_path gets an entry) but NO traceroot.span.starts_path
+      // attribute (e.g., old SDK parent), the fallback finds undefined, and the guard
+      // fires: starts_path degrades to [] while ids_path has 1 entry.
+      //
+      // This is reachable: parents from old SDK versions, or spans stamped by
+      // processors that don't set starts_path.
+
+      // Create parent WITHOUT TraceRootSpanProcessor (so we can set attributes manually)
+      const parentExporter = new InMemorySpanExporter();
+      const parentInner = new SimpleSpanProcessor(parentExporter);
+      const parentProvider = new NodeTracerProvider();
+      parentProvider.addSpanProcessor(parentInner); // NO TraceRootSpanProcessor
+
+      const parentTracer = parentProvider.getTracer('test');
+      let craftedParentSpan: any;
+
+      await new Promise<void>((resolve) => {
+        parentTracer.startActiveSpan('parent', (parent) => {
+          craftedParentSpan = parent;
+          // Manually set INCONSISTENT attributes (ids_path length 2, starts_path length 0)
+          parent.setAttributes({
+            'traceroot.span.path': ['root', 'mid'],
+            'traceroot.span.ids_path': ['id_a', 'id_b'],
+            'traceroot.span.starts_path': [], // PRESENT but EMPTY (the key: defined!)
+          });
+          parent.end();
+          resolve();
+        });
+      });
+
+      // Now create child under a provider WITH TraceRootSpanProcessor
+      const childExporter = new InMemorySpanExporter();
+      const childInner = new SimpleSpanProcessor(childExporter);
+      const childProvider = new NodeTracerProvider();
+      childProvider.addSpanProcessor(new TraceRootSpanProcessor(childInner));
+
+      const childTracer = childProvider.getTracer('test');
+      const childContext = trace.setSpan(context.active(), craftedParentSpan);
+
+      await new Promise<void>((resolve) => {
+        const child = childTracer.startSpan('child', {}, childContext);
+        child.end();
+        resolve();
+      });
+
+      const childSpans = childExporter.getFinishedSpans();
+      assert.equal(childSpans.length, 1, 'should have one child');
+      const child = childSpans[0];
+
+      const childIdsPath = child.attributes['traceroot.span.ids_path'] as string[];
+      const childStartsPath = child.attributes['traceroot.span.starts_path'] as string[];
+
+      // CRITICAL: verify the guard fired by checking the MISMATCH it prevented.
+      // Without the guard: starts_path would be [parentStartNs] (length 1) while ids_path
+      // is [id_a, id_b, parentId] (length 3) — a 1-vs-3 mismatch that breaks frontend.
+      assert.deepEqual(
+        childStartsPath,
+        [],
+        'alignment guard: starts_path should be [] (guard fired)',
+      );
+      assert.equal(
+        childIdsPath.length,
+        3,
+        'ids_path should have 3 entries (gate opened, child added)',
+      );
+      assert.notEqual(
+        childStartsPath.length,
+        childIdsPath.length,
+        'the guard suppressed a length mismatch (1 vs 3)',
+      );
+
+      await parentProvider.shutdown();
+      await childProvider.shutdown();
+      parentExporter.reset();
+      childExporter.reset();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes #113.

Spans export only on completion, so the live trace view has to estimate a pending ancestor's start time from its earliest exported descendant — always an overestimate. Concurrently-started sibling sections therefore render in the wrong order until the slower branch finishes, then snap into place.

This emits a companion `traceroot.span.starts_path` from **both** the `TraceRootSpanProcessor` and the Mastra exporter: the ancestor chain's start times as epoch-nanosecond decimal strings, index-aligned 1:1 with `ids_path`, ordered root → parent, and `[]` for roots or on any misalignment. It extends the existing `path` / `ids_path` ancestry pattern (#71) and the Mastra ancestry attributes (#94), so the frontend can assign real start times to pending-ancestor placeholders and stop reordering mid-run.

## Contract (identical across both implementations)

- Homogeneous `string[]` of epoch-ns decimal integers
- `length === ids_path.length`, always
- Root-to-parent ordering
- `[]` for roots and on any misalignment

## Design notes

- **Incl-self map, ancestors-only attribute.** The ancestry map stores start times *including self* — asymmetric with the ids map — because the parent's start is not reachable locally: the processor's parent may be a `NonRecordingSpan`, and `trackSpanStart` only ever receives the current span. The emitted attribute drops self (`slice(0, -1)`).
- **Attribute fallback reconstruction.** In the processor's map-miss fallback, the map holds incl-self while the parent *attribute* holds ancestors-only, so the parent's own start is reconstructed there; an explicit length guard degrades to `[]` if the two paths ever disagree.
- **Untrusted boundary.** Parent span attributes are attacker/instrumentation controlled; the prior `as string[]` cast was erased at compile time and a non-iterable value threw a `TypeError` synchronously inside `onStart` (i.e. inside the caller's `startSpan()`), surfacing as an application crash. Now validated with `Array.isArray` + per-element string check.
- **Precision.** Epoch-ns (~1.7e18) exceeds `Number.MAX_SAFE_INTEGER`, so values are string-concatenated, never computed. The processor encodes OTel `HrTime` losslessly (`seconds` + zero-padded `nanos`); Mastra derives from its millisecond `Date` (`${ms}000000`).
- **Memory.** `starts_path` maps are cleaned up alongside the existing ancestry maps at `onEnd`, orphan sweep, and shutdown.

## Testing

- Processor: root → `[]`, child inherits parent start, `length === ids_path.length` invariant, remote/`NonRecordingSpan` map-only inheritance, malformed-attribute never throws in `onStart`, alignment guard degrades to `[]` for old-SDK parents.
- Mastra: root/child/grandchild chains, independent siblings, orphan gating, TTL eviction cleanup, out-of-order span ending, co-existence with `path`/`ids_path`.
- Full suite green (new tests pass; no regressions to existing `path`/`ids_path` behavior).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `traceroot.span.starts_path` with ancestor start times so the live trace view can order concurrent spans correctly and stop snapping mid-run. Emitted by both the `TraceRootSpanProcessor` and the `TraceRootExporter`.

- New Features
  - Adds `traceroot.span.starts_path` (string[] of epoch-ns) aligned 1:1 with `traceroot.span.ids_path` (root→parent); `[]` for roots or any mismatch.
  - Processor: stores start-chain including self for descendants, emits ancestors-only, validates untrusted parent attrs, reconstructs on attribute fallback using the parent’s start, and guards length alignment.
  - Exporter: builds chain from `Date` ms via string ns encoding (`${ms}000000`), emits ancestors-only on end, and cleans maps on end, sweep, and shutdown.
  - Tests cover invariants with `ids_path`, remote/non-recording parents, malformed attrs (no throw), out-of-order endings, deep chains, and coexistence with `path`/`ids_path`.

<sup>Written for commit 973364409d9a74e486efd05fe95c9c43d8bad0a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-ts/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

