### PR TITLE
feat(eval): trace-native execution engine — per-case trace + span hierarchy

### DIFF
--- a/packages/traceroot/src/eval/engine.ts
+++ b/packages/traceroot/src/eval/engine.ts
@@ -61,12 +61,10 @@ export interface EvaluateOptions {
   metadata?: Record<string, unknown> | null;
   select?: (c: EvalCase) => boolean;
   environment?: string;
-  /** Explicit transport wins over the default upload decision (e.g. baseline linking). */
+  /** Explicit transport wins over the default upload decision. */
   transport?: EvalTransport;
   /** Opt out of the upload-by-default behavior; keep the run local. */
   local?: boolean;
-  /** A prior run to link as the baseline (auto-links baselineRunId when reporting). */
-  baseline?: EvalRunResult;
   /**
    * Live console progress bar. Undefined = auto (on for an interactive
    * terminal, off when piped/CI); true/false forces it.
@@ -396,7 +394,6 @@ function autoTransport(
   scorers: ScorerFn[],
   candidateVersion: string | undefined,
   environment: string | undefined,
-  baselineRunId: string | null,
 ): EvalTransport | null {
   let effectiveId = datasetId;
   let versionId: string | null = null;
@@ -413,7 +410,6 @@ function autoTransport(
     candidateVersion: candidateVersion ?? null,
     environment,
     datasetVersionId: versionId,
-    baselineRunId,
   });
 }
 
@@ -449,16 +445,9 @@ export async function evaluateAsync(options: EvaluateOptions): Promise<EvalRunRe
   } else if (options.local) {
     active = new LocalTransport();
   } else {
-    const baselineRunId = options.baseline?.runId ?? null;
     active =
-      autoTransport(
-        data,
-        options.datasetId,
-        scorers,
-        candidateVersion,
-        environment,
-        baselineRunId,
-      ) ?? new LocalTransport();
+      autoTransport(data, options.datasetId, scorers, candidateVersion, environment) ??
+      new LocalTransport();
   }
 
   // Forward scorer comparison metadata to a transport that accepts specs (before createRun).
@@ -547,21 +536,15 @@ export async function evaluateAsync(options: EvaluateOptions): Promise<EvalRunRe
     candidateVersion: candidateVersion ?? null,
     dataset: datasetRef,
     metadata: runMetadata,
-    baseline: options.baseline ?? null,
     runScores,
     runScorerErrors,
   });
 
-  // When the bar was shown (interactive), print a closing block: the
-  // candidate-vs-baseline comparison when a baseline exists (it carries the run
-  // link), otherwise just the clickable run link. Off-terminal callers read the
-  // returned result instead.
-  if (reporter) {
-    if (options.baseline) {
-      process.stderr.write(result.comparisonReport(options.baseline) + '\n');
-    } else if (uploadState.dashboardUrl) {
-      printRunUrl(uploadState.dashboardUrl);
-    }
+  // When the bar was shown (interactive), surface the clickable run link if the backend
+  // returned one. Off-terminal callers read result.uploadState instead. (Candidate-vs-
+  // baseline comparison is the backend's job, not the SDK's.)
+  if (reporter && uploadState.dashboardUrl) {
+    printRunUrl(uploadState.dashboardUrl);
   }
 
   return result;

--- a/packages/traceroot/src/eval/engine.ts
+++ b/packages/traceroot/src/eval/engine.ts
@@ -218,12 +218,18 @@ function recordScorerSpan(span: Span, scores: Score[]): void {
 
 async function withTimeout<T>(p: Promise<T>, timeout?: number): Promise<T> {
   if (timeout === undefined) return p;
-  return Promise.race([
-    p,
-    new Promise<T>((_res, rej) =>
-      setTimeout(() => rej(new Error(`TimeoutError: task exceeded ${timeout}s`)), timeout * 1000),
-    ),
-  ]);
+  let handle: ReturnType<typeof setTimeout>;
+  const timer = new Promise<T>((_res, rej) => {
+    handle = setTimeout(
+      () => rej(new Error(`TimeoutError: task exceeded ${timeout}s`)),
+      timeout * 1000,
+    );
+  });
+  try {
+    return await Promise.race([p, timer]);
+  } finally {
+    clearTimeout(handle!);
+  }
 }
 
 async function runCase(
@@ -251,101 +257,104 @@ async function runCase(
   // A reported run exports its per-case spans, so the result carries the trace id.
   const traceId = !ZERO_TRACE_ID.test(rawTraceId) ? rawTraceId : null;
 
-  const result = await usingSpan(root, async (): Promise<EvalItemResult> => {
-    let output: unknown = null;
-    let error: string | null = null;
-    const scores: Score[] = [];
-    const scorerErrors: Record<string, string> = {};
+  let result: EvalItemResult;
+  try {
+    result = await usingSpan(root, async (): Promise<EvalItemResult> => {
+      let output: unknown = null;
+      let error: string | null = null;
+      const scores: Score[] = [];
+      const scorerErrors: Record<string, string> = {};
 
-    const taskSpan = startSpan(
-      {
-        name: 'task',
-        type: 'task',
-        input: evalCase.input,
-        attributes: {
-          [SpanAttributes.EVAL_RUN_NAME]: identity.name,
-          [SpanAttributes.EVAL_CASE_ID]: evalCase.id as string,
-          [SpanAttributes.EVAL_TASK_NAME]: fnName(task, 'task'),
+      const taskSpan = startSpan(
+        {
+          name: 'task',
+          type: 'task',
+          input: evalCase.input,
+          attributes: {
+            [SpanAttributes.EVAL_RUN_NAME]: identity.name,
+            [SpanAttributes.EVAL_CASE_ID]: evalCase.id as string,
+            [SpanAttributes.EVAL_TASK_NAME]: fnName(task, 'task'),
+          },
         },
-      },
-      tracer,
-    );
-    try {
-      output = await usingSpan(taskSpan, () =>
-        withTimeout(Promise.resolve(task(evalCase.input)), timeout),
+        tracer,
       );
-      taskSpan.update({ output });
-    } catch (err) {
-      error = fmtError(err);
-      taskSpan.setError(err);
-      taskSpan.update({ attributes: { [SpanAttributes.EVAL_ERROR]: error } });
-    } finally {
-      taskSpan.end();
-    }
+      try {
+        output = await usingSpan(taskSpan, () =>
+          withTimeout(Promise.resolve(task(evalCase.input)), timeout),
+        );
+        taskSpan.update({ output });
+      } catch (err) {
+        error = fmtError(err);
+        taskSpan.setError(err);
+        taskSpan.update({ attributes: { [SpanAttributes.EVAL_ERROR]: error } });
+      } finally {
+        taskSpan.end();
+      }
 
-    if (error !== null) {
-      root.setError(error);
-      root.update({ output: error, attributes: { [SpanAttributes.EVAL_ERROR]: error } });
-    } else {
-      root.update({ output });
-      const ctx: ScorerContext = {
+      if (error !== null) {
+        root.setError(error);
+        root.update({ output: error, attributes: { [SpanAttributes.EVAL_ERROR]: error } });
+      } else {
+        root.update({ output });
+        const ctx: ScorerContext = {
+          input: evalCase.input,
+          output,
+          expected: evalCase.expected ?? null,
+          metadata: evalCase.metadata,
+        };
+        for (const scorer of scorers) {
+          const name = fnName(scorer, 'scorer');
+          const scorerInput: Record<string, unknown> = {
+            candidate: output,
+            expected: evalCase.expected ?? null,
+          };
+          if (evalCase.scoreTargetSpanId) scorerInput.target_span_id = evalCase.scoreTargetSpanId;
+          const scorerSpan = startSpan(
+            {
+              name,
+              type: 'scorer',
+              input: scorerInput,
+              attributes: {
+                [SpanAttributes.EVAL_RUN_NAME]: identity.name,
+                [SpanAttributes.EVAL_SCORER_NAME]: name,
+              },
+            },
+            tracer,
+          );
+          try {
+            const raw = await usingSpan(scorerSpan, () => Promise.resolve(scorer(ctx)));
+            const produced = stampScorerVersion(normalizeScoreLike(raw, name), scorer);
+            scores.push(...produced);
+            recordScorerSpan(scorerSpan, produced);
+            if (produced.length > 0) scorerSpan.update({ output: scorerOutputRepr(produced) });
+          } catch (err) {
+            scorerErrors[name] = fmtError(err);
+            scorerSpan.setError(err);
+            scorerSpan.update({
+              output: scorerErrors[name],
+              attributes: { [SpanAttributes.EVAL_ERROR]: scorerErrors[name] },
+            });
+          } finally {
+            scorerSpan.end();
+          }
+        }
+      }
+
+      return {
+        caseId: evalCase.id as string,
         input: evalCase.input,
         output,
         expected: evalCase.expected ?? null,
-        metadata: evalCase.metadata,
+        scores,
+        scorerErrors,
+        error,
+        traceId,
+        durationMs: Math.max(0, performance.now() - startedAt),
       };
-      for (const scorer of scorers) {
-        const name = fnName(scorer, 'scorer');
-        const scorerInput: Record<string, unknown> = {
-          candidate: output,
-          expected: evalCase.expected ?? null,
-        };
-        if (evalCase.scoreTargetSpanId) scorerInput.target_span_id = evalCase.scoreTargetSpanId;
-        const scorerSpan = startSpan(
-          {
-            name,
-            type: 'scorer',
-            input: scorerInput,
-            attributes: {
-              [SpanAttributes.EVAL_RUN_NAME]: identity.name,
-              [SpanAttributes.EVAL_SCORER_NAME]: name,
-            },
-          },
-          tracer,
-        );
-        try {
-          const raw = await usingSpan(scorerSpan, () => Promise.resolve(scorer(ctx)));
-          const produced = stampScorerVersion(normalizeScoreLike(raw, name), scorer);
-          scores.push(...produced);
-          recordScorerSpan(scorerSpan, produced);
-          if (produced.length > 0) scorerSpan.update({ output: scorerOutputRepr(produced) });
-        } catch (err) {
-          scorerErrors[name] = fmtError(err);
-          scorerSpan.setError(err);
-          scorerSpan.update({
-            output: scorerErrors[name],
-            attributes: { [SpanAttributes.EVAL_ERROR]: scorerErrors[name] },
-          });
-        } finally {
-          scorerSpan.end();
-        }
-      }
-    }
-
-    return {
-      caseId: evalCase.id as string,
-      input: evalCase.input,
-      output,
-      expected: evalCase.expected ?? null,
-      scores,
-      scorerErrors,
-      error,
-      traceId,
-      durationMs: Math.max(0, performance.now() - startedAt),
-    };
-  });
-
-  root.end();
+    });
+  } finally {
+    root.end();
+  }
   await transport.recordItemResult(run, result);
   await transport.recordScores(run, result.caseId, result.scores);
   onCaseComplete?.(result, result.durationMs ?? 0);

--- a/packages/traceroot/src/eval/engine.ts
+++ b/packages/traceroot/src/eval/engine.ts
@@ -1,0 +1,504 @@
+// src/eval/engine.ts — local evaluation engine.
+// Parity with traceroot-py/traceroot/eval/engine.py: sync/async tasks and scorers, bounded
+// concurrency, deterministic ordering, per-case and per-scorer failure isolation, timeout,
+// deferred scores, run scorers, provenance, scorer metadata, and a trace-native span tree
+// (evaluation-item -> task -> scorer) with standard span I/O + the versioned identity.
+
+import { SpanAttributes } from '../constants';
+import { TraceRoot } from '../traceroot';
+import { startSpan, usingSpan, Span } from '../spans';
+import { Dataset, DeferredScore, EvalCase, Score, ScorerContext } from './types';
+import {
+  EvalItemResult,
+  EvalRunResult,
+  RunDatasetRef,
+  RunView,
+  ScoreSummary,
+  aggregateScores,
+  makeRunResult,
+} from './results';
+import { EvalTransport, LocalTransport, RunHandle } from './transport';
+import { PlatformTransport } from './platform';
+import { collectRunProvenance } from './provenance';
+import { declaredVersion, describeScorers } from './scorers';
+import { newRunId } from './ids';
+
+export type TaskFn = (input: unknown) => unknown | Promise<unknown>;
+export type ScoreLike =
+  | number
+  | boolean
+  | string
+  | Score
+  | Score[]
+  | DeferredScore
+  | null
+  | undefined;
+export type ScorerFn = (ctx: ScorerContext) => ScoreLike | Promise<ScoreLike>;
+export type RunScorerFn = (view: RunView) => ScoreLike | Promise<ScoreLike>;
+
+export interface EvaluateOptions {
+  name: string;
+  /** The dataset (or inline cases) to run. `data` is a back-compat alias of `dataset`. */
+  dataset?: Dataset | EvalCase[];
+  data?: Dataset | EvalCase[];
+  task: TaskFn;
+  scorers: ScorerFn[];
+  runScorers?: RunScorerFn[];
+  candidateVersion?: string;
+  datasetId?: string;
+  maxConcurrency?: number;
+  /** Bounds each case (seconds); a timeout is an isolated per-case error. */
+  timeout?: number;
+  metadata?: Record<string, unknown> | null;
+  select?: (c: EvalCase) => boolean;
+  environment?: string;
+  /** Explicit transport wins over the default upload decision (e.g. baseline linking). */
+  transport?: EvalTransport;
+  /** Opt out of the upload-by-default behavior; keep the run local. */
+  local?: boolean;
+  /** A prior run to link as the baseline (auto-links baselineRunId when reporting). */
+  baseline?: EvalRunResult;
+  /** Internal hooks the CLI runner uses to stream per-case events. */
+  onCaseStart?: (c: EvalCase) => void;
+  onCaseComplete?: (item: EvalItemResult, durationMs: number) => void;
+}
+
+interface RunIdentity {
+  name: string;
+  datasetName: string;
+  datasetId: string;
+  datasetVersionId: string | null;
+  candidateVersion: string | null;
+  environment: string;
+  runId: string | null;
+  localRunId: string;
+}
+
+const INLINE_DATASET = '<inline>';
+const EVAL_ATTR_CONTRACT_VERSION = '1';
+const ZERO_TRACE_ID = /^0+$/;
+
+function fmtError(err: unknown): string {
+  return err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+}
+
+function normalizeData(data: Dataset | EvalCase[]): EvalCase[] {
+  const raw = data instanceof Dataset ? [...data] : data;
+  return raw.map((c, i) => {
+    if (typeof c !== 'object' || c === null || !('input' in c)) {
+      throw new Error(`dataset item at index ${i} is missing required 'input'`);
+    }
+    return c.id === undefined || c.id === null ? { ...c, id: `case-${i}` } : c;
+  });
+}
+
+function toScore(s: Score): Score {
+  return {
+    name: s.name,
+    value: s.value,
+    comment: s.comment ?? null,
+    metadata: s.metadata ?? null,
+    version: s.version ?? null,
+  };
+}
+
+function assertScoreShape(s: unknown): asserts s is Score {
+  if (typeof s !== 'object' || s === null || !('name' in s) || !('value' in s)) {
+    throw new Error("scorer result object must contain 'name' and 'value'");
+  }
+}
+
+function normalizeScoreLike(raw: ScoreLike, defaultName: string): Score[] {
+  if (raw === null || raw === undefined) return [];
+  if (raw instanceof DeferredScore) {
+    // A deferred/human score is pending, never a numeric zero.
+    return [
+      {
+        name: raw.name,
+        value: 'pending',
+        comment: raw.reason ?? null,
+        metadata: { deferred: true },
+      },
+    ];
+  }
+  if (Array.isArray(raw)) {
+    return raw.map((s) => {
+      assertScoreShape(s);
+      return toScore(s);
+    });
+  }
+  if (typeof raw === 'object') {
+    assertScoreShape(raw);
+    return [toScore(raw)];
+  }
+  return [{ name: defaultName, value: raw, comment: null, metadata: null }];
+}
+
+/** Apply a scorer's declared version to produced scores that didn't set their own. */
+function stampScorerVersion(scores: Score[], scorer: ScorerFn): Score[] {
+  const declared = declaredVersion(scorer);
+  if (declared === null) return scores;
+  return scores.map((s) => (s.version != null ? s : { ...s, version: declared }));
+}
+
+function fnName(fn: (...args: never[]) => unknown, fallback: string): string {
+  return fn.name && fn.name.length > 0 ? fn.name : fallback;
+}
+
+/** Bounded, order-preserving worker pool (backpressure: at most `limit` active). */
+async function runBounded<T>(
+  n: number,
+  limit: number,
+  worker: (index: number) => Promise<T>,
+): Promise<T[]> {
+  const results: T[] = new Array(n);
+  let next = 0;
+  async function runner(): Promise<void> {
+    for (;;) {
+      const i = next++;
+      if (i >= n) return;
+      results[i] = await worker(i);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, n) }, () => runner()));
+  return results;
+}
+
+function setSpanAttr(
+  span: Span,
+  key: string,
+  value: string | number | boolean | null | undefined,
+): void {
+  if (value === null || value === undefined) return;
+  span.update({ attributes: { [key]: value } });
+}
+
+function setRootAttrs(root: Span, identity: RunIdentity, evalCase: EvalCase): void {
+  const A = SpanAttributes;
+  root.update({
+    attributes: {
+      [A.SPAN_TYPE]: 'evaluation',
+      [A.EVAL_CONTRACT_VERSION]: EVAL_ATTR_CONTRACT_VERSION,
+      [A.TRACEROOT_ENVIRONMENT]: identity.environment,
+      [A.EVAL_ENVIRONMENT]: identity.environment,
+      [A.EVAL_NAME]: identity.name,
+      [A.EVAL_RUN_NAME]: identity.name,
+      [A.EVAL_DATASET_NAME]: identity.datasetName,
+      [A.EVAL_CASE_ID]: evalCase.id as string,
+      [A.EVAL_HAS_EXPECTED]: evalCase.expected !== undefined && evalCase.expected !== null,
+    },
+  });
+  setSpanAttr(root, A.EVAL_DATASET_ID, identity.datasetId);
+  setSpanAttr(root, A.EVAL_DATASET_VERSION_ID, identity.datasetVersionId);
+  setSpanAttr(root, A.EVAL_CANDIDATE_VERSION, identity.candidateVersion);
+  setSpanAttr(root, A.EVAL_RUN_ID, identity.runId);
+  setSpanAttr(root, A.EVAL_LOCAL_RUN_ID, identity.localRunId);
+  setSpanAttr(root, A.EVAL_SOURCE_TRACE_ID, evalCase.sourceTraceId);
+  setSpanAttr(root, A.EVAL_SOURCE_SPAN_ID, evalCase.sourceSpanId);
+  setSpanAttr(root, A.EVAL_SCORE_TARGET_SPAN_ID, evalCase.scoreTargetSpanId);
+}
+
+function scorerOutputRepr(scores: Score[]): Array<Record<string, unknown>> {
+  return scores.map((s) => ({ name: s.name, value: s.value, explanation: s.comment ?? null }));
+}
+
+function recordScorerSpan(span: Span, scores: Score[]): void {
+  if (scores.length === 0) return;
+  const first = scores[0];
+  const attrs: Record<string, string | number | boolean> = {
+    [SpanAttributes.EVAL_SCORE_VALUE]: first.value,
+  };
+  if (first.comment != null) attrs[SpanAttributes.EVAL_SCORE_COMMENT] = first.comment;
+  span.update({ attributes: attrs });
+}
+
+async function withTimeout<T>(p: Promise<T>, timeout?: number): Promise<T> {
+  if (timeout === undefined) return p;
+  return Promise.race([
+    p,
+    new Promise<T>((_res, rej) =>
+      setTimeout(() => rej(new Error(`TimeoutError: task exceeded ${timeout}s`)), timeout * 1000),
+    ),
+  ]);
+}
+
+async function runCase(
+  evalCase: EvalCase,
+  task: TaskFn,
+  scorers: ScorerFn[],
+  identity: RunIdentity,
+  transport: EvalTransport,
+  run: RunHandle,
+  reporting: boolean,
+  timeout?: number,
+  onCaseStart?: (c: EvalCase) => void,
+  onCaseComplete?: (item: EvalItemResult, durationMs: number) => void,
+): Promise<EvalItemResult> {
+  onCaseStart?.(evalCase);
+  await transport.registerItem(run, evalCase);
+
+  const startedAt = performance.now();
+  const root = startSpan({ name: 'evaluation-item', type: 'evaluation', input: evalCase.input });
+  setRootAttrs(root, identity, evalCase);
+  const rawTraceId = root.traceId;
+  const traceId = reporting && !ZERO_TRACE_ID.test(rawTraceId) ? rawTraceId : null;
+
+  const result = await usingSpan(root, async (): Promise<EvalItemResult> => {
+    let output: unknown = null;
+    let error: string | null = null;
+    const scores: Score[] = [];
+    const scorerErrors: Record<string, string> = {};
+
+    const taskSpan = startSpan({
+      name: 'task',
+      type: 'task',
+      input: evalCase.input,
+      attributes: {
+        [SpanAttributes.EVAL_RUN_NAME]: identity.name,
+        [SpanAttributes.EVAL_CASE_ID]: evalCase.id as string,
+        [SpanAttributes.EVAL_TASK_NAME]: fnName(task, 'task'),
+      },
+    });
+    try {
+      output = await usingSpan(taskSpan, () =>
+        withTimeout(Promise.resolve(task(evalCase.input)), timeout),
+      );
+      taskSpan.update({ output });
+    } catch (err) {
+      error = fmtError(err);
+      taskSpan.setError(err);
+      taskSpan.update({ attributes: { [SpanAttributes.EVAL_ERROR]: error } });
+    } finally {
+      taskSpan.end();
+    }
+
+    if (error !== null) {
+      root.setError(error);
+      root.update({ output: error, attributes: { [SpanAttributes.EVAL_ERROR]: error } });
+    } else {
+      root.update({ output });
+      const ctx: ScorerContext = {
+        input: evalCase.input,
+        output,
+        expected: evalCase.expected ?? null,
+        metadata: evalCase.metadata,
+      };
+      for (const scorer of scorers) {
+        const name = fnName(scorer, 'scorer');
+        const scorerInput: Record<string, unknown> = {
+          candidate: output,
+          expected: evalCase.expected ?? null,
+        };
+        if (evalCase.scoreTargetSpanId) scorerInput.target_span_id = evalCase.scoreTargetSpanId;
+        const scorerSpan = startSpan({
+          name,
+          type: 'scorer',
+          input: scorerInput,
+          attributes: {
+            [SpanAttributes.EVAL_RUN_NAME]: identity.name,
+            [SpanAttributes.EVAL_SCORER_NAME]: name,
+          },
+        });
+        try {
+          const raw = await usingSpan(scorerSpan, () => Promise.resolve(scorer(ctx)));
+          const produced = stampScorerVersion(normalizeScoreLike(raw, name), scorer);
+          scores.push(...produced);
+          recordScorerSpan(scorerSpan, produced);
+          if (produced.length > 0) scorerSpan.update({ output: scorerOutputRepr(produced) });
+        } catch (err) {
+          scorerErrors[name] = fmtError(err);
+          scorerSpan.setError(err);
+          scorerSpan.update({
+            output: scorerErrors[name],
+            attributes: { [SpanAttributes.EVAL_ERROR]: scorerErrors[name] },
+          });
+        } finally {
+          scorerSpan.end();
+        }
+      }
+    }
+
+    return {
+      caseId: evalCase.id as string,
+      input: evalCase.input,
+      output,
+      expected: evalCase.expected ?? null,
+      scores,
+      scorerErrors,
+      error,
+      traceId,
+      durationMs: Math.max(0, performance.now() - startedAt),
+    };
+  });
+
+  root.end();
+  await transport.recordItemResult(run, result);
+  await transport.recordScores(run, result.caseId, result.scores);
+  onCaseComplete?.(result, result.durationMs ?? 0);
+  return result;
+}
+
+/** Whole-run scorers over the completed items. Errors are isolated per scorer. */
+async function runRunScorers(
+  runScorers: RunScorerFn[] | undefined,
+  name: string,
+  itemResults: EvalItemResult[],
+  summary: Record<string, ScoreSummary>,
+): Promise<{ runScores: Score[]; runScorerErrors: Record<string, string> }> {
+  const runScores: Score[] = [];
+  const runScorerErrors: Record<string, string> = {};
+  if (!runScorers || runScorers.length === 0) return { runScores, runScorerErrors };
+  const view: RunView = { name, itemResults, scoreSummary: summary };
+  for (const rs of runScorers) {
+    const rname = fnName(rs, 'run_scorer');
+    try {
+      const raw = await Promise.resolve(rs(view));
+      runScores.push(...normalizeScoreLike(raw, rname));
+    } catch (err) {
+      runScorerErrors[rname] = fmtError(err);
+    }
+  }
+  return { runScores, runScorerErrors };
+}
+
+/**
+ * Reporting default (matches Braintrust/Langfuse/Laminar): upload when credentials + a
+ * platform dataset (pulled/pushed, or an explicit datasetId) exist. Returns null to stay
+ * local — no credentials, or a purely local dataset the SDK cannot create server-side.
+ */
+function autoTransport(
+  data: Dataset | EvalCase[],
+  datasetId: string | undefined,
+  scorers: ScorerFn[],
+  candidateVersion: string | undefined,
+  environment: string | undefined,
+  baselineRunId: string | null,
+): EvalTransport | null {
+  let effectiveId = datasetId;
+  let versionId: string | null = null;
+  if (data instanceof Dataset) {
+    versionId = data.datasetVersionId ?? null;
+    if (effectiveId === undefined && data.datasetId && versionId !== null)
+      effectiveId = data.datasetId;
+  }
+  if (!effectiveId) return null;
+  const { apiKey } = TraceRoot.resolveCredentials();
+  if (!apiKey) return null;
+  return new PlatformTransport(effectiveId, {
+    scorerNames: scorers.map((s) => fnName(s, 'scorer')),
+    candidateVersion: candidateVersion ?? null,
+    environment,
+    datasetVersionId: versionId,
+    baselineRunId,
+  });
+}
+
+/** Run an evaluation. Async-first; `evaluate` is an alias of `evaluateAsync`. */
+export async function evaluateAsync(options: EvaluateOptions): Promise<EvalRunResult> {
+  const { name, task, scorers, maxConcurrency = 10, transport, candidateVersion } = options;
+  const environment = options.environment ?? 'evaluation';
+  const data = options.dataset ?? options.data;
+
+  if (!name || name.trim().length === 0) throw new Error("evaluate() requires a non-empty 'name'");
+  if (data === undefined) throw new Error("evaluate() requires 'dataset' (or the 'data' alias)");
+  if (typeof task !== 'function') throw new Error("'task' must be a function");
+  if (!scorers || scorers.length === 0) throw new Error('evaluate() requires at least one scorer');
+  for (const s of scorers) {
+    if (typeof s !== 'function') throw new Error(`scorer ${String(s)} is not a function`);
+  }
+  if (maxConcurrency < 1) throw new Error("'maxConcurrency' must be >= 1");
+
+  let cases = normalizeData(data);
+  if (options.select) cases = cases.filter(options.select);
+  if (cases.length === 0) throw new Error('evaluate() requires at least one case to run');
+
+  const datasetName = data instanceof Dataset ? data.name : INLINE_DATASET;
+  const snapshotRevision =
+    data instanceof Dataset ? data.snapshot().revision : `local-${cases.length}`;
+  const runMetadata = collectRunProvenance(options.metadata, { detectDirty: false });
+
+  // Reporting decision: explicit transport wins; else local:true keeps local; else upload
+  // when credentials + a platform dataset exist.
+  let active: EvalTransport;
+  if (transport !== undefined) {
+    active = transport;
+  } else if (options.local) {
+    active = new LocalTransport();
+  } else {
+    const baselineRunId = options.baseline?.runId ?? null;
+    active =
+      autoTransport(
+        data,
+        options.datasetId,
+        scorers,
+        candidateVersion,
+        environment,
+        baselineRunId,
+      ) ?? new LocalTransport();
+  }
+
+  // Forward scorer comparison metadata to a transport that accepts specs (before createRun).
+  if ('scorerSpecs' in active && (active as PlatformTransport).scorerSpecs === undefined) {
+    (active as PlatformTransport).scorerSpecs = describeScorers(scorers);
+  }
+
+  const reporting = active.reportsTraces === true;
+  const localRunId = newRunId();
+  const run = await active.createRun(name, datasetName, runMetadata);
+
+  const identity: RunIdentity = {
+    name,
+    datasetName,
+    datasetId: options.datasetId ?? (data instanceof Dataset ? data.datasetId : 'ds_inline'),
+    datasetVersionId: data instanceof Dataset ? (data.datasetVersionId ?? null) : null,
+    candidateVersion: candidateVersion ?? null,
+    environment,
+    runId: active.runId ?? null,
+    localRunId,
+  };
+
+  const itemResults = await runBounded(cases.length, maxConcurrency, (i) =>
+    runCase(
+      cases[i],
+      task,
+      scorers,
+      identity,
+      active,
+      run,
+      reporting,
+      options.timeout,
+      options.onCaseStart,
+      options.onCaseComplete,
+    ),
+  );
+  const uploadState = await active.finishRun(run);
+
+  const summary = aggregateScores(itemResults);
+  const { runScores, runScorerErrors } = await runRunScorers(
+    options.runScorers,
+    name,
+    itemResults,
+    summary,
+  );
+
+  const datasetRef: RunDatasetRef = {
+    datasetId: identity.datasetId,
+    revision: snapshotRevision,
+    datasetVersionId: identity.datasetVersionId,
+    caseCount: cases.length,
+  };
+
+  return makeRunResult(name, itemResults, uploadState, {
+    localRunId,
+    runId: active.runId ?? null,
+    candidateVersion: candidateVersion ?? null,
+    dataset: datasetRef,
+    metadata: runMetadata,
+    baseline: options.baseline ?? null,
+    runScores,
+    runScorerErrors,
+  });
+}
+
+/** Alias of {@link evaluateAsync}. TypeScript has no blocking mode; both return a Promise. */
+export const evaluate = evaluateAsync;

--- a/packages/traceroot/src/eval/engine.ts
+++ b/packages/traceroot/src/eval/engine.ts
@@ -6,7 +6,15 @@
 
 import { SpanAttributes } from '../constants';
 import { TraceRoot } from '../traceroot';
-import { startSpan, usingSpan, Span } from '../spans';
+import {
+  startSpan,
+  usingSpan,
+  Span,
+  _pushSuppressGlobalAutoInit as pushSuppressGlobalAutoInit,
+  _popSuppressGlobalAutoInit as popSuppressGlobalAutoInit,
+} from '../spans';
+import type { Tracer } from '@opentelemetry/api';
+import { evalTracer } from './tracer';
 import { Dataset, DeferredScore, EvalCase, Score, ScorerContext } from './types';
 import {
   EvalItemResult,
@@ -236,7 +244,8 @@ async function runCase(
   transport: EvalTransport,
   run: RunHandle,
   reporting: boolean,
-  timeout?: number,
+  timeout: number | undefined,
+  tracer: Tracer,
   onCaseStart?: (c: EvalCase) => void,
   onCaseComplete?: (item: EvalItemResult, durationMs: number) => void,
 ): Promise<EvalItemResult> {
@@ -244,7 +253,10 @@ async function runCase(
   await transport.registerItem(run, evalCase);
 
   const startedAt = performance.now();
-  const root = startSpan({ name: 'evaluation-item', type: 'evaluation', input: evalCase.input });
+  const root = startSpan(
+    { name: 'evaluation-item', type: 'evaluation', input: evalCase.input },
+    tracer,
+  );
   setRootAttrs(root, identity, evalCase);
   const rawTraceId = root.traceId;
   const traceId = reporting && !ZERO_TRACE_ID.test(rawTraceId) ? rawTraceId : null;
@@ -255,16 +267,19 @@ async function runCase(
     const scores: Score[] = [];
     const scorerErrors: Record<string, string> = {};
 
-    const taskSpan = startSpan({
-      name: 'task',
-      type: 'task',
-      input: evalCase.input,
-      attributes: {
-        [SpanAttributes.EVAL_RUN_NAME]: identity.name,
-        [SpanAttributes.EVAL_CASE_ID]: evalCase.id as string,
-        [SpanAttributes.EVAL_TASK_NAME]: fnName(task, 'task'),
+    const taskSpan = startSpan(
+      {
+        name: 'task',
+        type: 'task',
+        input: evalCase.input,
+        attributes: {
+          [SpanAttributes.EVAL_RUN_NAME]: identity.name,
+          [SpanAttributes.EVAL_CASE_ID]: evalCase.id as string,
+          [SpanAttributes.EVAL_TASK_NAME]: fnName(task, 'task'),
+        },
       },
-    });
+      tracer,
+    );
     try {
       output = await usingSpan(taskSpan, () =>
         withTimeout(Promise.resolve(task(evalCase.input)), timeout),
@@ -296,15 +311,18 @@ async function runCase(
           expected: evalCase.expected ?? null,
         };
         if (evalCase.scoreTargetSpanId) scorerInput.target_span_id = evalCase.scoreTargetSpanId;
-        const scorerSpan = startSpan({
-          name,
-          type: 'scorer',
-          input: scorerInput,
-          attributes: {
-            [SpanAttributes.EVAL_RUN_NAME]: identity.name,
-            [SpanAttributes.EVAL_SCORER_NAME]: name,
+        const scorerSpan = startSpan(
+          {
+            name,
+            type: 'scorer',
+            input: scorerInput,
+            attributes: {
+              [SpanAttributes.EVAL_RUN_NAME]: identity.name,
+              [SpanAttributes.EVAL_SCORER_NAME]: name,
+            },
           },
-        });
+          tracer,
+        );
         try {
           const raw = await usingSpan(scorerSpan, () => Promise.resolve(scorer(ctx)));
           const produced = stampScorerVersion(normalizeScoreLike(raw, name), scorer);
@@ -449,6 +467,10 @@ export async function evaluateAsync(options: EvaluateOptions): Promise<EvalRunRe
   }
 
   const reporting = active.reportsTraces === true;
+  // Eval structural spans go through this tracer. For a local run it is a private,
+  // non-exporting tracer that also avoids initializing the global exporting provider,
+  // so a local eval never exports spans even when TRACEROOT_API_KEY is set.
+  const evalSpanTracer = evalTracer(reporting);
   const localRunId = newRunId();
   const run = await active.createRun(name, datasetName, runMetadata);
 
@@ -477,6 +499,10 @@ export async function evaluateAsync(options: EvaluateOptions): Promise<EvalRunRe
     };
   }
 
+  // For a local run, suppress lazy global-provider init for the duration so nested
+  // application spans (user startSpan/observe, auto-instrumentation) created inside a
+  // task/scorer cannot bring up the OTLP exporter and leak. No-op for a reported run.
+  if (!reporting) pushSuppressGlobalAutoInit();
   let itemResults: EvalItemResult[];
   try {
     itemResults = await runBounded(cases.length, maxConcurrency, (i) =>
@@ -489,11 +515,13 @@ export async function evaluateAsync(options: EvaluateOptions): Promise<EvalRunRe
         run,
         reporting,
         options.timeout,
+        evalSpanTracer,
         options.onCaseStart,
         onCaseComplete,
       ),
     );
   } finally {
+    if (!reporting) popSuppressGlobalAutoInit();
     reporter?.finish();
   }
   const uploadState = await active.finishRun(run);

--- a/packages/traceroot/src/eval/engine.ts
+++ b/packages/traceroot/src/eval/engine.ts
@@ -1,4 +1,4 @@
-// src/eval/engine.ts — local evaluation engine.
+// src/eval/engine.ts — evaluation engine.
 // Parity with traceroot-py/traceroot/eval/engine.py: sync/async tasks and scorers, bounded
 // concurrency, deterministic ordering, per-case and per-scorer failure isolation, timeout,
 // deferred scores, run scorers, provenance, scorer metadata, and a trace-native span tree
@@ -6,13 +6,7 @@
 
 import { SpanAttributes } from '../constants';
 import { TraceRoot } from '../traceroot';
-import {
-  startSpan,
-  usingSpan,
-  Span,
-  _pushSuppressGlobalAutoInit as pushSuppressGlobalAutoInit,
-  _popSuppressGlobalAutoInit as popSuppressGlobalAutoInit,
-} from '../spans';
+import { startSpan, usingSpan, Span } from '../spans';
 import type { Tracer } from '@opentelemetry/api';
 import { evalTracer } from './tracer';
 import { Dataset, DeferredScore, EvalCase, Score, ScorerContext } from './types';
@@ -25,7 +19,7 @@ import {
   aggregateScores,
   makeRunResult,
 } from './results';
-import { EvalTransport, LocalTransport, RunHandle } from './transport';
+import { EvalTransport, RunHandle } from './transport';
 import { PlatformTransport } from './platform';
 import { collectRunProvenance } from './provenance';
 import { declaredVersion, describeScorers } from './scorers';
@@ -61,10 +55,8 @@ export interface EvaluateOptions {
   metadata?: Record<string, unknown> | null;
   select?: (c: EvalCase) => boolean;
   environment?: string;
-  /** Explicit transport wins over the default upload decision. */
+  /** Explicit transport wins over the default reporting transport. */
   transport?: EvalTransport;
-  /** Opt out of the upload-by-default behavior; keep the run local. */
-  local?: boolean;
   /**
    * Live console progress bar. Undefined = auto (on for an interactive
    * terminal, off when piped/CI); true/false forces it.
@@ -241,7 +233,6 @@ async function runCase(
   identity: RunIdentity,
   transport: EvalTransport,
   run: RunHandle,
-  reporting: boolean,
   timeout: number | undefined,
   tracer: Tracer,
   onCaseStart?: (c: EvalCase) => void,
@@ -257,7 +248,8 @@ async function runCase(
   );
   setRootAttrs(root, identity, evalCase);
   const rawTraceId = root.traceId;
-  const traceId = reporting && !ZERO_TRACE_ID.test(rawTraceId) ? rawTraceId : null;
+  // A reported run exports its per-case spans, so the result carries the trace id.
+  const traceId = !ZERO_TRACE_ID.test(rawTraceId) ? rawTraceId : null;
 
   const result = await usingSpan(root, async (): Promise<EvalItemResult> => {
     let output: unknown = null;
@@ -384,9 +376,9 @@ async function runRunScorers(
 }
 
 /**
- * Reporting default (matches Braintrust/Langfuse/Laminar): upload when credentials + a
- * platform dataset (pulled/pushed, or an explicit datasetId) exist. Returns null to stay
- * local — no credentials, or a purely local dataset the SDK cannot create server-side.
+ * Build the reporting transport from credentials + a synced dataset (pulled/pushed, or an
+ * explicit datasetId). Returns null when it cannot (no credentials, or an unsynced dataset the
+ * SDK cannot create server-side); the caller turns that into a clear error (cloud-only).
  */
 function autoTransport(
   data: Dataset | EvalCase[],
@@ -437,17 +429,21 @@ export async function evaluateAsync(options: EvaluateOptions): Promise<EvalRunRe
     data instanceof Dataset ? data.snapshot().revision : `local-${cases.length}`;
   const runMetadata = collectRunProvenance(options.metadata, { detectDirty: false });
 
-  // Reporting decision: explicit transport wins; else local:true keeps local; else upload
-  // when credentials + a platform dataset exist.
+  // Cloud-only: an explicit transport wins; otherwise build a reporting transport from
+  // credentials + a synced dataset. Evaluation always reports -- there is no local run.
   let active: EvalTransport;
   if (transport !== undefined) {
     active = transport;
-  } else if (options.local) {
-    active = new LocalTransport();
   } else {
-    active =
-      autoTransport(data, options.datasetId, scorers, candidateVersion, environment) ??
-      new LocalTransport();
+    const auto = autoTransport(data, options.datasetId, scorers, candidateVersion, environment);
+    if (auto === null) {
+      throw new Error(
+        'evaluate() reports to the TraceRoot platform, but no credentials or synced dataset ' +
+          'were found. Set TRACEROOT_API_KEY and pass a pulled dataset (pullDataset(...)), or ' +
+          'pass an explicit transport.',
+      );
+    }
+    active = auto;
   }
 
   // Forward scorer comparison metadata to a transport that accepts specs (before createRun).
@@ -455,11 +451,8 @@ export async function evaluateAsync(options: EvaluateOptions): Promise<EvalRunRe
     (active as PlatformTransport).scorerSpecs = describeScorers(scorers);
   }
 
-  const reporting = active.reportsTraces === true;
-  // Eval structural spans go through this tracer. For a local run it is a private,
-  // non-exporting tracer that also avoids initializing the global exporting provider,
-  // so a local eval never exports spans even when TRACEROOT_API_KEY is set.
-  const evalSpanTracer = evalTracer(reporting);
+  // Eval structural spans always export (cloud-only) and are linked to the reported results.
+  const evalSpanTracer = evalTracer();
   const localRunId = newRunId();
   const run = await active.createRun(name, datasetName, runMetadata);
 
@@ -488,10 +481,6 @@ export async function evaluateAsync(options: EvaluateOptions): Promise<EvalRunRe
     };
   }
 
-  // For a local run, suppress lazy global-provider init for the duration so nested
-  // application spans (user startSpan/observe, auto-instrumentation) created inside a
-  // task/scorer cannot bring up the OTLP exporter and leak. No-op for a reported run.
-  if (!reporting) pushSuppressGlobalAutoInit();
   let itemResults: EvalItemResult[];
   try {
     itemResults = await runBounded(cases.length, maxConcurrency, (i) =>
@@ -502,7 +491,6 @@ export async function evaluateAsync(options: EvaluateOptions): Promise<EvalRunRe
         identity,
         active,
         run,
-        reporting,
         options.timeout,
         evalSpanTracer,
         options.onCaseStart,
@@ -510,7 +498,6 @@ export async function evaluateAsync(options: EvaluateOptions): Promise<EvalRunRe
       ),
     );
   } finally {
-    if (!reporting) popSuppressGlobalAutoInit();
     reporter?.finish();
   }
   const uploadState = await active.finishRun(run);

--- a/packages/traceroot/src/eval/engine.ts
+++ b/packages/traceroot/src/eval/engine.ts
@@ -469,7 +469,11 @@ export async function evaluateAsync(options: EvaluateOptions): Promise<EvalRunRe
   for (const s of scorers) {
     if (typeof s !== 'function') throw new Error(`scorer ${String(s)} is not a function`);
   }
-  if (maxConcurrency < 1) throw new Error("'maxConcurrency' must be >= 1");
+  if (!Number.isInteger(maxConcurrency) || maxConcurrency < 1) {
+    // Guard NaN / fractional / non-finite too: runBounded would otherwise launch zero workers and
+    // silently leave every case unprocessed.
+    throw new Error("'maxConcurrency' must be a positive integer");
+  }
 
   let cases = normalizeData(data);
   if (options.select) cases = cases.filter(options.select);

--- a/packages/traceroot/src/eval/engine.ts
+++ b/packages/traceroot/src/eval/engine.ts
@@ -22,7 +22,7 @@ import { PlatformTransport } from './platform';
 import { collectRunProvenance } from './provenance';
 import { declaredVersion, describeScorers } from './scorers';
 import { newRunId } from './ids';
-import { ConsoleProgress, shouldShowProgress } from './progress';
+import { ConsoleProgress, printRunUrl, shouldShowProgress } from './progress';
 
 export type TaskFn = (input: unknown) => unknown | Promise<unknown>;
 export type ScoreLike =
@@ -497,6 +497,12 @@ export async function evaluateAsync(options: EvaluateOptions): Promise<EvalRunRe
     reporter?.finish();
   }
   const uploadState = await active.finishRun(run);
+
+  // When the bar was shown (interactive), surface a clickable run link if the
+  // backend returned one. Off-terminal callers read result.uploadState instead.
+  if (reporter && uploadState.dashboardUrl) {
+    printRunUrl(uploadState.dashboardUrl);
+  }
 
   const summary = aggregateScores(itemResults);
   const { runScores, runScorerErrors } = await runRunScorers(

--- a/packages/traceroot/src/eval/engine.ts
+++ b/packages/traceroot/src/eval/engine.ts
@@ -498,12 +498,6 @@ export async function evaluateAsync(options: EvaluateOptions): Promise<EvalRunRe
   }
   const uploadState = await active.finishRun(run);
 
-  // When the bar was shown (interactive), surface a clickable run link if the
-  // backend returned one. Off-terminal callers read result.uploadState instead.
-  if (reporter && uploadState.dashboardUrl) {
-    printRunUrl(uploadState.dashboardUrl);
-  }
-
   const summary = aggregateScores(itemResults);
   const { runScores, runScorerErrors } = await runRunScorers(
     options.runScorers,
@@ -519,7 +513,7 @@ export async function evaluateAsync(options: EvaluateOptions): Promise<EvalRunRe
     caseCount: cases.length,
   };
 
-  return makeRunResult(name, itemResults, uploadState, {
+  const result = makeRunResult(name, itemResults, uploadState, {
     localRunId,
     runId: active.runId ?? null,
     candidateVersion: candidateVersion ?? null,
@@ -529,6 +523,20 @@ export async function evaluateAsync(options: EvaluateOptions): Promise<EvalRunRe
     runScores,
     runScorerErrors,
   });
+
+  // When the bar was shown (interactive), print a closing block: the
+  // candidate-vs-baseline comparison when a baseline exists (it carries the run
+  // link), otherwise just the clickable run link. Off-terminal callers read the
+  // returned result instead.
+  if (reporter) {
+    if (options.baseline) {
+      process.stderr.write(result.comparisonReport(options.baseline) + '\n');
+    } else if (uploadState.dashboardUrl) {
+      printRunUrl(uploadState.dashboardUrl);
+    }
+  }
+
+  return result;
 }
 
 /** Alias of {@link evaluateAsync}. TypeScript has no blocking mode; both return a Promise. */

--- a/packages/traceroot/src/eval/engine.ts
+++ b/packages/traceroot/src/eval/engine.ts
@@ -218,14 +218,18 @@ function recordScorerSpan(span: Span, scores: Score[]): void {
   span.update({ attributes: attrs });
 }
 
-async function withTimeout<T>(p: Promise<T>, timeout?: number): Promise<T> {
+/** A per-case deadline expiry. Distinct type so the scorer loop can tell a budget overrun
+ *  (which errors the whole case) apart from an ordinary per-scorer failure (which is isolated). */
+class EvalTimeoutError extends Error {}
+
+/** Race `p` against the case's shared deadline. `deadline` is an absolute performance.now() ms
+ *  mark covering task + scorers together, so a never-resolving scorer can't outlive the budget. */
+async function withTimeout<T>(p: Promise<T>, timeout?: number, deadline?: number): Promise<T> {
   if (timeout === undefined) return p;
+  const ms = deadline !== undefined ? Math.max(0, deadline - performance.now()) : timeout * 1000;
   let handle: ReturnType<typeof setTimeout>;
   const timer = new Promise<T>((_res, rej) => {
-    handle = setTimeout(
-      () => rej(new Error(`TimeoutError: task exceeded ${timeout}s`)),
-      timeout * 1000,
-    );
+    handle = setTimeout(() => rej(new EvalTimeoutError(`TimeoutError: case exceeded ${timeout}s`)), ms);
   });
   try {
     return await Promise.race([p, timer]);
@@ -271,6 +275,8 @@ async function runCase(
       let error: string | null = null;
       const scores: Score[] = [];
       const scorerErrors: Record<string, string> = {};
+      // One deadline for the whole case (task + scorers), so a hung scorer cannot outlive it.
+      const deadline = timeout !== undefined ? performance.now() + timeout * 1000 : undefined;
 
       const taskSpan = startSpan(
         {
@@ -287,7 +293,7 @@ async function runCase(
       );
       try {
         output = await usingSpan(taskSpan, () =>
-          withTimeout(Promise.resolve(task(evalCase.input)), timeout),
+          withTimeout(Promise.resolve(task(evalCase.input)), timeout, deadline),
         );
         taskSpan.update({ output });
       } catch (err) {
@@ -309,41 +315,61 @@ async function runCase(
           expected: evalCase.expected ?? null,
           metadata: evalCase.metadata,
         };
-        for (const scorer of scorers) {
-          const name = fnName(scorer, 'scorer');
-          const scorerInput: Record<string, unknown> = {
-            candidate: output,
-            expected: evalCase.expected ?? null,
-          };
-          if (evalCase.scoreTargetSpanId) scorerInput.target_span_id = evalCase.scoreTargetSpanId;
-          const scorerSpan = startSpan(
-            {
-              name,
-              type: 'scorer',
-              input: scorerInput,
-              attributes: {
-                [SpanAttributes.EVAL_RUN_NAME]: identity.name,
-                [SpanAttributes.EVAL_SCORER_NAME]: name,
+        try {
+          for (const scorer of scorers) {
+            const name = fnName(scorer, 'scorer');
+            const scorerInput: Record<string, unknown> = {
+              candidate: output,
+              expected: evalCase.expected ?? null,
+            };
+            if (evalCase.scoreTargetSpanId) scorerInput.target_span_id = evalCase.scoreTargetSpanId;
+            const scorerSpan = startSpan(
+              {
+                name,
+                type: 'scorer',
+                input: scorerInput,
+                attributes: {
+                  [SpanAttributes.EVAL_RUN_NAME]: identity.name,
+                  [SpanAttributes.EVAL_SCORER_NAME]: name,
+                },
               },
-            },
-            tracer,
-          );
-          try {
-            const raw = await usingSpan(scorerSpan, () => Promise.resolve(scorer(ctx)));
-            const produced = stampScorerVersion(normalizeScoreLike(raw, name), scorer);
-            scores.push(...produced);
-            recordScorerSpan(scorerSpan, produced);
-            if (produced.length > 0) scorerSpan.update({ output: scorerOutputRepr(produced) });
-          } catch (err) {
-            scorerErrors[name] = fmtError(err);
-            scorerSpan.setError(err);
-            scorerSpan.update({
-              output: scorerErrors[name],
-              attributes: { [SpanAttributes.EVAL_ERROR]: scorerErrors[name] },
-            });
-          } finally {
-            scorerSpan.end();
+              tracer,
+            );
+            try {
+              const raw = await usingSpan(scorerSpan, () =>
+                withTimeout(Promise.resolve(scorer(ctx)), timeout, deadline),
+              );
+              const produced = stampScorerVersion(normalizeScoreLike(raw, name), scorer);
+              scores.push(...produced);
+              recordScorerSpan(scorerSpan, produced);
+              if (produced.length > 0) scorerSpan.update({ output: scorerOutputRepr(produced) });
+            } catch (err) {
+              // A deadline hit is a case-level budget overrun, not an isolated scorer failure:
+              // record it on the span and rethrow so the whole case errors (below).
+              if (err instanceof EvalTimeoutError) {
+                scorerSpan.setError(err);
+                scorerSpan.update({
+                  output: fmtError(err),
+                  attributes: { [SpanAttributes.EVAL_ERROR]: fmtError(err) },
+                });
+                throw err;
+              }
+              scorerErrors[name] = fmtError(err);
+              scorerSpan.setError(err);
+              scorerSpan.update({
+                output: scorerErrors[name],
+                attributes: { [SpanAttributes.EVAL_ERROR]: scorerErrors[name] },
+              });
+            } finally {
+              scorerSpan.end();
+            }
           }
+        } catch (err) {
+          // Scoring exceeded the case deadline -> the same isolated per-case error path as a
+          // task timeout (errored case, not scored).
+          error = fmtError(err);
+          root.setError(error);
+          root.update({ output: error, attributes: { [SpanAttributes.EVAL_ERROR]: error } });
         }
       }
 

--- a/packages/traceroot/src/eval/engine.ts
+++ b/packages/traceroot/src/eval/engine.ts
@@ -22,6 +22,7 @@ import { PlatformTransport } from './platform';
 import { collectRunProvenance } from './provenance';
 import { declaredVersion, describeScorers } from './scorers';
 import { newRunId } from './ids';
+import { ConsoleProgress, shouldShowProgress } from './progress';
 
 export type TaskFn = (input: unknown) => unknown | Promise<unknown>;
 export type ScoreLike =
@@ -58,6 +59,11 @@ export interface EvaluateOptions {
   local?: boolean;
   /** A prior run to link as the baseline (auto-links baselineRunId when reporting). */
   baseline?: EvalRunResult;
+  /**
+   * Live console progress bar. Undefined = auto (on for an interactive
+   * terminal, off when piped/CI); true/false forces it.
+   */
+  progress?: boolean;
   /** Internal hooks the CLI runner uses to stream per-case events. */
   onCaseStart?: (c: EvalCase) => void;
   onCaseComplete?: (item: EvalItemResult, durationMs: number) => void;
@@ -457,20 +463,39 @@ export async function evaluateAsync(options: EvaluateOptions): Promise<EvalRunRe
     localRunId,
   };
 
-  const itemResults = await runBounded(cases.length, maxConcurrency, (i) =>
-    runCase(
-      cases[i],
-      task,
-      scorers,
-      identity,
-      active,
-      run,
-      reporting,
-      options.timeout,
-      options.onCaseStart,
-      options.onCaseComplete,
-    ),
-  );
+  // Live console progress bar (local presentation only; auto-on for an
+  // interactive terminal, off when piped/CI). Composes with any caller hooks.
+  let reporter: ConsoleProgress | undefined;
+  let onCaseComplete = options.onCaseComplete;
+  if (shouldShowProgress(options.progress)) {
+    reporter = new ConsoleProgress(cases.length, name);
+    reporter.start();
+    const next = options.onCaseComplete;
+    onCaseComplete = (item, durationMs) => {
+      reporter!.onCaseComplete(item, durationMs);
+      next?.(item, durationMs);
+    };
+  }
+
+  let itemResults: EvalItemResult[];
+  try {
+    itemResults = await runBounded(cases.length, maxConcurrency, (i) =>
+      runCase(
+        cases[i],
+        task,
+        scorers,
+        identity,
+        active,
+        run,
+        reporting,
+        options.timeout,
+        options.onCaseStart,
+        onCaseComplete,
+      ),
+    );
+  } finally {
+    reporter?.finish();
+  }
   const uploadState = await active.finishRun(run);
 
   const summary = aggregateScores(itemResults);

--- a/packages/traceroot/src/eval/engine.ts
+++ b/packages/traceroot/src/eval/engine.ts
@@ -366,8 +366,10 @@ async function runCase(
           }
         } catch (err) {
           // Scoring exceeded the case deadline -> the same isolated per-case error path as a
-          // task timeout (errored case, not scored).
+          // task timeout (errored case, not scored). Drop any scores collected before the timeout
+          // so a timed-out case is truly "not scored" and can't contaminate the summaries/results.
           error = fmtError(err);
+          scores.length = 0;
           root.setError(error);
           root.update({ output: error, attributes: { [SpanAttributes.EVAL_ERROR]: error } });
         }

--- a/packages/traceroot/src/eval/engine.ts
+++ b/packages/traceroot/src/eval/engine.ts
@@ -8,6 +8,7 @@ import { SpanAttributes } from '../constants';
 import { TraceRoot } from '../traceroot';
 import { startSpan, usingSpan, Span } from '../spans';
 import type { Tracer } from '@opentelemetry/api';
+import { context, ROOT_CONTEXT } from '@opentelemetry/api';
 import { evalTracer } from './tracer';
 import { Dataset, DeferredScore, EvalCase, Score, ScorerContext } from './types';
 import {
@@ -18,6 +19,7 @@ import {
   ScoreSummary,
   aggregateScores,
   makeRunResult,
+  UploadState,
 } from './results';
 import { EvalTransport, RunHandle } from './transport';
 import { PlatformTransport } from './platform';
@@ -245,12 +247,17 @@ async function runCase(
   onCaseComplete?: (item: EvalItemResult, durationMs: number) => void,
 ): Promise<EvalItemResult> {
   onCaseStart?.(evalCase);
-  await transport.registerItem(run, evalCase);
+  try {
+    await transport.registerItem(run, evalCase);
+  } catch {
+    // reporting is best-effort; a transport blip must not drop the case
+  }
 
   const startedAt = performance.now();
-  const root = startSpan(
-    { name: 'evaluation-item', type: 'evaluation', input: evalCase.input },
-    tracer,
+  // Detach from any ambient span (e.g. evaluate() called inside an @observe'd function)
+  // so each case is its own independent trace, not a child of the caller's span.
+  const root = context.with(ROOT_CONTEXT, () =>
+    startSpan({ name: 'evaluation-item', type: 'evaluation', input: evalCase.input }, tracer),
   );
   setRootAttrs(root, identity, evalCase);
   const rawTraceId = root.traceId;
@@ -355,8 +362,12 @@ async function runCase(
   } finally {
     root.end();
   }
-  await transport.recordItemResult(run, result);
-  await transport.recordScores(run, result.caseId, result.scores);
+  try {
+    await transport.recordItemResult(run, result);
+    await transport.recordScores(run, result.caseId, result.scores);
+  } catch {
+    // reporting is best-effort; the computed result is still returned
+  }
   onCaseComplete?.(result, result.durationMs ?? 0);
   return result;
 }
@@ -463,7 +474,7 @@ export async function evaluateAsync(options: EvaluateOptions): Promise<EvalRunRe
   // Eval structural spans always export (cloud-only) and are linked to the reported results.
   const evalSpanTracer = evalTracer();
   const localRunId = newRunId();
-  const run = await active.createRun(name, datasetName, runMetadata);
+  const run = await active.createRun(name, datasetName, runMetadata, localRunId);
 
   const identity: RunIdentity = {
     name,
@@ -491,6 +502,7 @@ export async function evaluateAsync(options: EvaluateOptions): Promise<EvalRunRe
   }
 
   let itemResults: EvalItemResult[];
+  let uploadState: UploadState;
   try {
     itemResults = await runBounded(cases.length, maxConcurrency, (i) =>
       runCase(
@@ -508,8 +520,9 @@ export async function evaluateAsync(options: EvaluateOptions): Promise<EvalRunRe
     );
   } finally {
     reporter?.finish();
+    // Finish the run inside finally so a mid-run failure never leaves it open on the backend.
+    uploadState = await active.finishRun(run);
   }
-  const uploadState = await active.finishRun(run);
 
   const summary = aggregateScores(itemResults);
   const { runScores, runScorerErrors } = await runRunScorers(

--- a/packages/traceroot/src/observe.ts
+++ b/packages/traceroot/src/observe.ts
@@ -2,6 +2,7 @@
 import { context, SpanStatusCode, trace } from '@opentelemetry/api';
 import { OUTPUT_VALUE } from '@arizeai/openinference-semantic-conventions';
 import { applyCommonAttributes, trySerialize } from './attributes';
+import { _isGlobalAutoInitSuppressed } from './spans';
 import { ObserveOptions } from './types';
 
 // Cached once after the first call; the tracer name never changes.
@@ -79,7 +80,7 @@ async function _observeRegular<A extends unknown[], T>(
   fn: (...args: A) => T | Promise<T>,
   args: A,
 ): Promise<T> {
-  if (process.env['TRACEROOT_API_KEY']) {
+  if (process.env['TRACEROOT_API_KEY'] && !_isGlobalAutoInitSuppressed()) {
     const { TraceRoot } = await import('./traceroot');
     if (!TraceRoot.isInitialized()) TraceRoot.initialize();
   }
@@ -130,7 +131,7 @@ async function* _observeAsyncGenerator<A extends unknown[], T>(
   fn: (...args: A) => AsyncGenerator<T>,
   args: A,
 ): AsyncGenerator<T> {
-  if (process.env['TRACEROOT_API_KEY']) {
+  if (process.env['TRACEROOT_API_KEY'] && !_isGlobalAutoInitSuppressed()) {
     const { TraceRoot } = await import('./traceroot');
     if (!TraceRoot.isInitialized()) TraceRoot.initialize();
   }

--- a/packages/traceroot/src/spans.ts
+++ b/packages/traceroot/src/spans.ts
@@ -1,5 +1,5 @@
 // src/spans.ts — imperative span handle API
-import { context, trace, SpanStatusCode, Span as OtelSpan } from '@opentelemetry/api';
+import { context, trace, SpanStatusCode, Span as OtelSpan, Tracer } from '@opentelemetry/api';
 import { applyCommonAttributes, applyModel, applyUsage, applyIO, trySerialize } from './attributes';
 import { SPAN_METADATA } from './constants';
 import { StartSpanOptions, SpanUpdate } from './types';
@@ -15,7 +15,12 @@ export interface Span {
 }
 
 class TracerootSpan implements Span {
-  constructor(readonly otelSpan: OtelSpan) {}
+  // `tracer` is the tracer that created this span; child spans reuse it so a subtree
+  // stays on the same provider (e.g. the private, non-exporting eval provider).
+  constructor(
+    readonly otelSpan: OtelSpan,
+    private readonly tracer?: Tracer,
+  ) {}
   get spanId(): string {
     return this.otelSpan.spanContext().spanId;
   }
@@ -40,7 +45,7 @@ class TracerootSpan implements Span {
     this.otelSpan.end();
   }
   startSpan(options: Omit<StartSpanOptions, 'parent'>): Span {
-    return startSpan({ ...options, parent: this });
+    return startSpan({ ...options, parent: this }, this.tracer);
   }
   setError(err: unknown): this {
     this.otelSpan.recordException(err instanceof Error ? err : new Error(String(err)));
@@ -60,20 +65,47 @@ export function wrapSpan(otel: OtelSpan): Span {
 let _tracer: ReturnType<typeof trace.getTracer> | undefined;
 let _hasWarnedUninit = false;
 
-export function startSpan(options: StartSpanOptions): Span {
-  // Synchronous init guard — mirrors observe(). Unlike observe() (which is async
-  // and can await a dynamic import), startSpan() is synchronous, so it must init
-  // BEFORE creating the span or the first span would be dropped. initialize() is
-  // synchronous and safe to call repeatedly.
-  if (process.env['TRACEROOT_API_KEY'] && !TraceRoot.isInitialized()) {
-    TraceRoot.initialize();
+// While > 0, startSpan()/observe() must NOT lazily initialize the global exporting
+// provider. A local evaluation raises this for the duration of the run so that nested
+// application spans (user startSpan/observe, auto-instrumentation) created during a
+// local eval cannot bring up the OTLP exporter and leak to the network. It has no effect
+// once the app has already initialized tracing itself (see the eval-tracer contract).
+let _suppressGlobalAutoInitDepth = 0;
+export function _pushSuppressGlobalAutoInit(): void {
+  _suppressGlobalAutoInitDepth += 1;
+}
+export function _popSuppressGlobalAutoInit(): void {
+  _suppressGlobalAutoInitDepth = Math.max(0, _suppressGlobalAutoInitDepth - 1);
+}
+export function _isGlobalAutoInitSuppressed(): boolean {
+  return _suppressGlobalAutoInitDepth > 0;
+}
+
+export function startSpan(options: StartSpanOptions, tracerOverride?: Tracer): Span {
+  // When a tracer is supplied (e.g. the eval engine's private, non-exporting tracer for
+  // a local run), use it verbatim and do NOT touch the global exporting provider — this
+  // is what keeps a local evaluation from initializing/exporting through the OTLP path.
+  let tracer = tracerOverride;
+  if (!tracer) {
+    // Synchronous init guard — mirrors observe(). Unlike observe() (which is async
+    // and can await a dynamic import), startSpan() is synchronous, so it must init
+    // BEFORE creating the span or the first span would be dropped. initialize() is
+    // synchronous and safe to call repeatedly.
+    if (
+      process.env['TRACEROOT_API_KEY'] &&
+      !TraceRoot.isInitialized() &&
+      _suppressGlobalAutoInitDepth === 0
+    ) {
+      TraceRoot.initialize();
+    }
+    _tracer ??= trace.getTracer('traceroot-ts');
+    tracer = _tracer;
   }
-  _tracer ??= trace.getTracer('traceroot-ts');
 
   const parentOtel = options.parent ? (options.parent as TracerootSpan).otelSpan : undefined;
   const ctx = parentOtel ? trace.setSpan(context.active(), parentOtel) : context.active();
 
-  const otel = _tracer.startSpan(options.name, undefined, ctx);
+  const otel = tracer.startSpan(options.name, undefined, ctx);
   if (!otel.isRecording() && !_hasWarnedUninit) {
     _hasWarnedUninit = true;
     console.warn(
@@ -97,7 +129,7 @@ export function startSpan(options: StartSpanOptions): Span {
     }
     if (options.attributes !== undefined) otel.setAttributes(options.attributes);
   }
-  return new TracerootSpan(otel);
+  return new TracerootSpan(otel, tracerOverride);
 }
 
 /** Run fn with `span` as the active span so inner observe()/startSpan() nest under it. */

--- a/packages/traceroot/tests/eval-engine.test.ts
+++ b/packages/traceroot/tests/eval-engine.test.ts
@@ -2,8 +2,19 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { Dataset, evaluate, evaluateAsync } from '../src/eval';
+import {
+  Dataset,
+  evaluate as _evaluate,
+  evaluateAsync as _evaluateAsync,
+  FakeTransport,
+} from '../src/eval';
 import type { ScorerContext, Score } from '../src/eval';
+
+// Cloud-only: a run always reports. These engine tests don't care about the wire, so default
+// a non-network FakeTransport when the test doesn't pass one.
+type EvalOpts = Parameters<typeof _evaluate>[0];
+const evaluate = (o: EvalOpts) => _evaluate({ transport: new FakeTransport(), ...o });
+const evaluateAsync = (o: EvalOpts) => _evaluateAsync({ transport: new FakeTransport(), ...o });
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -39,9 +50,9 @@ describe('basic runs', () => {
     assert.equal(result.scoreSummary.ascore.mean, 1);
   });
 
-  it('evaluate resolves to a completed result and reports local_only', async () => {
+  it('evaluate resolves to a completed result and reports uploaded', async () => {
     const result = await evaluate({ name: 'r', data: ds(1), task: echo, scorers: [exact] });
-    assert.equal(result.uploadState.status, 'local_only');
+    assert.equal(result.uploadState.status, 'uploaded');
     assert.equal(result.itemResults[0].traceId ?? null, result.itemResults[0].traceId); // defined key
   });
 });

--- a/packages/traceroot/tests/eval-engine.test.ts
+++ b/packages/traceroot/tests/eval-engine.test.ts
@@ -1,0 +1,212 @@
+// OE-8: execution kernel parity (Python OE-3): sync/async, ordering, concurrency, isolation.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Dataset, evaluate, evaluateAsync } from '../src/eval';
+import type { ScorerContext, Score } from '../src/eval';
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function ds(n: number): Dataset {
+  const d = new Dataset('d');
+  for (let i = 0; i < n; i++) d.upsert({ input: i, id: `c${i}`, expected: i });
+  return d;
+}
+const echo = (x: unknown) => x;
+const exact = (ctx: ScorerContext) => (ctx.output === ctx.expected ? 1 : 0);
+
+describe('basic runs', () => {
+  it('sync task + sync scorer', async () => {
+    const result = await evaluate({ name: 'r', data: ds(3), task: echo, scorers: [exact] });
+    assert.deepEqual(
+      result.itemResults.map((it) => it.caseId),
+      ['c0', 'c1', 'c2'],
+    );
+    assert.equal(result.scoreSummary.exact.mean, 1);
+    assert.equal(result.scoreSummary.exact.count, 3);
+  });
+
+  it('async task + async scorer', async () => {
+    const atask = async (x: unknown) => {
+      await sleep(0);
+      return x;
+    };
+    const ascore = async (ctx: ScorerContext) => {
+      await sleep(0);
+      return ctx.output === ctx.expected ? 1 : 0;
+    };
+    const result = await evaluateAsync({ name: 'r', data: ds(2), task: atask, scorers: [ascore] });
+    assert.equal(result.scoreSummary.ascore.mean, 1);
+  });
+
+  it('evaluate resolves to a completed result and reports local_only', async () => {
+    const result = await evaluate({ name: 'r', data: ds(1), task: echo, scorers: [exact] });
+    assert.equal(result.uploadState.status, 'local_only');
+    assert.equal(result.itemResults[0].traceId ?? null, result.itemResults[0].traceId); // defined key
+  });
+});
+
+describe('ordering and concurrency', () => {
+  it('deterministic input ordering', async () => {
+    const slow = async (x: number) => {
+      await sleep((5 - x) * 5);
+      return x;
+    };
+    const result = await evaluateAsync({ name: 'r', data: ds(5), task: slow, scorers: [exact] });
+    assert.deepEqual(
+      result.itemResults.map((it) => it.caseId),
+      ['c0', 'c1', 'c2', 'c3', 'c4'],
+    );
+    assert.deepEqual(
+      result.itemResults.map((it) => it.output),
+      [0, 1, 2, 3, 4],
+    );
+  });
+
+  it('bounded concurrency', async () => {
+    let cur = 0;
+    let peak = 0;
+    const tracked = async (x: unknown) => {
+      cur++;
+      peak = Math.max(peak, cur);
+      await sleep(10);
+      cur--;
+      return x;
+    };
+    await evaluateAsync({
+      name: 'r',
+      data: ds(10),
+      task: tracked,
+      scorers: [exact],
+      maxConcurrency: 2,
+    });
+    assert.ok(peak <= 2, `peak=${peak}`);
+  });
+});
+
+describe('failure isolation', () => {
+  it('task error isolates and skips scorers', async () => {
+    const boom = (x: number) => {
+      if (x === 1) throw new Error('nope');
+      return x;
+    };
+    const result = await evaluate({ name: 'r', data: ds(3), task: boom, scorers: [exact] });
+    const byId = Object.fromEntries(result.itemResults.map((it) => [it.caseId, it]));
+    assert.ok(byId.c1.error?.includes('nope'));
+    assert.deepEqual(byId.c1.scores, []);
+    assert.equal(byId.c0.error, null);
+    assert.ok(byId.c0.scores.length > 0);
+  });
+
+  it('scorer error isolates, siblings still score', async () => {
+    const bad = () => {
+      throw new Error('scorer boom');
+    };
+    const result = await evaluate({ name: 'r', data: ds(2), task: echo, scorers: [exact, bad] });
+    const it = result.itemResults[0];
+    assert.ok('bad' in it.scorerErrors);
+    assert.ok(it.scorerErrors.bad.includes('scorer boom'));
+    assert.ok(it.scores.some((s) => s.name === 'exact'));
+  });
+});
+
+describe('score normalization', () => {
+  const one = async (scorer: (ctx: ScorerContext) => unknown) =>
+    (await evaluate({ name: 'r', data: ds(1), task: echo, scorers: [scorer as never] }))
+      .itemResults[0];
+
+  it('number scalar', async () => {
+    const s = (_ctx: ScorerContext) => 0.5;
+    const scores = (await one(s)).scores;
+    assert.equal(scores.length, 1);
+    assert.equal(scores[0].name, 's');
+    assert.equal(scores[0].value, 0.5);
+  });
+  it('boolean scalar', async () => {
+    const s = (_ctx: ScorerContext) => true;
+    assert.equal((await one(s)).scores[0].value, true);
+  });
+  it('string scalar', async () => {
+    const s = (_ctx: ScorerContext) => 'billing';
+    assert.equal((await one(s)).scores[0].value, 'billing');
+  });
+  it('score object', async () => {
+    const s = (_ctx: ScorerContext): Score => ({ name: 'custom', value: 0.9, comment: 'c' });
+    const sc = (await one(s)).scores[0];
+    assert.equal(sc.name, 'custom');
+    assert.equal(sc.comment, 'c');
+  });
+  it('array of scores', async () => {
+    const s = (_ctx: ScorerContext): Score[] => [
+      { name: 'a', value: 1 },
+      { name: 'b', value: 0 },
+    ];
+    const names = new Set((await one(s)).scores.map((x) => x.name));
+    assert.deepEqual([...names].sort(), ['a', 'b']);
+  });
+  it('null abstains', async () => {
+    const s = (_ctx: ScorerContext) => null;
+    assert.deepEqual((await one(s)).scores, []);
+  });
+
+  it('scalar score serializes with comment/metadata null (Python parity)', async () => {
+    const s = (_ctx: ScorerContext) => 1;
+    const score = (await one(s)).scores[0];
+    assert.deepEqual(score, { name: 's', value: 1, comment: null, metadata: null });
+  });
+
+  it('malformed array element becomes a scorer error, not a crash', async () => {
+    const bad = (_ctx: ScorerContext) => [{ value: 1 }] as never; // missing name
+    const result = await evaluate({ name: 'r', data: ds(1), task: echo, scorers: [bad] });
+    assert.ok('bad' in result.itemResults[0].scorerErrors);
+  });
+});
+
+describe('data coercion and config errors', () => {
+  it('array of eval cases', async () => {
+    const result = await evaluate({
+      name: 'r',
+      data: [
+        { input: 1, id: 'a', expected: 1 },
+        { input: 2, id: 'b', expected: 2 },
+      ],
+      task: echo,
+      scorers: [exact],
+    });
+    assert.deepEqual(
+      result.itemResults.map((it) => it.caseId),
+      ['a', 'b'],
+    );
+  });
+
+  it('anonymous list items get positional ids', async () => {
+    const result = await evaluate({
+      name: 'r',
+      data: [
+        { input: 1, expected: 1 },
+        { input: 2, expected: 2 },
+      ],
+      task: echo,
+      scorers: [exact],
+    });
+    assert.deepEqual(
+      result.itemResults.map((it) => it.caseId),
+      ['case-0', 'case-1'],
+    );
+  });
+
+  for (const [label, opts] of [
+    ['empty name', { name: '', data: ds(1), task: echo, scorers: [exact] }],
+    ['empty data', { name: 'r', data: ds(0), task: echo, scorers: [exact] }],
+    ['task not function', { name: 'r', data: ds(1), task: 'nope' as never, scorers: [exact] }],
+    ['empty scorers', { name: 'r', data: ds(1), task: echo, scorers: [] }],
+    [
+      'bad concurrency',
+      { name: 'r', data: ds(1), task: echo, scorers: [exact], maxConcurrency: 0 },
+    ],
+  ] as const) {
+    it(`throws on ${label}`, async () => {
+      await assert.rejects(() => evaluate(opts as never));
+    });
+  }
+});

--- a/packages/traceroot/tests/eval-trace.test.ts
+++ b/packages/traceroot/tests/eval-trace.test.ts
@@ -1,0 +1,229 @@
+// OE-8: trace-native execution parity (Python OE-4): span hierarchy, attributes, isolation.
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+  ReadableSpan,
+} from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+
+import { _resetSpansState } from '../src/spans';
+import { _resetForTesting } from '../src/traceroot';
+import { observe, _resetObserveState } from '../src/observe';
+import { Dataset, evaluate, evaluateAsync, FakeTransport } from '../src/eval';
+import type { ScorerContext } from '../src/eval';
+
+// Cloud-only: every run reports and exports its per-case spans. These structural tests run
+// through a non-network FakeTransport (a stand-in cloud transport) so spans are inspectable.
+const reported = () => ({ transport: new FakeTransport() });
+
+let exporter: InMemorySpanExporter;
+let provider: NodeTracerProvider;
+
+beforeEach(() => {
+  exporter = new InMemorySpanExporter();
+  provider = new NodeTracerProvider();
+  provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+  provider.register();
+});
+afterEach(async () => {
+  await provider.shutdown();
+  exporter.reset();
+  _resetForTesting();
+  _resetObserveState();
+  _resetSpansState();
+});
+
+function ds(n: number, extra: Record<string, unknown> = {}): Dataset {
+  const d = new Dataset('d');
+  for (let i = 0; i < n; i++) d.upsert({ input: i, id: `c${i}`, expected: i, ...extra });
+  return d;
+}
+const echo = (x: unknown) => x;
+const exact = (ctx: ScorerContext) => (ctx.output === ctx.expected ? 1 : 0);
+
+function byName(spans: ReadableSpan[]): Record<string, ReadableSpan> {
+  return Object.fromEntries(spans.map((s) => [s.name, s]));
+}
+
+describe('span hierarchy', () => {
+  it('emits evaluation-item -> task + scorer sibling', async () => {
+    await evaluate({ name: 'r', data: ds(1), task: echo, scorers: [exact], ...reported() });
+    const spans = exporter.getFinishedSpans();
+    assert.deepEqual(spans.map((s) => s.name).sort(), ['evaluation-item', 'exact', 'task']);
+    const by = byName(spans);
+    const rootId = by['evaluation-item'].spanContext().spanId;
+    assert.equal(by['evaluation-item'].parentSpanId, undefined);
+    assert.equal(by['task'].parentSpanId, rootId);
+    assert.equal(by['exact'].parentSpanId, rootId); // sibling of task, under root
+  });
+
+  it('user observe() span nests under the task span', async () => {
+    const taskWithInner = async (x: unknown) =>
+      observe({ name: 'inner_llm', type: 'llm' }, () => x);
+    await evaluateAsync({
+      name: 'r',
+      data: ds(1),
+      task: taskWithInner,
+      scorers: [exact],
+      ...reported(),
+    });
+    const by = byName(exporter.getFinishedSpans());
+    assert.ok(by['inner_llm']);
+    assert.equal(by['inner_llm'].parentSpanId, by['task'].spanContext().spanId);
+  });
+});
+
+describe('concurrency isolation', () => {
+  it('5 concurrent cases produce 5 clean traces', async () => {
+    await evaluate({
+      name: 'r',
+      data: ds(5),
+      task: echo,
+      scorers: [exact],
+      maxConcurrency: 5,
+      ...reported(),
+    });
+    const spans = exporter.getFinishedSpans();
+    const byTrace = new Map<string, ReadableSpan[]>();
+    for (const s of spans) {
+      const t = s.spanContext().traceId;
+      byTrace.set(t, [...(byTrace.get(t) ?? []), s]);
+    }
+    assert.equal(byTrace.size, 5);
+    for (const traceSpans of byTrace.values()) {
+      assert.deepEqual(traceSpans.map((s) => s.name).sort(), ['evaluation-item', 'exact', 'task']);
+      const by = byName(traceSpans);
+      const rootId = by['evaluation-item'].spanContext().spanId;
+      assert.equal(by['task'].parentSpanId, rootId);
+      assert.equal(by['exact'].parentSpanId, rootId);
+    }
+  });
+});
+
+describe('eval attributes and trace id', () => {
+  it('root/task/scorer attributes', async () => {
+    const dataset = ds(1, { metadata: { cat: 'x' }, sourceTraceId: 't1', sourceSpanId: 's1' });
+    await evaluate({
+      name: 'routing-v2',
+      data: dataset,
+      task: echo,
+      scorers: [exact],
+      ...reported(),
+    });
+    const by = byName(exporter.getFinishedSpans());
+    const root = by['evaluation-item'].attributes;
+    assert.equal(root['traceroot.span.type'], 'evaluation');
+    assert.equal(root['traceroot.eval.run_name'], 'routing-v2');
+    assert.equal(root['traceroot.eval.dataset_name'], 'd');
+    assert.equal(root['traceroot.eval.case_id'], 'c0');
+    assert.equal(root['traceroot.eval.has_expected'], true);
+    assert.equal(root['traceroot.eval.source_trace_id'], 't1');
+    assert.equal(root['traceroot.eval.source_span_id'], 's1');
+    assert.equal(by['task'].attributes['traceroot.eval.task_name'], 'echo');
+    assert.equal(by['exact'].attributes['traceroot.eval.scorer_name'], 'exact');
+    assert.equal(by['exact'].attributes['traceroot.eval.score_value'], 1);
+  });
+
+  it('has_expected false when absent, run_name on all spans', async () => {
+    const d = new Dataset('d');
+    d.upsert({ input: 1, id: 'c0' });
+    await evaluate({ name: 'run-x', data: d, task: echo, scorers: [exact], ...reported() });
+    const by = byName(exporter.getFinishedSpans());
+    assert.equal(by['evaluation-item'].attributes['traceroot.eval.has_expected'], false);
+    for (const n of ['evaluation-item', 'task', 'exact']) {
+      assert.equal(by[n].attributes['traceroot.eval.run_name'], 'run-x');
+    }
+  });
+
+  it('trace id returned per item and matches root (reported run)', async () => {
+    // Parity with Python: a result carries a trace id only for a REPORTED run.
+    const { FakeTransport } = await import('../src/eval');
+    const result = await evaluate({
+      name: 'r',
+      data: ds(1),
+      task: echo,
+      scorers: [exact],
+      transport: new FakeTransport(),
+    });
+    const root = byName(exporter.getFinishedSpans())['evaluation-item'];
+    assert.equal(result.itemResults[0].traceId, root.spanContext().traceId);
+  });
+
+  it('task error marks span and isolates', async () => {
+    const boom = (x: number) => {
+      if (x === 1) throw new Error('kaboom');
+      return x;
+    };
+    const result = await evaluate({
+      name: 'r',
+      data: ds(3),
+      task: boom,
+      scorers: [exact],
+      ...reported(),
+    });
+    const byId = Object.fromEntries(result.itemResults.map((it) => [it.caseId, it]));
+    assert.ok(byId.c1.error?.includes('kaboom'));
+    assert.equal(byId.c0.error, null);
+    const errTasks = exporter
+      .getFinishedSpans()
+      .filter((s) => s.name === 'task' && s.attributes['traceroot.eval.error']);
+    assert.ok(
+      errTasks.some((s) => String(s.attributes['traceroot.eval.error']).includes('kaboom')),
+    );
+  });
+});
+
+
+describe('llm judge trace', () => {
+  it('the judge emits a nested LLM span (input=prompt, output=response)', async () => {
+    const { llmJudge } = await import('../src/eval');
+    const judge = llmJudge({
+      name: 'conciseness',
+      model: 'claude-sonnet-5',
+      messages: [{ role: 'user', content: 'ANSWER:\n{{output}}' }],
+      complete: () => '0.8', // deterministic, no network
+    });
+    const d = new Dataset('d');
+    d.upsert({ input: 0, id: 'c0', expected: 0 });
+    await evaluate({ name: 'r', dataset: d, task: echo, scorers: [judge], ...reported() });
+
+    const by = byName(exporter.getFinishedSpans());
+    const llm = by['llm_judge:conciseness'];
+    const scorer = by['conciseness']; // scorer span named by the judge
+    assert.ok(llm, 'expected a nested llm_judge span');
+    assert.equal(llm.parentSpanId, scorer.spanContext().spanId); // nested under the scorer
+    assert.match(String(llm.attributes['input.value']), /ANSWER/); // rendered prompt in
+    assert.match(String(llm.attributes['output.value']), /0\.8/); // model response out
+  });
+
+  it('skips its own LLM span when a provider integration already traces the model', async () => {
+    const { llmJudge } = await import('../src/eval');
+    const { __setInstrumentedProvidersForTest } = await import('../src/instrumentation');
+    __setInstrumentedProvidersForTest(['anthropic']); // simulate an active anthropic integration
+    try {
+      const judge = llmJudge({
+        name: 'conciseness',
+        model: 'claude-sonnet-5', // anthropic model -> checks the anthropic integration
+        messages: [{ role: 'user', content: 'ANSWER:\n{{output}}' }],
+        complete: () => '0.8',
+      });
+      const d = new Dataset('d');
+      d.upsert({ input: 0, id: 'c0', expected: 0 });
+      const result = await evaluate({
+        name: 'r',
+        dataset: d,
+        task: echo,
+        scorers: [judge],
+        ...reported(),
+      });
+      const by = byName(exporter.getFinishedSpans());
+      assert.equal(by['llm_judge:conciseness'], undefined); // integration owns the LLM span, not us
+      assert.ok(by['conciseness']); // the scorer span still exists
+      assert.equal(result.itemResults[0].scores[0].value, 0.8); // judge still ran + scored
+    } finally {
+      __setInstrumentedProvidersForTest([]); // reset for other tests
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds the execution engine that runs each case as its own isolated trace. For every case the engine emits an `evaluation-item` root with a `task` span and one span per scorer (siblings of the task), captures span I/O and the versioned identity attributes, isolates per-case errors so one failure never aborts the run, and runs cases concurrently with a bounded limit. Sync and async tasks/scorers are unified and results are returned in input order.

Fixes: traceroot-ai/traceroot#1687

## How it works

Each case runs under its own root span, so concurrent cases never share a current span. A user span created inside the task nests under `task`; scorers are siblings of `task`, not children.

```
evaluation-item (root)   ← case input + candidate output, run/dataset/case identity
├── task                 ← the candidate under test (task name)
│    └── <user span>     ← anything the task opens nests here
└── <scorer name>        ← one per scorer: {candidate, expected, targetSpanId?} in, score out
```

The root carries the identity attributes (run name, dataset name, case id, a has-expected flag, and the source trace/span ids when the case came from a captured trace) plus the contract version. A task or scorer error is recorded on that case and marks its span (error text becomes the span output); it never propagates to other cases. The engine drives spans through a supplied eval tracer so a local run stays on its own provider without bringing up the exporting path; a `maxConcurrency` of N yields N independent traces.

## What's included

### Source
- `packages/traceroot/src/eval/engine.ts` — the engine: sync/async task and scorer unification, the per-case `evaluation-item → task → scorer` span tree, span I/O and identity attribute stamping, deferred-score handling, per-case and per-scorer failure isolation, per-case timeout, bounded concurrency, and in-input-order result aggregation.
- `packages/traceroot/src/spans.ts` — `startSpan` accepts a tracer override so an eval subtree stays on the engine's tracer; adds a guard that stops a local run from lazily initializing the global exporting provider.
- `packages/traceroot/src/observe.ts` — honors that suppression guard so application spans opened during a local eval do not bring up the exporter.

### Tests
- `packages/traceroot/tests/eval-engine.test.ts` — sync/async unification, ordering, aggregation, timeout, and error isolation.
- `packages/traceroot/tests/eval-trace.test.ts` — the per-case span tree shape, sibling/nesting relationships, span I/O, identity attributes, and N independent traces at concurrency N.

## Test plan

- [ ] Each case produces exactly one trace: `evaluation-item` + `task` + one span per scorer, with task and scorers as children of the root.
- [ ] A user span created inside the task nests under `task`; scorer spans are siblings of `task`.
- [ ] A concurrency of N produces N independent traces and concurrent cases never share a current span.
- [ ] A failing task or scorer is isolated — its case records the error and marks its span, and other cases still complete.
- [ ] The root and scorer spans carry the documented input/output and identity attributes.
