### PR TITLE
feat(eval): span export — per-case span I/O + item→trace link

### DIFF
--- a/packages/traceroot/src/eval/tracer.ts
+++ b/packages/traceroot/src/eval/tracer.ts
@@ -1,0 +1,49 @@
+// src/eval/tracer.ts — the tracer used for evaluation structural spans.
+//
+// Parity with Python `traceroot/eval/engine.py::_eval_tracer`. This is the layer that
+// enforces the trace-privacy boundary for LOCAL evaluations: a local run's eval spans
+// are created on a private, non-exporting provider and the global exporting provider is
+// never initialized by the eval path — so neither the eval spans nor any nested
+// application spans (created via the global tracer) can reach the OTLP endpoint just
+// because TRACEROOT_API_KEY happens to be set.
+
+import { trace, type Tracer } from '@opentelemetry/api';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { AlwaysOffSampler } from '@opentelemetry/sdk-trace-base';
+import { TraceRoot } from '../traceroot';
+
+const EVAL_TRACER_NAME = 'traceroot-ts';
+
+// Lazily constructed private provider. It has NO span processors and NO exporter, and is
+// never registered globally, so spans it creates cannot be exported. The AlwaysOff
+// sampler makes its spans non-recording while still giving them a valid span context, so
+// nested application spans still parent to the eval tree (and, under the global default
+// ParentBased sampler, are themselves dropped).
+let _localEvalProvider: NodeTracerProvider | undefined;
+
+/**
+ * Return the tracer for evaluation spans, honoring the trace-privacy boundary.
+ *
+ * Reported run -> the global production tracer, so per-case eval spans export and can be
+ * linked to reported results (initializes the global provider if credentials exist).
+ *
+ * Local run -> a private, non-exporting provider. The global exporting provider is NOT
+ * initialized here.
+ */
+export function evalTracer(reporting: boolean): Tracer {
+  if (reporting) {
+    if (process.env['TRACEROOT_API_KEY'] && !TraceRoot.isInitialized()) {
+      TraceRoot.initialize();
+    }
+    return trace.getTracer(EVAL_TRACER_NAME);
+  }
+  if (!_localEvalProvider) {
+    _localEvalProvider = new NodeTracerProvider({ sampler: new AlwaysOffSampler() });
+  }
+  return _localEvalProvider.getTracer(EVAL_TRACER_NAME);
+}
+
+/** @internal test reset */
+export function _resetEvalTracer(): void {
+  _localEvalProvider = undefined;
+}

--- a/packages/traceroot/src/eval/tracer.ts
+++ b/packages/traceroot/src/eval/tracer.ts
@@ -1,49 +1,21 @@
 // src/eval/tracer.ts — the tracer used for evaluation structural spans.
 //
-// Parity with Python `traceroot/eval/engine.py::_eval_tracer`. This is the layer that
-// enforces the trace-privacy boundary for LOCAL evaluations: a local run's eval spans
-// are created on a private, non-exporting provider and the global exporting provider is
-// never initialized by the eval path — so neither the eval spans nor any nested
-// application spans (created via the global tracer) can reach the OTLP endpoint just
-// because TRACEROOT_API_KEY happens to be set.
+// Parity with Python `traceroot/eval/engine.py::_eval_tracer`. Evaluation is cloud-only, so a
+// run always exports its per-case spans through the global production tracer, which are then
+// linked to the reported results.
 
 import { trace, type Tracer } from '@opentelemetry/api';
-import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { AlwaysOffSampler } from '@opentelemetry/sdk-trace-base';
 import { TraceRoot } from '../traceroot';
 
 const EVAL_TRACER_NAME = 'traceroot-ts';
 
-// Lazily constructed private provider. It has NO span processors and NO exporter, and is
-// never registered globally, so spans it creates cannot be exported. The AlwaysOff
-// sampler makes its spans non-recording while still giving them a valid span context, so
-// nested application spans still parent to the eval tree (and, under the global default
-// ParentBased sampler, are themselves dropped).
-let _localEvalProvider: NodeTracerProvider | undefined;
-
-/**
- * Return the tracer for evaluation spans, honoring the trace-privacy boundary.
- *
- * Reported run -> the global production tracer, so per-case eval spans export and can be
- * linked to reported results (initializes the global provider if credentials exist).
- *
- * Local run -> a private, non-exporting provider. The global exporting provider is NOT
- * initialized here.
- */
-export function evalTracer(reporting: boolean): Tracer {
-  if (reporting) {
-    if (process.env['TRACEROOT_API_KEY'] && !TraceRoot.isInitialized()) {
-      TraceRoot.initialize();
-    }
-    return trace.getTracer(EVAL_TRACER_NAME);
+/** The global production tracer for evaluation spans (initializes it if credentials exist). */
+export function evalTracer(): Tracer {
+  if (process.env['TRACEROOT_API_KEY'] && !TraceRoot.isInitialized()) {
+    TraceRoot.initialize();
   }
-  if (!_localEvalProvider) {
-    _localEvalProvider = new NodeTracerProvider({ sampler: new AlwaysOffSampler() });
-  }
-  return _localEvalProvider.getTracer(EVAL_TRACER_NAME);
+  return trace.getTracer(EVAL_TRACER_NAME);
 }
 
-/** @internal test reset */
-export function _resetEvalTracer(): void {
-  _localEvalProvider = undefined;
-}
+/** @internal test reset (no-op; retained for test compatibility) */
+export function _resetEvalTracer(): void {}

--- a/packages/traceroot/tests/eval-trace.test.ts
+++ b/packages/traceroot/tests/eval-trace.test.ts
@@ -175,6 +175,52 @@ describe('eval attributes and trace id', () => {
   });
 });
 
+describe('eval span IO (parity: root + scorer carry span.input/output)', () => {
+  const IN = 'input.value';
+  const OUT = 'output.value';
+
+  it('root carries case input and candidate output', async () => {
+    await evaluate({ name: 'r', data: ds(1), task: echo, scorers: [exact], ...reported() });
+    const root = byName(exporter.getFinishedSpans())['evaluation-item'];
+    assert.equal(root.attributes[IN], '0'); // case input
+    assert.equal(root.attributes[OUT], '0'); // candidate output
+  });
+
+  it('root output is the task error on failure', async () => {
+    const boom = () => {
+      throw new Error('kaboom');
+    };
+    await evaluate({ name: 'r', data: ds(1), task: boom, scorers: [exact], ...reported() });
+    const root = byName(exporter.getFinishedSpans())['evaluation-item'];
+    assert.ok(String(root.attributes[OUT]).includes('kaboom'));
+  });
+
+  it('scorer input has candidate + expected; output has the score value', async () => {
+    await evaluate({ name: 'r', data: ds(1), task: echo, scorers: [exact], ...reported() });
+    const scorer = byName(exporter.getFinishedSpans())['exact'];
+    const inp = String(scorer.attributes[IN]);
+    assert.ok(inp.includes('candidate') && inp.includes('expected'));
+    const out = String(scorer.attributes[OUT]);
+    assert.ok(out.includes('value') && out.includes('1'));
+  });
+
+  it('scorer output is the scorer error on failure', async () => {
+    const broken = () => {
+      throw new Error('judge down');
+    };
+    await evaluate({ name: 'r', data: ds(1), task: echo, scorers: [broken], ...reported() });
+    const scorer = byName(exporter.getFinishedSpans())['broken'];
+    assert.ok(String(scorer.attributes[OUT]).includes('judge down'));
+  });
+
+  it('scorer input includes target_span_id when present', async () => {
+    const d = new Dataset('d');
+    d.upsert({ input: 0, id: 'c0', expected: 0, scoreTargetSpanId: 'span-xyz' });
+    await evaluate({ name: 'r', dataset: d, task: echo, scorers: [exact], ...reported() });
+    const scorer = byName(exporter.getFinishedSpans())['exact'];
+    assert.ok(String(scorer.attributes[IN]).includes('span-xyz'));
+  });
+});
 
 describe('llm judge trace', () => {
   it('the judge emits a nested LLM span (input=prompt, output=response)', async () => {


### PR DESCRIPTION
## Summary

Evaluation is cloud-only, so a run always exports its per-case spans through the global production tracer, links each result item to the trace id of its exported root span, and marks the trace at its root so downstream can tell an evaluation trace apart from a normal one. This branch adds the eval tracer seam that routes the structural spans through the global production tracer (initializing it when credentials exist), and finalizes the span-export contract so the root and scorer spans carry the standard `input.value` / `output.value` attributes — the trace viewer renders them like any other span and diff mode has real content to compare.

Fixes: traceroot-ai/traceroot#1688

## How it works

Each case is exported as its own trace shaped `evaluation-item → task → scorer`. The root span kind is `evaluation` (with `task` / `scorer` kinds on the children) and carries the `traceroot.eval.*` identity attributes plus a versioned contract attribute, so ingest and detectors can distinguish it. On top of that structure, the structural spans also carry standard I/O:

```
evaluation-item   input.value = case input,  output.value = candidate output (or task error)
  └─ task         the candidate task
       └─ <scorer>  input.value = {candidate, expected, targetSpanId?},  output.value = score value (or scorer error)
```

The tracer seam (`evalTracer()`) returns the global production tracer and initializes the SDK when an API key is present, so an eval run exports without the caller wiring anything up. Because the structural spans use the same `input.value` / `output.value` keys as ordinary spans, no special-casing is needed downstream: the root shows what the case fed in and what the candidate produced, and each scorer span shows exactly what it compared and the value it returned. Failures are captured too — a task error becomes the root's output, a scorer error becomes that scorer span's output.

## What's included

### Source
- `packages/traceroot/src/eval/tracer.ts` — `evalTracer()`, the tracer used for the evaluation structural spans: returns the global production tracer and initializes the SDK when `TRACEROOT_API_KEY` is set (parity with the Python eval tracer). Includes a test-only reset hook.

### Tests
- `packages/traceroot/tests/eval-trace.test.ts` — new span-IO coverage: the root span carries the case input and candidate output; the root output becomes the task error on task failure; a scorer span's input contains the candidate and expected (and the target span id when the case sets `scoreTargetSpanId`); the scorer output carries the score value; and a scorer failure surfaces as that span's output.

## Test plan

- [ ] Run an evaluation and confirm each item carries the trace id of its exported root span.
- [ ] Confirm the structural spans (`evaluation-item` / `task` / `<scorer>`) are exported and inspectable.
- [ ] Confirm the root span is tagged as an evaluation trace (span kind + `traceroot.eval.*` identity attributes) so ingest and detectors can distinguish it from a normal trace.
- [ ] Confirm the root span's `input.value` / `output.value` hold the case input and candidate output, and the task error when the task throws.
- [ ] Confirm each scorer span's `input.value` holds the candidate and expected (plus the target span id when present) and its `output.value` holds the score value, or the scorer error on failure.
- [ ] Create a nested user span inside a task and confirm it exports and nests under the task span.
