### PR TITLE
feat(eval): dataset lifecycle — content-hashed snapshot + pull/push

### DIFF
--- a/packages/traceroot/src/eval/dataset_sync.ts
+++ b/packages/traceroot/src/eval/dataset_sync.ts
@@ -45,36 +45,61 @@ export class LocalDatasetSync implements DatasetSyncTransport {
 
 /** Deterministic in-memory sync for tests: versions, idempotency, conflicts. */
 export class FakeDatasetSync implements DatasetSyncTransport {
-  currentVersionId: string | null = null;
-  private versionCounter = 0;
-  private lastRevision: string | null = null;
+  // Per-dataset version/idempotency/conflict state, so ONE instance can model several independent
+  // server datasets. A single global cursor previously cross-contaminated them (a second dataset
+  // would inherit the first's version and produce false conflicts or skip a real change).
+  private readonly byDataset = new Map<
+    string,
+    { versionId: string | null; counter: number; revision: string | null }
+  >();
+  private lastDatasetId: string | null = null;
   readonly pushes: Array<[string, string, string]> = [];
 
-  forceCurrentVersion(versionId: string): void {
-    this.currentVersionId = versionId;
+  private stateFor(datasetId: string): { versionId: string | null; counter: number; revision: string | null } {
+    let s = this.byDataset.get(datasetId);
+    if (!s) {
+      s = { versionId: null, counter: 0, revision: null };
+      this.byDataset.set(datasetId, s);
+    }
+    return s;
+  }
+
+  /** Current server version for a dataset (defaults to the most recently pushed one). */
+  get currentVersionId(): string | null {
+    return this.lastDatasetId ? (this.byDataset.get(this.lastDatasetId)?.versionId ?? null) : null;
+  }
+
+  /** Seed a server version to simulate the server moving ahead (test helper). Applies to the
+   *  given dataset, or the most recently pushed one. */
+  forceCurrentVersion(versionId: string, datasetId?: string): void {
+    const id = datasetId ?? this.lastDatasetId;
+    if (id === null) throw new Error('forceCurrentVersion: push a dataset first, or pass a datasetId');
+    this.stateFor(id).versionId = versionId;
   }
 
   async pushDataset(snapshot: DatasetSnapshot, baseVersionId: string | null): Promise<PushResult> {
-    if (this.currentVersionId !== null && baseVersionId !== this.currentVersionId) {
-      throw new DatasetConflictError(baseVersionId, this.currentVersionId);
+    const s = this.stateFor(snapshot.datasetId);
+    this.lastDatasetId = snapshot.datasetId;
+    if (s.versionId !== null && baseVersionId !== s.versionId) {
+      throw new DatasetConflictError(baseVersionId, s.versionId);
     }
-    if (snapshot.revision === this.lastRevision) {
+    if (snapshot.revision === s.revision) {
       return {
         status: 'uploaded',
         datasetId: snapshot.datasetId,
-        datasetVersionId: this.currentVersionId,
-        versionNumber: this.versionCounter,
+        datasetVersionId: s.versionId,
+        versionNumber: s.counter,
       };
     }
-    this.versionCounter += 1;
-    this.currentVersionId = `dsv_${this.versionCounter}`;
-    this.lastRevision = snapshot.revision;
-    this.pushes.push([snapshot.datasetId, snapshot.revision, this.currentVersionId]);
+    s.counter += 1;
+    s.versionId = `dsv_${s.counter}`;
+    s.revision = snapshot.revision;
+    this.pushes.push([snapshot.datasetId, snapshot.revision, s.versionId]);
     return {
       status: 'uploaded',
       datasetId: snapshot.datasetId,
-      datasetVersionId: this.currentVersionId,
-      versionNumber: this.versionCounter,
+      datasetVersionId: s.versionId,
+      versionNumber: s.counter,
     };
   }
 }

--- a/packages/traceroot/src/eval/dataset_sync.ts
+++ b/packages/traceroot/src/eval/dataset_sync.ts
@@ -117,10 +117,14 @@ export class PlatformDatasetSync implements DatasetSyncTransport {
 
     let resp: any;
     try {
-      resp = await this.request('POST', `/api/v1/public/datasets/${snapshot.datasetId}/versions`, {
-        base_version_id: baseVersionId,
-        changes,
-      });
+      resp = await this.request(
+        'POST',
+        `/api/v1/public/datasets/${encodeURIComponent(snapshot.datasetId)}/versions`,
+        {
+          base_version_id: baseVersionId,
+          changes,
+        },
+      );
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes(' HTTP 413:')) {

--- a/packages/traceroot/src/eval/dataset_sync.ts
+++ b/packages/traceroot/src/eval/dataset_sync.ts
@@ -1,0 +1,150 @@
+// src/eval/dataset_sync.ts — explicit dataset publication seam (parity with
+// traceroot-py/traceroot/eval/dataset_sync.py).
+//
+// One explicit Dataset.push() = one immutable server dataset version, with
+// optimistic-concurrency conflict detection (baseVersionId). Local mutations never create
+// versions. Default LocalDatasetSync is local-only; FakeDatasetSync drives tests;
+// PlatformDatasetSync publishes to POST /api/v1/public/datasets + .../{id}/versions.
+
+import { TraceRoot } from '../traceroot';
+import { httpJson } from './platform';
+import type { DatasetSnapshot } from './types';
+
+export class DatasetConflictError extends Error {
+  constructor(
+    readonly baseVersionId: string | null,
+    readonly currentVersionId: string | null,
+  ) {
+    super(
+      `dataset changed remotely: base=${JSON.stringify(baseVersionId)} ` +
+        `current=${JSON.stringify(currentVersionId)}. Pull the latest version, review the ` +
+        `diff, and retry intentionally.`,
+    );
+    this.name = 'DatasetConflictError';
+  }
+}
+
+/** Outcome of Dataset.push — explicit about local vs uploaded state. */
+export interface PushResult {
+  status: 'local_only' | 'uploaded';
+  datasetId: string;
+  datasetVersionId?: string | null;
+  versionNumber?: number | null;
+}
+
+export interface DatasetSyncTransport {
+  pushDataset(snapshot: DatasetSnapshot, baseVersionId: string | null): Promise<PushResult>;
+}
+
+/** Default no-op: the dataset stays local; nothing is published. */
+export class LocalDatasetSync implements DatasetSyncTransport {
+  async pushDataset(snapshot: DatasetSnapshot): Promise<PushResult> {
+    return { status: 'local_only', datasetId: snapshot.datasetId };
+  }
+}
+
+/** Deterministic in-memory sync for tests: versions, idempotency, conflicts. */
+export class FakeDatasetSync implements DatasetSyncTransport {
+  currentVersionId: string | null = null;
+  private versionCounter = 0;
+  private lastRevision: string | null = null;
+  readonly pushes: Array<[string, string, string]> = [];
+
+  forceCurrentVersion(versionId: string): void {
+    this.currentVersionId = versionId;
+  }
+
+  async pushDataset(snapshot: DatasetSnapshot, baseVersionId: string | null): Promise<PushResult> {
+    if (this.currentVersionId !== null && baseVersionId !== this.currentVersionId) {
+      throw new DatasetConflictError(baseVersionId, this.currentVersionId);
+    }
+    if (snapshot.revision === this.lastRevision) {
+      return {
+        status: 'uploaded',
+        datasetId: snapshot.datasetId,
+        datasetVersionId: this.currentVersionId,
+        versionNumber: this.versionCounter,
+      };
+    }
+    this.versionCounter += 1;
+    this.currentVersionId = `dsv_${this.versionCounter}`;
+    this.lastRevision = snapshot.revision;
+    this.pushes.push([snapshot.datasetId, snapshot.revision, this.currentVersionId]);
+    return {
+      status: 'uploaded',
+      datasetId: snapshot.datasetId,
+      datasetVersionId: this.currentVersionId,
+      versionNumber: this.versionCounter,
+    };
+  }
+}
+
+/** Real dataset publish against the live backend (A2/A4). */
+export class PlatformDatasetSync implements DatasetSyncTransport {
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+
+  constructor(opts: { apiKey?: string; baseUrl?: string } = {}) {
+    const { apiKey, baseUrl } = TraceRoot.resolveCredentials(opts.apiKey, opts.baseUrl);
+    if (!apiKey) throw new Error('PlatformDatasetSync needs an API key.');
+    this.apiKey = apiKey;
+    this.baseUrl = baseUrl;
+  }
+
+  private request(method: string, path: string, body?: unknown): Promise<any> {
+    return httpJson(method, `${this.baseUrl}${path}`, this.apiKey, body);
+  }
+
+  async pushDataset(snapshot: DatasetSnapshot, baseVersionId: string | null): Promise<PushResult> {
+    await this.request('POST', '/api/v1/public/datasets', {
+      dataset_id: snapshot.datasetId,
+      name: snapshot.name,
+      description: snapshot.description,
+    });
+    // Native JSON at the HTTP boundary: input/expected/metadata are sent as their real
+    // values; the backend owns the single JSON-encode. The SDK does NOT pre-encode.
+    const changes: Record<string, unknown>[] = [];
+    for (const c of snapshot.cases) {
+      const change: Record<string, unknown> = { op: 'upsert', test_case_id: c.id, input: c.input };
+      if (c.expected !== undefined && c.expected !== null) change.expected = c.expected;
+      if (c.metadata != null) change.metadata = c.metadata;
+      if (c.sourceTraceId != null) change.source_trace_id = c.sourceTraceId;
+      if (c.sourceSpanId != null) change.source_span_id = c.sourceSpanId;
+      changes.push(change);
+    }
+    if (changes.length === 0)
+      throw new Error('cannot publish a dataset version with no active cases');
+
+    let resp: any;
+    try {
+      resp = await this.request('POST', `/api/v1/public/datasets/${snapshot.datasetId}/versions`, {
+        base_version_id: baseVersionId,
+        changes,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes(' HTTP 413:')) {
+        throw new Error(
+          `too many changes in one push (${changes.length}); the backend caps a version at ` +
+            `~1000 changes. Split the dataset or publish in stages.`,
+        );
+      }
+      if (msg.includes(' HTTP 409:')) {
+        let current: string | null = null;
+        try {
+          current = JSON.parse(msg.split(' HTTP 409:')[1].trim()).current_version_id ?? null;
+        } catch {
+          /* ignore */
+        }
+        throw new DatasetConflictError(baseVersionId, current);
+      }
+      throw err;
+    }
+    return {
+      status: 'uploaded',
+      datasetId: snapshot.datasetId,
+      datasetVersionId: resp.dataset_version_id ?? null,
+      versionNumber: resp.version_number ?? null,
+    };
+  }
+}

--- a/packages/traceroot/src/eval/types.ts
+++ b/packages/traceroot/src/eval/types.ts
@@ -95,15 +95,20 @@ function canonicalJson(value: unknown): string {
   return JSON.stringify(norm(value));
 }
 
-/** Clone a case for a snapshot: structuredClone for the common case, falling back to a JSON-safe
- *  structural copy for payloads structuredClone can't handle (e.g. a function or proxy left in the
- *  data). Either way the snapshot is fully isolated and freezable — it never throws mid-capture or
- *  leaves a live object aliased into the snapshot. */
+/** Clone a case for a snapshot. `structuredClone` is a LOSSLESS deep copy for every value a
+ *  dataset case should hold (primitives, plain objects/arrays, Date, Map/Set, typed arrays, nested
+ *  and cyclic graphs), giving full isolation. It only throws on values that aren't valid case data
+ *  (functions, symbols, unclonable class instances) — we reject those explicitly rather than fall
+ *  back to a lossy JSON copy that would silently drop/convert fields and publish an incomplete case. */
 function snapshotClone<T>(v: T): T {
   try {
     return structuredClone(v);
-  } catch {
-    return JSON.parse(JSON.stringify(v)) as T;
+  } catch (err) {
+    throw new Error(
+      `dataset case payload is not snapshottable (not structured-cloneable): ${
+        err instanceof Error ? err.message : String(err)
+      }. Snapshots require plain data — remove functions/symbols/non-cloneable objects from the case.`,
+    );
   }
 }
 

--- a/packages/traceroot/src/eval/types.ts
+++ b/packages/traceroot/src/eval/types.ts
@@ -94,6 +94,14 @@ export function contentRevision(cases: EvalCase[]): string {
 }
 
 /** An immutable, content-addressed snapshot of a dataset's active cases. */
+export interface DatasetSnapshot {
+  datasetId: string;
+  name: string;
+  description: string | null;
+  revision: string;
+  cases: EvalCase[];
+  baseVersionId: string | null;
+}
 
 /**
  * A local, mutable, ordered collection of {@link EvalCase} keyed by stable id. Construction
@@ -101,3 +109,196 @@ export function contentRevision(cases: EvalCase[]): string {
  * assigned at creation; `datasetVersionId` is set only when this mirrors a pushed/pulled
  * remote version.
  */
+export class Dataset {
+  name: string;
+  description: string | null;
+  datasetId: string;
+  datasetVersionId?: string;
+  baseVersionId: string | null = null;
+  private readonly casesById = new Map<string, EvalCase>();
+
+  constructor(name: string, description: string | null = null) {
+    this.name = name;
+    this.description = description;
+    this.datasetId = newDatasetId();
+  }
+
+  // --- authoring / mutation (network-free) ---
+  add(
+    input: unknown,
+    opts: {
+      expected?: unknown;
+      metadata?: Record<string, unknown> | null;
+      sourceTraceId?: string;
+      sourceSpanId?: string;
+      id?: string;
+    } = {},
+  ): EvalCase {
+    const cid = opts.id ?? newTestCaseId();
+    if (this.casesById.has(cid)) throw new Error(`test case id already exists: ${cid}`);
+    const c: EvalCase = {
+      input,
+      id: cid,
+      expected: opts.expected,
+      metadata: opts.metadata,
+      sourceTraceId: opts.sourceTraceId,
+      sourceSpanId: opts.sourceSpanId,
+    };
+    this.casesById.set(cid, c);
+    return c;
+  }
+
+  /** Add or replace by id; anonymous cases get a stable ULID id. */
+  upsert(evalCase: EvalCase): EvalCase {
+    const stored = evalCase.id == null ? { ...evalCase, id: newTestCaseId() } : evalCase;
+    this.casesById.set(stored.id as string, stored);
+    return stored;
+  }
+
+  /** Replace fields of an existing case; throws if absent. */
+  update(id: string, changes: Partial<EvalCase>): EvalCase {
+    const cur = this.casesById.get(id);
+    if (!cur) throw new Error(`no such case: ${id}`);
+    const updated = { ...cur, ...changes, id };
+    this.casesById.set(id, updated);
+    return updated;
+  }
+
+  /** Soft-archive a case: retained for lineage, excluded from the active set. */
+  archive(id: string): void {
+    const cur = this.casesById.get(id);
+    if (!cur) throw new Error(`no such case: ${id}`);
+    this.casesById.set(id, { ...cur, archived: true });
+  }
+
+  /** Hard-delete a case; throws if absent. */
+  remove(id: string): void {
+    if (!this.casesById.delete(id)) throw new Error(`no such case: ${id}`);
+  }
+
+  // --- access ---
+  get(id: string): EvalCase | undefined {
+    return this.casesById.get(id);
+  }
+
+  cases(includeArchived = false): EvalCase[] {
+    return [...this.casesById.values()].filter((c) => includeArchived || !c.archived);
+  }
+
+  get size(): number {
+    return this.cases().length;
+  }
+
+  [Symbol.iterator](): Iterator<EvalCase> {
+    return this.cases()[Symbol.iterator]();
+  }
+
+  // --- snapshot ---
+  snapshot(): DatasetSnapshot {
+    const active = this.cases();
+    return {
+      datasetId: this.datasetId,
+      name: this.name,
+      description: this.description,
+      revision: contentRevision(active),
+      cases: active,
+      baseVersionId: this.baseVersionId,
+    };
+  }
+
+  // --- serialization (network-free) ---
+  toJSON(): {
+    datasetId: string;
+    name: string;
+    description: string | null;
+    baseVersionId: string | null;
+    cases: EvalCase[];
+  } {
+    return {
+      datasetId: this.datasetId,
+      name: this.name,
+      description: this.description,
+      baseVersionId: this.baseVersionId,
+      cases: [...this.casesById.values()], // incl. archived
+    };
+  }
+
+  static fromJSON(d: {
+    name: string;
+    description?: string | null;
+    datasetId?: string;
+    baseVersionId?: string | null;
+    datasetVersionId?: string;
+    cases?: EvalCase[];
+  }): Dataset {
+    const ds = new Dataset(d.name, d.description ?? null);
+    if (d.datasetId) ds.datasetId = d.datasetId;
+    ds.baseVersionId = d.baseVersionId ?? null;
+    ds.datasetVersionId = d.datasetVersionId;
+    for (const c of d.cases ?? []) ds.casesById.set(c.id as string, c);
+    return ds;
+  }
+
+  /** Write to disk. `.jsonl` = header line + one line per case; else `.json`. */
+  save(path: string): void {
+    if (path.endsWith('.jsonl')) {
+      const header = {
+        type: 'dataset',
+        datasetId: this.datasetId,
+        name: this.name,
+        description: this.description,
+        baseVersionId: this.baseVersionId,
+        schema: 1,
+      };
+      const lines = [JSON.stringify(header)];
+      for (const c of this.casesById.values()) lines.push(JSON.stringify({ type: 'case', ...c }));
+      writeFileSync(path, lines.join('\n') + '\n');
+    } else {
+      writeFileSync(path, JSON.stringify(this.toJSON()));
+    }
+  }
+
+  static load(path: string): Dataset {
+    const text = readFileSync(path, 'utf8');
+    if (path.endsWith('.jsonl')) {
+      const records = text
+        .trim()
+        .split('\n')
+        .map((l) => JSON.parse(l));
+      const header = records[0];
+      return Dataset.fromJSON({
+        datasetId: header.datasetId,
+        name: header.name,
+        description: header.description,
+        baseVersionId: header.baseVersionId,
+        cases: records.slice(1).map((r) => {
+          const { type: _t, ...rest } = r;
+          return rest as EvalCase;
+        }),
+      });
+    }
+    return Dataset.fromJSON(JSON.parse(text));
+  }
+
+  /**
+   * Explicitly publish this dataset as ONE immutable server version. Local mutations never
+   * create versions; this is the deliberate publish boundary. `transport` defaults to a
+   * no-op LocalDatasetSync (local-only). `baseVersionId` (defaults to the pinned version)
+   * drives optimistic concurrency; a stale base rejects with DatasetConflictError.
+   */
+  async push(
+    transport?: import('./dataset_sync').DatasetSyncTransport,
+    baseVersionId?: string | null,
+  ): Promise<import('./dataset_sync').PushResult> {
+    const { LocalDatasetSync } = await import('./dataset_sync');
+    const sync = transport ?? new LocalDatasetSync();
+    const snapshot = this.snapshot();
+    const base = baseVersionId !== undefined ? baseVersionId : this.baseVersionId;
+    const result = await sync.pushDataset(snapshot, base);
+    if (result.status === 'uploaded' && result.datasetVersionId != null) {
+      this.datasetVersionId = result.datasetVersionId;
+      this.baseVersionId = result.datasetVersionId;
+    }
+    return result;
+  }
+}

--- a/packages/traceroot/src/eval/types.ts
+++ b/packages/traceroot/src/eval/types.ts
@@ -132,12 +132,22 @@ function snapshotClone<T>(v: T): T {
   }
 }
 
-/** Recursively freeze a value so a snapshot cannot be mutated after capture. */
-function deepFreeze<T>(o: T): T {
-  if (o && typeof o === 'object' && !Object.isFrozen(o)) {
-    for (const v of Object.values(o as Record<string, unknown>)) deepFreeze(v);
-    Object.freeze(o);
+/** Recursively freeze a value so a snapshot cannot be mutated after capture. Cycle-aware (a
+ *  structuredClone'd graph may be cyclic) and tolerant of built-ins: typed arrays throw on
+ *  Object.freeze when populated, so they're left as-is (the clone already isolated them). */
+function deepFreeze<T>(o: T, seen: WeakSet<object> = new WeakSet()): T {
+  if (!o || typeof o !== 'object' || Object.isFrozen(o)) return o;
+  if (seen.has(o as object)) return o; // already on the active path -> cycle
+  seen.add(o as object);
+  if (ArrayBuffer.isView(o)) return o; // freezing a populated typed array throws
+  if (o instanceof Map) {
+    for (const v of (o as Map<unknown, unknown>).values()) deepFreeze(v, seen);
+  } else if (o instanceof Set) {
+    for (const v of o as Set<unknown>) deepFreeze(v, seen);
+  } else {
+    for (const v of Object.values(o as Record<string, unknown>)) deepFreeze(v, seen);
   }
+  Object.freeze(o);
   return o;
 }
 
@@ -297,7 +307,12 @@ export class Dataset {
     if (d.datasetId) ds.datasetId = d.datasetId;
     ds.baseVersionId = d.baseVersionId ?? null;
     ds.datasetVersionId = d.datasetVersionId;
-    for (const c of d.cases ?? []) ds.casesById.set(c.id as string, c);
+    // Anonymous cases (no id) each get a generated id — otherwise every one keys on `undefined`
+    // and all but the last silently collapse. Mirrors upsert().
+    for (const c of d.cases ?? []) {
+      const stored = c.id == null ? { ...c, id: newTestCaseId() } : c;
+      ds.casesById.set(stored.id as string, stored);
+    }
     return ds;
   }
 

--- a/packages/traceroot/src/eval/types.ts
+++ b/packages/traceroot/src/eval/types.ts
@@ -95,6 +95,18 @@ function canonicalJson(value: unknown): string {
   return JSON.stringify(norm(value));
 }
 
+/** Clone a case for a snapshot: structuredClone for the common case, falling back to a JSON-safe
+ *  structural copy for payloads structuredClone can't handle (e.g. a function or proxy left in the
+ *  data). Either way the snapshot is fully isolated and freezable — it never throws mid-capture or
+ *  leaves a live object aliased into the snapshot. */
+function snapshotClone<T>(v: T): T {
+  try {
+    return structuredClone(v);
+  } catch {
+    return JSON.parse(JSON.stringify(v)) as T;
+  }
+}
+
 /** Recursively freeze a value so a snapshot cannot be mutated after capture. */
 function deepFreeze<T>(o: T): T {
   if (o && typeof o === 'object' && !Object.isFrozen(o)) {
@@ -220,7 +232,7 @@ export class Dataset {
     // Deep-copy + freeze so the snapshot is a stable, content-addressed record: later mutation
     // of the dataset's live case objects can no longer change what this revision describes, and
     // the snapshot itself cannot be edited after capture.
-    const frozen = active.map((c) => deepFreeze(structuredClone(c)));
+    const frozen = active.map((c) => deepFreeze(snapshotClone(c)));
     return Object.freeze({
       datasetId: this.datasetId,
       name: this.name,

--- a/packages/traceroot/src/eval/types.ts
+++ b/packages/traceroot/src/eval/types.ts
@@ -93,6 +93,15 @@ function canonicalJson(value: unknown): string {
   return JSON.stringify(norm(value));
 }
 
+/** Recursively freeze a value so a snapshot cannot be mutated after capture. */
+function deepFreeze<T>(o: T): T {
+  if (o && typeof o === 'object' && !Object.isFrozen(o)) {
+    for (const v of Object.values(o as Record<string, unknown>)) deepFreeze(v);
+    Object.freeze(o);
+  }
+  return o;
+}
+
 export function contentRevision(cases: EvalCase[]): string {
   const content = cases.map((c) => {
     const o: Record<string, unknown> = {};
@@ -206,14 +215,18 @@ export class Dataset {
   // --- snapshot ---
   snapshot(): DatasetSnapshot {
     const active = this.cases();
-    return {
+    // Deep-copy + freeze so the snapshot is a stable, content-addressed record: later mutation
+    // of the dataset's live case objects can no longer change what this revision describes, and
+    // the snapshot itself cannot be edited after capture.
+    const frozen = active.map((c) => deepFreeze(structuredClone(c)));
+    return Object.freeze({
       datasetId: this.datasetId,
       name: this.name,
       description: this.description,
       revision: contentRevision(active),
-      cases: active,
+      cases: frozen,
       baseVersionId: this.baseVersionId,
-    };
+    });
   }
 
   // --- serialization (network-free) ---

--- a/packages/traceroot/tests/eval-lifecycle.test.ts
+++ b/packages/traceroot/tests/eval-lifecycle.test.ts
@@ -48,17 +48,22 @@ describe('Dataset authoring + snapshot', () => {
     assert.match(mk().snapshot().revision, /^rev_[0-9a-f]{16}$/);
   });
 
-  it('save/load round-trips (.json and .jsonl)', () => {
+  it('save/load round-trips metadata, archived cases, and value types (.json and .jsonl)', () => {
     const dir = mkdtempSync(join(tmpdir(), 'ds-'));
     const ds = new Dataset('tickets', 'd');
-    ds.add({ m: 'hi' }, { id: 'a', expected: { r: 'billing' }, metadata: { s: 1 } });
+    ds.add({ m: 'hi', n: 2, ok: true }, { id: 'a', expected: { r: 'billing' }, metadata: { s: 1 } });
+    ds.add({ m: 'bye' }, { id: 'b' });
+    ds.archive('b'); // archived cases are retained for lineage and must persist
     for (const ext of ['json', 'jsonl']) {
       const p = join(dir, `ds.${ext}`);
       ds.save(p);
       const loaded = Dataset.load(p);
       assert.equal(loaded.name, 'tickets');
-      assert.deepEqual(loaded.get('a')!.input, { m: 'hi' });
+      // number/boolean types survive the JSON round-trip (not coerced to strings).
+      assert.deepEqual(loaded.get('a')!.input, { m: 'hi', n: 2, ok: true });
       assert.deepEqual(loaded.get('a')!.expected, { r: 'billing' });
+      assert.deepEqual(loaded.get('a')!.metadata, { s: 1 }); // metadata preserved
+      assert.ok(loaded.get('b')?.archived, 'archived case must round-trip');
     }
   });
 });

--- a/packages/traceroot/tests/eval-lifecycle.test.ts
+++ b/packages/traceroot/tests/eval-lifecycle.test.ts
@@ -1,0 +1,89 @@
+// Parity: dataset authoring/snapshot/save-load + push seam (LocalDatasetSync / FakeDatasetSync
+// / conflict) + ULID ids.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  Dataset,
+  FakeDatasetSync,
+  LocalDatasetSync,
+  DatasetConflictError,
+  newRunId,
+  newDatasetId,
+} from '../src/eval';
+
+describe('ids', () => {
+  it('typed ULID ids, time-sortable-ish and unique', () => {
+    assert.match(newDatasetId(), /^ds_[0-9A-Z]{26}$/);
+    assert.match(newRunId(), /^run_[0-9A-Z]{26}$/);
+    assert.notEqual(newRunId(), newRunId());
+  });
+});
+
+describe('Dataset authoring + snapshot', () => {
+  it('add/update/archive/remove + active vs archived', () => {
+    const ds = new Dataset('d', 'desc');
+    ds.add({ q: 1 } as unknown, { id: 'c0', expected: 1 });
+    assert.throws(() => ds.add(2, { id: 'c0' }), /already exists/);
+    ds.add(2, { id: 'c1' });
+    ds.update('c1', { expected: 99 });
+    assert.equal(ds.get('c1')!.expected, 99);
+    ds.archive('c0');
+    assert.equal(ds.size, 1); // c0 archived -> excluded from active
+    assert.equal(ds.cases(true).length, 2);
+    ds.remove('c1');
+    assert.equal(ds.size, 0);
+  });
+
+  it('snapshot revision is content-addressed and stable', () => {
+    const mk = () => {
+      const d = new Dataset('d');
+      d.add({ m: 'x' }, { id: 'a', expected: 1 });
+      return d;
+    };
+    assert.equal(mk().snapshot().revision, mk().snapshot().revision);
+    assert.match(mk().snapshot().revision, /^rev_[0-9a-f]{16}$/);
+  });
+
+  it('save/load round-trips (.json and .jsonl)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ds-'));
+    const ds = new Dataset('tickets', 'd');
+    ds.add({ m: 'hi' }, { id: 'a', expected: { r: 'billing' }, metadata: { s: 1 } });
+    for (const ext of ['json', 'jsonl']) {
+      const p = join(dir, `ds.${ext}`);
+      ds.save(p);
+      const loaded = Dataset.load(p);
+      assert.equal(loaded.name, 'tickets');
+      assert.deepEqual(loaded.get('a')!.input, { m: 'hi' });
+      assert.deepEqual(loaded.get('a')!.expected, { r: 'billing' });
+    }
+  });
+});
+
+describe('push seam', () => {
+  it('LocalDatasetSync stays local', async () => {
+    const ds = new Dataset('d');
+    ds.add(1, { id: 'a' });
+    const r = await ds.push(new LocalDatasetSync());
+    assert.equal(r.status, 'local_only');
+    assert.equal(ds.datasetVersionId, undefined);
+  });
+
+  it('FakeDatasetSync versions, idempotency, and conflict', async () => {
+    const sync = new FakeDatasetSync();
+    const ds = new Dataset('d');
+    ds.add(1, { id: 'a' });
+    const v1 = await ds.push(sync);
+    assert.equal(v1.status, 'uploaded');
+    assert.equal(ds.datasetVersionId, v1.datasetVersionId); // pinned
+    // idempotent re-push of unchanged content -> same version
+    const again = await ds.push(sync, v1.datasetVersionId);
+    assert.equal(again.datasetVersionId, v1.datasetVersionId);
+    // a stale base rejects
+    sync.forceCurrentVersion('dsv_99');
+    await assert.rejects(() => ds.push(sync, 'dsv_stale'), DatasetConflictError);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the dataset lifecycle: an in-memory `Dataset` you author locally, an immutable content-hashed snapshot so a run can pin an exact version, and an explicit publish seam that turns local edits into immutable server versions. Construction and mutation do no network I/O; a snapshot's `revision` is derived purely from content, so identical content always yields an identical revision. `input`/`expected` round-trip through canonical, type-preserving JSON at the HTTP boundary, and a push is idempotent for unchanged content and rejects a stale base.

Fixes: traceroot-ai/traceroot#1686

## How it works

`Dataset` holds ordered cases keyed by a stable id and supports `add`/`upsert`/`update`/`archive`/`remove`; archived cases are retained for lineage but excluded from the active set and from snapshots. `snapshot()` freezes the active cases and stamps a content-addressed `revision` (`rev_` + a hash over the identity fields only, ignoring volatile/archived state). Publication is deliberate and explicit — local mutations never create versions.

```
Dataset (mutable, local)         no network on author/mutate
  └─ snapshot()  → DatasetSnapshot (frozen, revision = hash(content))
       └─ push(transport, baseVersionId)
            ├─ LocalDatasetSync   → local_only (default, no network)
            └─ PlatformDatasetSync → one immutable server version
                 · base behind current → DatasetConflictError
                 · unchanged content    → idempotent (no new version)
```

## What's included

### Source
- `packages/traceroot/src/eval/types.ts` — `DatasetSnapshot` (content-addressed) and the `Dataset` class: authoring/mutation, `snapshot()`, `.json`/`.jsonl` save/load round trip, and `push()` (the explicit publish boundary that stamps `datasetVersionId` on success).
- `packages/traceroot/src/eval/dataset_sync.ts` — the publication seam: `DatasetSyncTransport` interface, `PushResult`, a default no-op `LocalDatasetSync`, a deterministic `FakeDatasetSync` for tests, `PlatformDatasetSync` for the live backend, and `DatasetConflictError` for a stale base.

### Tests
- `packages/traceroot/tests/eval-lifecycle.test.ts` — snapshot revision stability, `.json`/`.jsonl` save/load round trip with type-preserving values, version stamping, idempotent re-push, and stale-base conflict.

## Test plan

- [ ] A snapshot's revision is content-addressed and stable — identical content yields an identical revision.
- [ ] Pull-by-id binds the dataset to its current version; pull-by-version reproduces the exact recorded cases.
- [ ] A push stamps a version, is idempotent for unchanged content, and rejects a stale base with a conflict.
- [ ] Types inside `input`/`expected` survive the canonical JSON round trip at the HTTP boundary unchanged.
- [ ] Save then load a dataset as both `.json` and `.jsonl` and confirm the cases (incl. archived) are recovered.
