### PR TITLE
chore(traceroot): bump version to 0.1.8

### DIFF
--- a/packages/traceroot/package.json
+++ b/packages/traceroot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@traceroot-ai/traceroot",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "TraceRoot TypeScript SDK for AI observability",
   "keywords": [
     "traceroot",


### PR DESCRIPTION
Bumps `@traceroot-ai/traceroot` from 0.1.7 → 0.1.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `@traceroot-ai/traceroot` from 0.1.7 to 0.1.8 to publish the latest SDK version. No functional changes—version update only.

<sup>Written for commit dde922fa770a663f7ec2d12a3ce5092bd281bf7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot-ts/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

