### PR TITLE
feat(eval): reporting transport + wire contract

### DIFF
--- a/packages/traceroot/src/eval/platform.ts
+++ b/packages/traceroot/src/eval/platform.ts
@@ -159,7 +159,6 @@ export interface PlatformTransportOptions {
   environment?: string;
   mainScoreName?: string | null;
   datasetVersionId?: string | null;
-  baselineRunId?: string | null;
   clientRunId?: string | null;
   passThreshold?: number | null;
   apiKey?: string;
@@ -182,7 +181,6 @@ export class PlatformTransport implements EvalTransport {
   private readonly environment: string;
   private readonly mainScoreName: string | null;
   private readonly datasetVersionId: string | null;
-  private readonly baselineRunId: string | null;
   private readonly clientRunId: string | null;
   private readonly passThreshold: number | null;
   private readonly apiKey: string;
@@ -205,7 +203,6 @@ export class PlatformTransport implements EvalTransport {
     this.environment = opts.environment ?? 'evaluation';
     this.mainScoreName = opts.mainScoreName ?? this.scorerNames[0] ?? null;
     this.datasetVersionId = opts.datasetVersionId ?? null;
-    this.baselineRunId = opts.baselineRunId ?? null;
     this.clientRunId = opts.clientRunId ?? null;
     this.passThreshold = opts.passThreshold ?? null;
     this.apiKey = apiKey;
@@ -255,7 +252,6 @@ export class PlatformTransport implements EvalTransport {
     };
     if (this.datasetVersionId !== null) body.dataset_version_id = this.datasetVersionId;
     if (this.mainScoreName !== null) body.main_score_name = this.mainScoreName;
-    if (this.baselineRunId !== null) body.baseline_run_id = this.baselineRunId;
     const effectiveClientRun = clientRunId ?? this.clientRunId;
     if (effectiveClientRun != null) body.client_run_id = effectiveClientRun;
     const resp = await this.request('POST', '/api/v1/public/evaluation-runs', body);

--- a/packages/traceroot/src/eval/platform.ts
+++ b/packages/traceroot/src/eval/platform.ts
@@ -265,6 +265,15 @@ export class PlatformTransport implements EvalTransport {
     return DEFAULT_PASS_THRESHOLD;
   }
 
+  private effectiveDirection(): string {
+    // The main scorer's DECLARED comparison direction (higher_is_better by default).
+    // lower_is_better inverts the threshold comparison; none -> not_scored.
+    for (const spec of this.scorerSpecs ?? []) {
+      if (spec.name === this.mainScoreName && spec.direction != null) return String(spec.direction);
+    }
+    return 'higher_is_better';
+  }
+
   async createRun(
     name: string,
     _datasetName: string,
@@ -382,6 +391,12 @@ export class PlatformTransport implements EvalTransport {
       if (this.mainScoreName !== null) break; // named main is categorical -> no numeric main
     }
     if (main === null) return ['not_scored', null];
-    return [main >= this.effectiveThreshold() ? 'passed' : 'failed', main];
+    const threshold = this.effectiveThreshold();
+    const direction = this.effectiveDirection();
+    let passed: boolean;
+    if (direction === 'lower_is_better') passed = main <= threshold;
+    else if (direction === 'none') return ['not_scored', main];
+    else passed = main >= threshold; // higher_is_better (the default)
+    return [passed ? 'passed' : 'failed', main];
   }
 }

--- a/packages/traceroot/src/eval/platform.ts
+++ b/packages/traceroot/src/eval/platform.ts
@@ -1,0 +1,352 @@
+// src/eval/platform.ts — platform reporting + dataset pull (parity with
+// traceroot-py/traceroot/eval/platform.py). Same endpoints and wire payloads as the
+// Python SDK, since the backend contract is shared.
+
+import { TraceRoot } from '../traceroot';
+import { Dataset } from './types';
+import type { EvalItemResult, UploadState } from './results';
+import type { EvalTransport, RunHandle, PublishResult } from './transport';
+
+const UNVERSIONED_SCORER = 'unversioned';
+const DEFAULT_PASS_THRESHOLD = 1.0;
+
+// --- HTTP seam (fetch) -------------------------------------------------------
+async function httpGetJson(url: string, apiKey: string): Promise<any> {
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${apiKey}` } });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    throw new Error(`GET ${url} -> HTTP ${res.status}: ${detail}`);
+  }
+  return res.json();
+}
+
+export async function httpJson(
+  method: string,
+  url: string,
+  apiKey: string,
+  body?: unknown,
+): Promise<any> {
+  const res = await fetch(url, {
+    method,
+    headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    throw new Error(`${method} ${url} -> HTTP ${res.status}: ${detail}`);
+  }
+  return res.json();
+}
+
+/** Result-reporting fields are backend z.string(); a non-string is JSON-encoded. */
+function asText(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  return typeof value === 'string' ? value : JSON.stringify(value);
+}
+
+/** Per-case duration for the wire: a nonnegative INTEGER of ms, or null when unknown. */
+function durationMs(value: number | null): number | null {
+  return value === null ? null : Math.max(0, Math.round(value));
+}
+
+export interface PullOptions {
+  versionId?: string;
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+function datasetFromVersion(snapshot: any, name: string): Dataset {
+  // Native JSON at the HTTP boundary: the backend already JSON-decodes input/expected
+  // before returning them, so the SDK takes the values as-is (no re-decode).
+  const ds = new Dataset(name);
+  ds.datasetId = snapshot.dataset_id ?? undefined;
+  ds.datasetVersionId = snapshot.dataset_version_id ?? undefined;
+  for (const item of snapshot.items ?? []) {
+    ds.upsert({
+      id: item.test_case_id,
+      input: item.input,
+      expected: item.expected,
+      metadata: item.metadata ?? null,
+      sourceTraceId: item.source_trace_id ?? undefined,
+      sourceSpanId: item.source_span_id ?? undefined,
+    });
+  }
+  return ds;
+}
+
+/**
+ * Fetch a platform dataset into a local Dataset.
+ *
+ * Pull data, not runs: reproduce a run by pulling its `datasetVersionId` (see
+ * {@link pullDatasetVersion}) — there is no pullRun. Without `versionId` the CURRENT
+ * published version is pulled; with it, that EXACT immutable version (validated to
+ * belong to `datasetId`). The returned Dataset carries `datasetId`/`datasetVersionId`.
+ */
+export async function pullDataset(datasetId: string, opts: PullOptions = {}): Promise<Dataset> {
+  const { apiKey, baseUrl } = TraceRoot.resolveCredentials(opts.apiKey, opts.baseUrl);
+  if (!apiKey)
+    throw new Error('pullDataset needs an API key (initialize TraceRoot or pass apiKey).');
+
+  const meta = await httpGetJson(`${baseUrl}/api/v1/public/datasets/${datasetId}`, apiKey);
+  const versionId = opts.versionId ?? meta.current_dataset_version_id;
+  return pullDatasetVersion(versionId, {
+    datasetId,
+    name: meta.name ?? datasetId,
+    apiKey,
+    baseUrl,
+  });
+}
+
+export interface PullVersionOptions {
+  datasetId?: string;
+  name?: string;
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+/**
+ * Fetch one EXACT immutable dataset version by id — this is how you reproduce a run:
+ * pass the run's `datasetVersionId` to get the exact cases it scored, then bring your own
+ * task + scorers (only the data lives on the platform; there is no pullRun). When
+ * `datasetId` is supplied the version is validated to belong to it.
+ */
+export async function pullDatasetVersion(
+  versionId: string,
+  opts: PullVersionOptions = {},
+): Promise<Dataset> {
+  const { apiKey, baseUrl } = TraceRoot.resolveCredentials(opts.apiKey, opts.baseUrl);
+  if (!apiKey)
+    throw new Error('pullDatasetVersion needs an API key (initialize TraceRoot or pass apiKey).');
+
+  let snapshot: any;
+  try {
+    snapshot = await httpGetJson(`${baseUrl}/api/v1/public/dataset-versions/${versionId}`, apiKey);
+  } catch (err) {
+    if (err instanceof Error && / HTTP 404:/.test(err.message)) {
+      throw new Error(`dataset version ${JSON.stringify(versionId)} not found`);
+    }
+    throw err;
+  }
+
+  const returnedDatasetId = snapshot.dataset_id ?? null;
+  if (opts.datasetId && returnedDatasetId && returnedDatasetId !== opts.datasetId) {
+    throw new Error(
+      `dataset version ${JSON.stringify(versionId)} belongs to dataset ` +
+        `${JSON.stringify(returnedDatasetId)}, not ${JSON.stringify(opts.datasetId)}`,
+    );
+  }
+  const ds = datasetFromVersion(
+    snapshot,
+    opts.name ?? returnedDatasetId ?? opts.datasetId ?? versionId,
+  );
+  ds.datasetVersionId = ds.datasetVersionId ?? versionId;
+  ds.datasetId = ds.datasetId ?? opts.datasetId ?? undefined;
+  return ds;
+}
+
+export interface ScorerSpec {
+  name: string;
+  version?: string | null;
+  value_type?: string | null;
+  direction?: string | null;
+  threshold?: number | null;
+}
+
+export interface PlatformTransportOptions {
+  scorerNames?: string[];
+  scorerSpecs?: ScorerSpec[];
+  candidateVersion?: string | null;
+  environment?: string;
+  mainScoreName?: string | null;
+  datasetVersionId?: string | null;
+  baselineRunId?: string | null;
+  clientRunId?: string | null;
+  passThreshold?: number | null;
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+/** Reports an evaluation run to the TraceRoot backend. One instance per run. */
+export class PlatformTransport implements EvalTransport {
+  readonly reportsTraces = true;
+  runId: string | null = null;
+
+  private readonly datasetId: string;
+  private readonly scorerNames: string[];
+  /** Rich scorer descriptors (value_type/direction/threshold); the engine fills this when
+   *  the caller leaves it undefined. Falls back to scorerNames when unset. */
+  scorerSpecs?: ScorerSpec[];
+  private readonly candidateVersion: string;
+  private readonly environment: string;
+  private readonly mainScoreName: string | null;
+  private readonly datasetVersionId: string | null;
+  private readonly baselineRunId: string | null;
+  private readonly clientRunId: string | null;
+  private readonly passThreshold: number | null;
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+
+  private scored = 0;
+  private taskErrors = 0;
+  private scorerErrors = 0;
+  private mainSum = 0;
+  private mainCount = 0;
+
+  constructor(datasetId: string, opts: PlatformTransportOptions = {}) {
+    const { apiKey, baseUrl } = TraceRoot.resolveCredentials(opts.apiKey, opts.baseUrl);
+    if (!apiKey)
+      throw new Error('PlatformTransport needs an API key (uploading requires credentials).');
+    this.datasetId = datasetId;
+    this.scorerNames = opts.scorerNames ?? [];
+    this.scorerSpecs = opts.scorerSpecs;
+    this.candidateVersion = opts.candidateVersion || 'sdk';
+    this.environment = opts.environment ?? 'evaluation';
+    this.mainScoreName = opts.mainScoreName ?? this.scorerNames[0] ?? null;
+    this.datasetVersionId = opts.datasetVersionId ?? null;
+    this.baselineRunId = opts.baselineRunId ?? null;
+    this.clientRunId = opts.clientRunId ?? null;
+    this.passThreshold = opts.passThreshold ?? null;
+    this.apiKey = apiKey;
+    this.baseUrl = baseUrl;
+  }
+
+  private request(method: string, path: string, body?: unknown): Promise<any> {
+    return httpJson(method, `${this.baseUrl}${path}`, this.apiKey, body);
+  }
+
+  private scorerRefs(): Record<string, unknown>[] {
+    if (this.scorerSpecs && this.scorerSpecs.length > 0) {
+      return this.scorerSpecs.map((spec) => {
+        const ref: Record<string, unknown> = {
+          name: spec.name,
+          version: spec.version || UNVERSIONED_SCORER,
+        };
+        for (const k of ['value_type', 'direction', 'threshold'] as const) {
+          if (spec[k] != null) ref[k] = spec[k];
+        }
+        return ref;
+      });
+    }
+    return this.scorerNames.map((n) => ({ name: n, version: UNVERSIONED_SCORER }));
+  }
+
+  private effectiveThreshold(): number {
+    if (this.passThreshold !== null) return this.passThreshold;
+    for (const spec of this.scorerSpecs ?? []) {
+      if (spec.name === this.mainScoreName && spec.threshold != null) return spec.threshold;
+    }
+    return DEFAULT_PASS_THRESHOLD;
+  }
+
+  async createRun(
+    name: string,
+    _datasetName: string,
+    _metadata: Record<string, unknown> | null,
+    clientRunId?: string,
+  ): Promise<RunHandle> {
+    const body: Record<string, unknown> = {
+      evaluation_name: name,
+      dataset_id: this.datasetId,
+      candidate_version: this.candidateVersion,
+      environment: this.environment,
+      scorers: this.scorerRefs(),
+    };
+    if (this.datasetVersionId !== null) body.dataset_version_id = this.datasetVersionId;
+    if (this.mainScoreName !== null) body.main_score_name = this.mainScoreName;
+    if (this.baselineRunId !== null) body.baseline_run_id = this.baselineRunId;
+    const effectiveClientRun = clientRunId ?? this.clientRunId;
+    if (effectiveClientRun != null) body.client_run_id = effectiveClientRun;
+    const resp = await this.request('POST', '/api/v1/public/evaluation-runs', body);
+    this.runId = resp.evaluation_run_id;
+    return { name, datasetName: _datasetName, metadata: _metadata };
+  }
+
+  async registerItem(): Promise<void> {
+    // The item->trace link is folded into the result upsert (contract), so no-op.
+  }
+
+  async recordItemResult(_run: RunHandle, item: EvalItemResult): Promise<void> {
+    const [status, main] = this.statusAndMain(item);
+    if (status === 'errored') this.taskErrors += 1;
+    else if (status === 'passed' || status === 'failed') this.scored += 1;
+    if (main !== null) {
+      this.mainSum += main;
+      this.mainCount += 1;
+    }
+    this.scorerErrors += Object.keys(item.scorerErrors).length;
+    await this.request('POST', `/api/v1/public/evaluation-runs/${this.runId}/results`, {
+      test_case_id: item.caseId,
+      trace_id: item.traceId,
+      input: asText(item.input) ?? '',
+      expected_output: asText(item.expected),
+      candidate_output: asText(item.output),
+      status,
+      main_score: main,
+      task_error: item.error,
+      duration_ms: durationMs(item.durationMs),
+      scores: this.scoresPayload(item),
+    });
+  }
+
+  async recordScores(): Promise<void> {
+    // Already sent inside recordItemResult (which carries the full item).
+  }
+
+  async finishRun(_run: RunHandle, statusOverride?: string | null): Promise<UploadState> {
+    const status =
+      statusOverride ??
+      (this.taskErrors || this.scorerErrors ? 'completed_with_errors' : 'completed');
+    const body: Record<string, unknown> = {
+      status,
+      scored_count: this.scored,
+      task_error_count: this.taskErrors,
+      scorer_error_count: this.scorerErrors,
+    };
+    if (this.mainCount) body.main_score = this.mainSum / this.mainCount;
+    await this.request('POST', `/api/v1/public/evaluation-runs/${this.runId}/complete`, body);
+    return { status: 'uploaded', dashboardUrl: null };
+  }
+
+  async publishDataset(datasetName: string, itemCount: number): Promise<PublishResult> {
+    // Datasets are server/UI-owned; the SDK cannot create them. Stay local-only.
+    return { status: 'local_only', datasetName, itemCount };
+  }
+
+  private scoresPayload(item: EvalItemResult): Record<string, unknown>[] {
+    const payload: Record<string, unknown>[] = [];
+    for (const s of item.scores) {
+      const entry: Record<string, unknown> = {
+        scorer_name: s.name,
+        scorer_version: UNVERSIONED_SCORER,
+      };
+      if (typeof s.value === 'boolean') entry.bool_value = s.value;
+      else if (typeof s.value === 'number') entry.numeric_value = s.value;
+      else entry.string_value = String(s.value);
+      if (s.comment !== undefined && s.comment !== null) entry.explanation = s.comment;
+      payload.push(entry);
+    }
+    for (const [name, msg] of Object.entries(item.scorerErrors)) {
+      payload.push({ scorer_name: name, scorer_version: UNVERSIONED_SCORER, error: msg });
+    }
+    return payload;
+  }
+
+  private statusAndMain(item: EvalItemResult): [string, number | null] {
+    if (item.error !== null) return ['errored', null];
+    let main: number | null = null;
+    for (const s of item.scores) {
+      if (this.mainScoreName !== null && s.name !== this.mainScoreName) continue;
+      if (typeof s.value === 'boolean') {
+        main = s.value ? 1.0 : 0.0;
+        break;
+      }
+      if (typeof s.value === 'number') {
+        main = s.value;
+        break;
+      }
+      if (this.mainScoreName !== null) break; // named main is categorical -> no numeric main
+    }
+    if (main === null) return ['not_scored', null];
+    return [main >= this.effectiveThreshold() ? 'passed' : 'failed', main];
+  }
+}

--- a/packages/traceroot/src/eval/platform.ts
+++ b/packages/traceroot/src/eval/platform.ts
@@ -201,11 +201,12 @@ export class PlatformTransport implements EvalTransport {
   private readonly apiKey: string;
   private readonly baseUrl: string;
 
-  private scored = 0;
-  private taskErrors = 0;
-  private scorerErrors = 0;
-  private mainSum = 0;
-  private mainCount = 0;
+  // Per-case contribution keyed by test_case_id, so a retried case (or a repeated upload() with
+  // the same transport) REPLACES its contribution instead of double-counting the completion totals.
+  private readonly contrib = new Map<
+    string,
+    { status: string; main: number | null; scorerErrors: number }
+  >();
 
   constructor(datasetId: string, opts: PlatformTransportOptions = {}) {
     const { apiKey, baseUrl } = TraceRoot.resolveCredentials(opts.apiKey, opts.baseUrl);
@@ -319,15 +320,13 @@ export class PlatformTransport implements EvalTransport {
       duration_ms: durationMs(item.durationMs),
       scores: this.scoresPayload(item),
     });
-    // Fold into the completion counts only AFTER the upsert has actually persisted, so a failed
-    // or retried request can't leave the run's counts/main_score inconsistent with stored results.
-    if (status === 'errored') this.taskErrors += 1;
-    else if (status === 'passed' || status === 'failed') this.scored += 1;
-    if (main !== null) {
-      this.mainSum += main;
-      this.mainCount += 1;
-    }
-    this.scorerErrors += Object.keys(item.scorerErrors).length;
+    // Record this case's contribution only AFTER the upsert persisted, keyed by id so a retry or
+    // repeated upload replaces (not adds to) the completion aggregate.
+    this.contrib.set(item.caseId, {
+      status,
+      main,
+      scorerErrors: Object.keys(item.scorerErrors).length,
+    });
   }
 
   async recordScores(): Promise<void> {
@@ -335,16 +334,31 @@ export class PlatformTransport implements EvalTransport {
   }
 
   async finishRun(_run: RunHandle, statusOverride?: string | null): Promise<UploadState> {
+    // Derive the completion aggregate from the per-case map, so counts always match the distinct
+    // cases actually persisted (no inflation from retries/replays).
+    let scored = 0;
+    let taskErrors = 0;
+    let scorerErrors = 0;
+    let mainSum = 0;
+    let mainCount = 0;
+    for (const c of this.contrib.values()) {
+      if (c.status === 'errored') taskErrors += 1;
+      else if (c.status === 'passed' || c.status === 'failed') scored += 1;
+      if (c.main !== null) {
+        mainSum += c.main;
+        mainCount += 1;
+      }
+      scorerErrors += c.scorerErrors;
+    }
     const status =
-      statusOverride ??
-      (this.taskErrors || this.scorerErrors ? 'completed_with_errors' : 'completed');
+      statusOverride ?? (taskErrors || scorerErrors ? 'completed_with_errors' : 'completed');
     const body: Record<string, unknown> = {
       status,
-      scored_count: this.scored,
-      task_error_count: this.taskErrors,
-      scorer_error_count: this.scorerErrors,
+      scored_count: scored,
+      task_error_count: taskErrors,
+      scorer_error_count: scorerErrors,
     };
-    if (this.mainCount) body.main_score = this.mainSum / this.mainCount;
+    if (mainCount) body.main_score = mainSum / mainCount;
     await this.request('POST', `/api/v1/public/evaluation-runs/${this.runId}/complete`, body);
     // Join the backend's UI-relative run path with our host; null when absent.
     // Prefer the backend's absolute run_url; fall back to baseUrl + run_path for a control

--- a/packages/traceroot/src/eval/platform.ts
+++ b/packages/traceroot/src/eval/platform.ts
@@ -147,9 +147,17 @@ export async function pullDatasetVersion(
 export interface ScorerSpec {
   name: string;
   version?: string | null;
+  scorer_type?: string | null;
   value_type?: string | null;
   direction?: string | null;
   threshold?: number | null;
+  output_type?: string | null;
+  description?: string | null;
+  metadata?: Record<string, unknown> | null;
+  language?: string | null;
+  source?: string | null;
+  model?: string | null;
+  messages?: unknown;
 }
 
 export interface PlatformTransportOptions {
@@ -220,7 +228,20 @@ export class PlatformTransport implements EvalTransport {
           name: spec.name,
           version: spec.version || UNVERSIONED_SCORER,
         };
-        for (const k of ['value_type', 'direction', 'threshold'] as const) {
+        // Comparison metadata + the read-only definition. Absent fields are omitted.
+        for (const k of [
+          'scorer_type',
+          'value_type',
+          'direction',
+          'threshold',
+          'output_type',
+          'description',
+          'metadata',
+          'language',
+          'source',
+          'model',
+          'messages',
+        ] as const) {
           if (spec[k] != null) ref[k] = spec[k];
         }
         return ref;

--- a/packages/traceroot/src/eval/platform.ts
+++ b/packages/traceroot/src/eval/platform.ts
@@ -175,7 +175,6 @@ export interface PlatformTransportOptions {
 
 /** Reports an evaluation run to the TraceRoot backend. One instance per run. */
 export class PlatformTransport implements EvalTransport {
-  readonly reportsTraces = true;
   runId: string | null = null;
   /** Absolute UI run link from the backend (resolved against the UI origin), when present. */
   runUrl: string | null = null;

--- a/packages/traceroot/src/eval/platform.ts
+++ b/packages/traceroot/src/eval/platform.ts
@@ -87,7 +87,10 @@ export async function pullDataset(datasetId: string, opts: PullOptions = {}): Pr
   if (!apiKey)
     throw new Error('pullDataset needs an API key (initialize TraceRoot or pass apiKey).');
 
-  const meta = await httpGetJson(`${baseUrl}/api/v1/public/datasets/${datasetId}`, apiKey);
+  const meta = await httpGetJson(
+    `${baseUrl}/api/v1/public/datasets/${encodeURIComponent(datasetId)}`,
+    apiKey,
+  );
   const versionId = opts.versionId ?? meta.current_dataset_version_id;
   return pullDatasetVersion(versionId, {
     datasetId,
@@ -120,7 +123,10 @@ export async function pullDatasetVersion(
 
   let snapshot: any;
   try {
-    snapshot = await httpGetJson(`${baseUrl}/api/v1/public/dataset-versions/${versionId}`, apiKey);
+    snapshot = await httpGetJson(
+      `${baseUrl}/api/v1/public/dataset-versions/${encodeURIComponent(versionId)}`,
+      apiKey,
+    );
   } catch (err) {
     if (err instanceof Error && / HTTP 404:/.test(err.message)) {
       throw new Error(`dataset version ${JSON.stringify(versionId)} not found`);
@@ -346,7 +352,7 @@ export class PlatformTransport implements EvalTransport {
     for (const s of item.scores) {
       const entry: Record<string, unknown> = {
         scorer_name: s.name,
-        scorer_version: UNVERSIONED_SCORER,
+        scorer_version: s.version || UNVERSIONED_SCORER,
       };
       if (typeof s.value === 'boolean') entry.bool_value = s.value;
       else if (typeof s.value === 'number') entry.numeric_value = s.value;

--- a/packages/traceroot/src/eval/platform.ts
+++ b/packages/traceroot/src/eval/platform.ts
@@ -177,7 +177,9 @@ export interface PlatformTransportOptions {
 export class PlatformTransport implements EvalTransport {
   readonly reportsTraces = true;
   runId: string | null = null;
-  /** UI-relative run path from the backend, when it returns one. */
+  /** Absolute UI run link from the backend (resolved against the UI origin), when present. */
+  runUrl: string | null = null;
+  /** UI-relative run path from the backend — same-origin fallback for runUrl. */
   runPath: string | null = null;
 
   private readonly datasetId: string;
@@ -277,7 +279,10 @@ export class PlatformTransport implements EvalTransport {
     if (effectiveClientRun != null) body.client_run_id = effectiveClientRun;
     const resp = await this.request('POST', '/api/v1/public/evaluation-runs', body);
     this.runId = resp.evaluation_run_id;
-    // Optional: absent on older/self-hosted backends -> dashboardUrl stays null.
+    // Optional, absent on older/self-hosted backends. Prefer the absolute run_url (resolved
+    // against the UI origin) so the link is correct across split API/UI origins; keep
+    // run_path as a same-origin fallback.
+    this.runUrl = resp.run_url ?? null;
     this.runPath = resp.run_path ?? null;
     return { name, datasetName: _datasetName, metadata: _metadata };
   }
@@ -326,7 +331,9 @@ export class PlatformTransport implements EvalTransport {
     if (this.mainCount) body.main_score = this.mainSum / this.mainCount;
     await this.request('POST', `/api/v1/public/evaluation-runs/${this.runId}/complete`, body);
     // Join the backend's UI-relative run path with our host; null when absent.
-    const url = this.runPath ? `${this.baseUrl}${this.runPath}` : null;
+    // Prefer the backend's absolute run_url; fall back to baseUrl + run_path for a control
+    // plane that predates run_url (keeps the same-origin behavior).
+    const url = this.runUrl ?? (this.runPath ? `${this.baseUrl}${this.runPath}` : null);
     return { status: 'uploaded', dashboardUrl: url };
   }
 

--- a/packages/traceroot/src/eval/platform.ts
+++ b/packages/traceroot/src/eval/platform.ts
@@ -307,13 +307,6 @@ export class PlatformTransport implements EvalTransport {
 
   async recordItemResult(_run: RunHandle, item: EvalItemResult): Promise<void> {
     const [status, main] = this.statusAndMain(item);
-    if (status === 'errored') this.taskErrors += 1;
-    else if (status === 'passed' || status === 'failed') this.scored += 1;
-    if (main !== null) {
-      this.mainSum += main;
-      this.mainCount += 1;
-    }
-    this.scorerErrors += Object.keys(item.scorerErrors).length;
     await this.request('POST', `/api/v1/public/evaluation-runs/${this.runId}/results`, {
       test_case_id: item.caseId,
       trace_id: item.traceId,
@@ -326,6 +319,15 @@ export class PlatformTransport implements EvalTransport {
       duration_ms: durationMs(item.durationMs),
       scores: this.scoresPayload(item),
     });
+    // Fold into the completion counts only AFTER the upsert has actually persisted, so a failed
+    // or retried request can't leave the run's counts/main_score inconsistent with stored results.
+    if (status === 'errored') this.taskErrors += 1;
+    else if (status === 'passed' || status === 'failed') this.scored += 1;
+    if (main !== null) {
+      this.mainSum += main;
+      this.mainCount += 1;
+    }
+    this.scorerErrors += Object.keys(item.scorerErrors).length;
   }
 
   async recordScores(): Promise<void> {

--- a/packages/traceroot/src/eval/platform.ts
+++ b/packages/traceroot/src/eval/platform.ts
@@ -170,6 +170,8 @@ export interface PlatformTransportOptions {
 export class PlatformTransport implements EvalTransport {
   readonly reportsTraces = true;
   runId: string | null = null;
+  /** UI-relative run path from the backend, when it returns one. */
+  runPath: string | null = null;
 
   private readonly datasetId: string;
   private readonly scorerNames: string[];
@@ -258,6 +260,8 @@ export class PlatformTransport implements EvalTransport {
     if (effectiveClientRun != null) body.client_run_id = effectiveClientRun;
     const resp = await this.request('POST', '/api/v1/public/evaluation-runs', body);
     this.runId = resp.evaluation_run_id;
+    // Optional: absent on older/self-hosted backends -> dashboardUrl stays null.
+    this.runPath = resp.run_path ?? null;
     return { name, datasetName: _datasetName, metadata: _metadata };
   }
 
@@ -304,7 +308,9 @@ export class PlatformTransport implements EvalTransport {
     };
     if (this.mainCount) body.main_score = this.mainSum / this.mainCount;
     await this.request('POST', `/api/v1/public/evaluation-runs/${this.runId}/complete`, body);
-    return { status: 'uploaded', dashboardUrl: null };
+    // Join the backend's UI-relative run path with our host; null when absent.
+    const url = this.runPath ? `${this.baseUrl}${this.runPath}` : null;
+    return { status: 'uploaded', dashboardUrl: url };
   }
 
   async publishDataset(datasetName: string, itemCount: number): Promise<PublishResult> {

--- a/packages/traceroot/src/eval/runner.ts
+++ b/packages/traceroot/src/eval/runner.ts
@@ -112,18 +112,11 @@ function iterPaths(paths: string[]): string[] {
   return files;
 }
 
-// A REAL dynamic import even in the CommonJS build: a plain `import()` is transpiled to
-// `require()` for CJS, which cannot resolve a `file://` URL (nor .mjs). Hiding it behind Function
-// keeps a native `import()` so file-URL specifiers load.
-const nativeImport = new Function('specifier', 'return import(specifier)') as (
-  s: string,
-) => Promise<Record<string, unknown>>;
-
 export async function discover(paths: string[]): Promise<Array<[string, Evaluation]>> {
   const found: Array<[string, Evaluation]> = [];
   const seen = new Set<Evaluation>();
   for (const path of iterPaths(paths)) {
-    const mod = await nativeImport(pathToFileURL(path).href);
+    const mod = await import(pathToFileURL(path).href);
     for (const value of Object.values(mod)) {
       if (value instanceof Evaluation && !seen.has(value)) {
         seen.add(value);

--- a/packages/traceroot/tests/eval-platform.test.ts
+++ b/packages/traceroot/tests/eval-platform.test.ts
@@ -5,6 +5,7 @@ import assert from 'node:assert/strict';
 
 import { Dataset, evaluate, pullDataset, pullDatasetVersion } from '../src/eval';
 import type { ScorerContext } from '../src/eval';
+import { PlatformTransport } from '../src/eval/platform';
 
 const echo = (x: unknown) => x;
 const exact = (ctx: ScorerContext) => (ctx.output === ctx.expected ? 1 : 0);
@@ -20,6 +21,7 @@ function mockBackend(
     current?: string;
     versions?: Record<string, any>;
     apiKey?: string;
+    runPath?: string;
   } = {},
 ) {
   const versions = opts.versions ?? {};
@@ -45,7 +47,9 @@ function mockBackend(
       );
     }
     if (u.endsWith('/evaluation-runs')) {
-      return new Response(JSON.stringify({ evaluation_run_id: 'run_1' }), { status: 200 });
+      const resp: Record<string, unknown> = { evaluation_run_id: 'run_1' };
+      if (opts.runPath) resp.run_path = opts.runPath;
+      return new Response(JSON.stringify(resp), { status: 200 });
     }
     return new Response(JSON.stringify({}), { status: 200 }); // results/complete
   }) as any;
@@ -187,5 +191,38 @@ describe('reporting default (upload-by-default)', () => {
     await evaluate({ name: 'r', dataset: ds, task: echo, scorers: [exact], baseline });
     const reg = calls.find((c) => c.url.endsWith('/evaluation-runs'))!;
     assert.equal(reg.body.baseline_run_id, 'run_base');
+  });
+});
+
+describe('run URL (run_path -> dashboardUrl)', () => {
+  it('joins host + run_path into dashboardUrl', async () => {
+    mockBackend({ runPath: '/projects/proj_9/evaluations/run_1' });
+    const ds = new Dataset('d');
+    ds.add({ i: 0 }, { expected: { i: 0 } });
+    const run = await evaluate({
+      name: 'r',
+      dataset: ds,
+      task: echo,
+      scorers: [exact],
+      transport: new PlatformTransport('ds_1'),
+    });
+    // host is whatever resolveCredentials returns; the point is host + run_path joined.
+    const url = run.uploadState.dashboardUrl!;
+    assert.match(url, /^https?:\/\/.+\/projects\/proj_9\/evaluations\/run_1$/);
+  });
+
+  it('leaves dashboardUrl null when the backend omits run_path', async () => {
+    mockBackend();
+    const ds = new Dataset('d');
+    ds.add({ i: 0 }, { expected: { i: 0 } });
+    const run = await evaluate({
+      name: 'r',
+      dataset: ds,
+      task: echo,
+      scorers: [exact],
+      transport: new PlatformTransport('ds_1'),
+    });
+    assert.equal(run.uploadState.dashboardUrl, null);
+    assert.equal(run.uploadState.status, 'uploaded');
   });
 });

--- a/packages/traceroot/tests/eval-platform.test.ts
+++ b/packages/traceroot/tests/eval-platform.test.ts
@@ -22,6 +22,7 @@ function mockBackend(
     versions?: Record<string, any>;
     apiKey?: string;
     runPath?: string;
+    runUrl?: string;
   } = {},
 ) {
   const versions = opts.versions ?? {};
@@ -49,6 +50,7 @@ function mockBackend(
     if (u.endsWith('/evaluation-runs')) {
       const resp: Record<string, unknown> = { evaluation_run_id: 'run_1' };
       if (opts.runPath) resp.run_path = opts.runPath;
+      if (opts.runUrl) resp.run_url = opts.runUrl;
       return new Response(JSON.stringify(resp), { status: 200 });
     }
     return new Response(JSON.stringify({}), { status: 200 }); // results/complete
@@ -198,7 +200,7 @@ describe('reporting default (upload-by-default)', () => {
   });
 });
 
-describe('run URL (run_path -> dashboardUrl)', () => {
+describe('run URL (run_url preferred, run_path fallback -> dashboardUrl)', () => {
   it('joins host + run_path into dashboardUrl', async () => {
     mockBackend({ runPath: '/projects/proj_9/evaluations/run_1' });
     const ds = new Dataset('d');
@@ -213,6 +215,28 @@ describe('run URL (run_path -> dashboardUrl)', () => {
     // host is whatever resolveCredentials returns; the point is host + run_path joined.
     const url = run.uploadState.dashboardUrl!;
     assert.match(url, /^https?:\/\/.+\/projects\/proj_9\/evaluations\/run_1$/);
+  });
+
+  it('prefers an absolute run_url over host + run_path (split origins)', async () => {
+    // API host on :8000, run_url resolved against the UI origin on :3000.
+    mockBackend({
+      runPath: '/projects/proj_9/evaluations/run_1',
+      runUrl: 'http://localhost:3000/projects/proj_9/evaluations/run_1',
+    });
+    const ds = new Dataset('d');
+    ds.add({ i: 0 }, { expected: { i: 0 } });
+    const run = await evaluate({
+      name: 'r',
+      dataset: ds,
+      task: echo,
+      scorers: [exact],
+      transport: new PlatformTransport('ds_1'),
+    });
+    // run_url wins verbatim; the API origin is never used to build the link.
+    assert.equal(
+      run.uploadState.dashboardUrl,
+      'http://localhost:3000/projects/proj_9/evaluations/run_1',
+    );
   });
 
   it('leaves dashboardUrl null when the backend omits run_path', async () => {

--- a/packages/traceroot/tests/eval-platform.test.ts
+++ b/packages/traceroot/tests/eval-platform.test.ts
@@ -124,16 +124,17 @@ describe('pull', () => {
   });
 });
 
-describe('reporting default (upload-by-default)', () => {
-  it('no credentials -> local', async () => {
-    // no api key set -> resolveCredentials returns empty -> stays local, no POST
+describe('reporting (cloud-only)', () => {
+  it('no credentials -> throws (nothing to report to)', async () => {
+    // no api key set -> resolveCredentials empty -> no reporting transport -> cloud-only raise
     const ds = new Dataset('d');
     ds.datasetId = 'ds_1';
     ds.datasetVersionId = 'dsv_1';
     ds.upsert({ input: 1, id: 'c0', expected: 1 });
-    const result = await evaluate({ name: 'r', dataset: ds, task: echo, scorers: [exact] });
-    assert.equal(result.uploadState.status, 'local_only');
-    assert.equal(result.runId, null);
+    await assert.rejects(
+      evaluate({ name: 'r', dataset: ds, task: echo, scorers: [exact] }),
+      /reports to the TraceRoot platform/,
+    );
   });
 
   it('remote dataset + creds -> uploaded by default, with correct payloads', async () => {
@@ -169,23 +170,6 @@ describe('reporting default (upload-by-default)', () => {
 
     const done = calls.find((c) => c.url.endsWith('/complete'))!;
     assert.equal(done.body.main_score, 1); // aggregate
-  });
-
-  it('local:true opts out even with creds + remote dataset', async () => {
-    mockBackend({});
-    const ds = new Dataset('d');
-    ds.datasetId = 'ds_1';
-    ds.datasetVersionId = 'dsv_1';
-    ds.upsert({ input: 1, id: 'c0', expected: 1 });
-    const result = await evaluate({
-      name: 'r',
-      dataset: ds,
-      task: echo,
-      scorers: [exact],
-      local: true,
-    });
-    assert.equal(result.uploadState.status, 'local_only');
-    assert.ok(!calls.some((c) => c.url.endsWith('/evaluation-runs')));
   });
 
   it('never sends a baseline_run_id (comparison is the backend’s job)', async () => {

--- a/packages/traceroot/tests/eval-platform.test.ts
+++ b/packages/traceroot/tests/eval-platform.test.ts
@@ -181,16 +181,15 @@ describe('reporting default (upload-by-default)', () => {
     assert.ok(!calls.some((c) => c.url.endsWith('/evaluation-runs')));
   });
 
-  it('baseline links baseline_run_id on the default path', async () => {
+  it('never sends a baseline_run_id (comparison is the backend’s job)', async () => {
     mockBackend({});
     const ds = new Dataset('d');
     ds.datasetId = 'ds_1';
     ds.datasetVersionId = 'dsv_1';
     ds.upsert({ input: 1, id: 'c0', expected: 1 });
-    const baseline = { runId: 'run_base' } as any;
-    await evaluate({ name: 'r', dataset: ds, task: echo, scorers: [exact], baseline });
+    await evaluate({ name: 'r', dataset: ds, task: echo, scorers: [exact] });
     const reg = calls.find((c) => c.url.endsWith('/evaluation-runs'))!;
-    assert.equal(reg.body.baseline_run_id, 'run_base');
+    assert.equal('baseline_run_id' in reg.body, false);
   });
 });
 

--- a/packages/traceroot/tests/eval-platform.test.ts
+++ b/packages/traceroot/tests/eval-platform.test.ts
@@ -1,0 +1,191 @@
+// Parity: pull (native JSON, exact version, mismatch, 404), upload-by-default decision,
+// and PlatformTransport wire payloads — with fetch mocked (no real network).
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Dataset, evaluate, pullDataset, pullDatasetVersion } from '../src/eval';
+import type { ScorerContext } from '../src/eval';
+
+const echo = (x: unknown) => x;
+const exact = (ctx: ScorerContext) => (ctx.output === ctx.expected ? 1 : 0);
+
+type Call = { method: string; url: string; body: any };
+let calls: Call[];
+const realFetch = globalThis.fetch;
+
+/** Install a fetch that routes GET dataset-version/dataset endpoints from `versions`
+ *  and records every POST. Returns nothing; inspect `calls`. */
+function mockBackend(
+  opts: {
+    current?: string;
+    versions?: Record<string, any>;
+    apiKey?: string;
+  } = {},
+) {
+  const versions = opts.versions ?? {};
+  process.env['TRACEROOT_API_KEY'] = opts.apiKey ?? 'tr-test';
+  process.env['TRACEROOT_HOST_URL'] = 'https://h';
+  // Keep credentials (for the reporting transport) but suppress OTLP span export, which
+  // would otherwise dial the fake host. Mirrors the Python `enabled=False` ambient-creds tests.
+  process.env['TRACEROOT_ENABLED'] = 'false';
+  globalThis.fetch = (async (url: string, init?: any) => {
+    const method = init?.method ?? 'GET';
+    const body = init?.body ? JSON.parse(init.body) : undefined;
+    calls.push({ method, url: String(url), body });
+    const u = String(url);
+    if (u.includes('/dataset-versions/')) {
+      const vid = u.split('/').pop() as string;
+      if (!(vid in versions)) return new Response('not found', { status: 404 });
+      return new Response(JSON.stringify(versions[vid]), { status: 200 });
+    }
+    if (u.match(/\/datasets\/[^/]+$/)) {
+      return new Response(
+        JSON.stringify({ name: 'test', current_dataset_version_id: opts.current }),
+        { status: 200 },
+      );
+    }
+    if (u.endsWith('/evaluation-runs')) {
+      return new Response(JSON.stringify({ evaluation_run_id: 'run_1' }), { status: 200 });
+    }
+    return new Response(JSON.stringify({}), { status: 200 }); // results/complete
+  }) as any;
+}
+
+function version(vid: string, datasetId: string, n = 1) {
+  return {
+    dataset_id: datasetId,
+    dataset_version_id: vid,
+    items: Array.from({ length: n }, (_, i) => ({
+      test_case_id: `c${i}`,
+      input: { i },
+      expected: { i },
+    })),
+  };
+}
+
+beforeEach(() => {
+  calls = [];
+});
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  delete process.env['TRACEROOT_API_KEY'];
+  delete process.env['TRACEROOT_HOST_URL'];
+  delete process.env['TRACEROOT_ENABLED'];
+});
+
+describe('pull', () => {
+  it('pulls current version and takes native values verbatim', async () => {
+    mockBackend({
+      current: 'dsv_cur',
+      versions: {
+        dsv_cur: {
+          dataset_id: 'ds_1',
+          dataset_version_id: 'dsv_cur',
+          items: [
+            { test_case_id: 'd', input: { message: 'hi' }, expected: { r: 1 } },
+            { test_case_id: 's', input: '{"looks":"like json"}', expected: '42' },
+          ],
+        },
+      },
+    });
+    const ds = await pullDataset('ds_1');
+    assert.equal(ds.datasetId, 'ds_1');
+    assert.equal(ds.datasetVersionId, 'dsv_cur');
+    assert.deepEqual(ds.get('d')!.input, { message: 'hi' }); // dict stays a dict
+    assert.equal(ds.get('s')!.input, '{"looks":"like json"}'); // json-looking string stays a string
+    assert.equal(ds.get('s')!.expected, '42'); // "42" stays a string
+  });
+
+  it('pulls an exact version and never fetches current', async () => {
+    mockBackend({ current: 'dsv_cur', versions: { dsv_old: version('dsv_old', 'ds_1', 3) } });
+    const ds = await pullDatasetVersion('dsv_old', { datasetId: 'ds_1' });
+    assert.equal(ds.datasetVersionId, 'dsv_old');
+    assert.equal(ds.size, 3);
+    assert.ok(!calls.some((c) => c.url.endsWith('/dataset-versions/dsv_cur')));
+  });
+
+  it('missing version raises a clear error', async () => {
+    mockBackend({ versions: {} });
+    await assert.rejects(() => pullDatasetVersion('dsv_missing'), /not found/);
+  });
+
+  it('mismatched dataset/version identity raises', async () => {
+    mockBackend({ versions: { dsv_x: version('dsv_x', 'ds_OTHER') } });
+    await assert.rejects(
+      () => pullDatasetVersion('dsv_x', { datasetId: 'ds_1' }),
+      /belongs to dataset/,
+    );
+  });
+});
+
+describe('reporting default (upload-by-default)', () => {
+  it('no credentials -> local', async () => {
+    // no api key set -> resolveCredentials returns empty -> stays local, no POST
+    const ds = new Dataset('d');
+    ds.datasetId = 'ds_1';
+    ds.datasetVersionId = 'dsv_1';
+    ds.upsert({ input: 1, id: 'c0', expected: 1 });
+    const result = await evaluate({ name: 'r', dataset: ds, task: echo, scorers: [exact] });
+    assert.equal(result.uploadState.status, 'local_only');
+    assert.equal(result.runId, null);
+  });
+
+  it('remote dataset + creds -> uploaded by default, with correct payloads', async () => {
+    mockBackend({});
+    const ds = new Dataset('d');
+    ds.datasetId = 'ds_1';
+    ds.datasetVersionId = 'dsv_1';
+    ds.upsert({ input: 1, id: 'c0', expected: 1 });
+    const result = await evaluate({
+      name: 'r',
+      dataset: ds,
+      task: echo,
+      scorers: [exact],
+      candidateVersion: 'v1',
+    });
+    assert.equal(result.uploadState.status, 'uploaded');
+    assert.equal(result.runId, 'run_1');
+
+    const reg = calls.find((c) => c.url.endsWith('/evaluation-runs'))!;
+    assert.equal(reg.body.candidate_version, 'v1');
+    assert.equal(reg.body.dataset_version_id, 'dsv_1');
+    assert.deepEqual(reg.body.scorers, [{ name: 'exact', version: 'unversioned' }]);
+
+    const res = calls.find((c) => c.url.endsWith('/results'))!;
+    assert.equal(res.body.status, 'passed');
+    assert.equal(res.body.main_score, 1);
+    assert.equal(typeof res.body.duration_ms, 'number');
+
+    const done = calls.find((c) => c.url.endsWith('/complete'))!;
+    assert.equal(done.body.main_score, 1); // aggregate
+  });
+
+  it('local:true opts out even with creds + remote dataset', async () => {
+    mockBackend({});
+    const ds = new Dataset('d');
+    ds.datasetId = 'ds_1';
+    ds.datasetVersionId = 'dsv_1';
+    ds.upsert({ input: 1, id: 'c0', expected: 1 });
+    const result = await evaluate({
+      name: 'r',
+      dataset: ds,
+      task: echo,
+      scorers: [exact],
+      local: true,
+    });
+    assert.equal(result.uploadState.status, 'local_only');
+    assert.ok(!calls.some((c) => c.url.endsWith('/evaluation-runs')));
+  });
+
+  it('baseline links baseline_run_id on the default path', async () => {
+    mockBackend({});
+    const ds = new Dataset('d');
+    ds.datasetId = 'ds_1';
+    ds.datasetVersionId = 'dsv_1';
+    ds.upsert({ input: 1, id: 'c0', expected: 1 });
+    const baseline = { runId: 'run_base' } as any;
+    await evaluate({ name: 'r', dataset: ds, task: echo, scorers: [exact], baseline });
+    const reg = calls.find((c) => c.url.endsWith('/evaluation-runs'))!;
+    assert.equal(reg.body.baseline_run_id, 'run_base');
+  });
+});

--- a/packages/traceroot/tests/eval-platform.test.ts
+++ b/packages/traceroot/tests/eval-platform.test.ts
@@ -153,7 +153,12 @@ describe('reporting default (upload-by-default)', () => {
     const reg = calls.find((c) => c.url.endsWith('/evaluation-runs'))!;
     assert.equal(reg.body.candidate_version, 'v1');
     assert.equal(reg.body.dataset_version_id, 'dsv_1');
-    assert.deepEqual(reg.body.scorers, [{ name: 'exact', version: 'unversioned' }]);
+    const sc = reg.body.scorers[0];
+    assert.equal(sc.name, 'exact');
+    assert.equal(sc.version, 'unversioned');
+    assert.equal(sc.scorer_type, 'code'); // definition rides the manifest
+    assert.equal(sc.language, 'typescript');
+    assert.ok(typeof sc.source === 'string' && sc.source.length > 0);
 
     const res = calls.find((c) => c.url.endsWith('/results'))!;
     assert.equal(res.body.status, 'passed');

--- a/packages/traceroot/tests/eval-transport.test.ts
+++ b/packages/traceroot/tests/eval-transport.test.ts
@@ -1,9 +1,8 @@
-// OE-8: transport seam parity (Python OE-5): LocalTransport, FakeTransport, publish().
+// Transport seam parity (Python test_transport.py): FakeTransport wiring + cloud-only default.
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { Dataset, evaluate } from '../src/eval';
-import { FakeTransport, LocalTransport } from '../src/eval';
+import { Dataset, evaluate, FakeTransport } from '../src/eval';
 import type { ScorerContext } from '../src/eval';
 
 function ds(n: number): Dataset {
@@ -14,18 +13,12 @@ function ds(n: number): Dataset {
 const echo = (x: unknown) => x;
 const exact = (ctx: ScorerContext) => (ctx.output === ctx.expected ? 1 : 0);
 
-describe('LocalTransport', () => {
-  it('finishRun is local_only', async () => {
-    const t = new LocalTransport();
-    const run = await t.createRun('r', 'd', null);
-    const state = await t.finishRun(run);
-    assert.equal(state.status, 'local_only');
-    assert.equal(state.dashboardUrl, null);
-  });
-
-  it('default evaluate is local_only', async () => {
-    const result = await evaluate({ name: 'r', data: ds(1), task: echo, scorers: [exact] });
-    assert.equal(result.uploadState.status, 'local_only');
+describe('cloud-only default', () => {
+  it('bare evaluate requires reporting (no credentials + inline dataset -> throws)', async () => {
+    await assert.rejects(
+      evaluate({ name: 'r', data: ds(1), task: echo, scorers: [exact] }),
+      /reports to the TraceRoot platform/,
+    );
   });
 });
 
@@ -68,19 +61,16 @@ describe('FakeTransport wiring', () => {
     assert.deepEqual([...registered].sort(), ['c0', 'c1', 'c2']);
   });
 
-  it('exactly one finish_run', async () => {
+  it('exactly one finish_run, reported uploaded', async () => {
     const fake = new FakeTransport();
-    await evaluate({ name: 'r', data: ds(3), task: echo, scorers: [exact], transport: fake });
+    const result = await evaluate({
+      name: 'r',
+      data: ds(3),
+      task: echo,
+      scorers: [exact],
+      transport: fake,
+    });
     assert.equal(fake.calls.filter((c) => c[0] === 'finish_run').length, 1);
-  });
-});
-
-describe('Dataset.publish', () => {
-  it('returns a local_only PublishResult', async () => {
-    const d = ds(3);
-    const result = await d.publish();
-    assert.equal(result.status, 'local_only');
-    assert.equal(result.datasetName, 'd');
-    assert.equal(result.itemCount, 3);
+    assert.equal(result.uploadState.status, 'uploaded');
   });
 });

--- a/packages/traceroot/tests/eval-transport.test.ts
+++ b/packages/traceroot/tests/eval-transport.test.ts
@@ -1,0 +1,86 @@
+// OE-8: transport seam parity (Python OE-5): LocalTransport, FakeTransport, publish().
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Dataset, evaluate } from '../src/eval';
+import { FakeTransport, LocalTransport } from '../src/eval';
+import type { ScorerContext } from '../src/eval';
+
+function ds(n: number): Dataset {
+  const d = new Dataset('d');
+  for (let i = 0; i < n; i++) d.upsert({ input: i, id: `c${i}`, expected: i });
+  return d;
+}
+const echo = (x: unknown) => x;
+const exact = (ctx: ScorerContext) => (ctx.output === ctx.expected ? 1 : 0);
+
+describe('LocalTransport', () => {
+  it('finishRun is local_only', async () => {
+    const t = new LocalTransport();
+    const run = await t.createRun('r', 'd', null);
+    const state = await t.finishRun(run);
+    assert.equal(state.status, 'local_only');
+    assert.equal(state.dashboardUrl, null);
+  });
+
+  it('default evaluate is local_only', async () => {
+    const result = await evaluate({ name: 'r', data: ds(1), task: echo, scorers: [exact] });
+    assert.equal(result.uploadState.status, 'local_only');
+  });
+});
+
+describe('FakeTransport wiring', () => {
+  it('call order: create_run first, finish_run last, register before records', async () => {
+    const fake = new FakeTransport();
+    await evaluate({ name: 'r', data: ds(1), task: echo, scorers: [exact], transport: fake });
+    const kinds = fake.calls.map((c) => c[0]);
+    assert.equal(kinds[0], 'create_run');
+    assert.equal(kinds[kinds.length - 1], 'finish_run');
+    assert.ok(kinds.indexOf('register_item') < kinds.indexOf('record_item_result'));
+    assert.ok(kinds.indexOf('register_item') < kinds.indexOf('record_scores'));
+  });
+
+  it('register precedes result for every case', async () => {
+    const fake = new FakeTransport();
+    await evaluate({
+      name: 'r',
+      data: ds(4),
+      task: echo,
+      scorers: [exact],
+      transport: fake,
+      maxConcurrency: 1,
+    });
+    for (const cid of ['c0', 'c1', 'c2', 'c3']) {
+      const reg = fake.calls.findIndex((c) => c[0] === 'register_item' && c[1] === cid);
+      const rec = fake.calls.findIndex((c) => c[0] === 'record_item_result' && c[1] === cid);
+      assert.ok(reg < rec, cid);
+    }
+  });
+
+  it('register fires for erroring case', async () => {
+    const boom = (x: number) => {
+      if (x === 1) throw new Error('no');
+      return x;
+    };
+    const fake = new FakeTransport();
+    await evaluate({ name: 'r', data: ds(3), task: boom, scorers: [exact], transport: fake });
+    const registered = new Set(fake.calls.filter((c) => c[0] === 'register_item').map((c) => c[1]));
+    assert.deepEqual([...registered].sort(), ['c0', 'c1', 'c2']);
+  });
+
+  it('exactly one finish_run', async () => {
+    const fake = new FakeTransport();
+    await evaluate({ name: 'r', data: ds(3), task: echo, scorers: [exact], transport: fake });
+    assert.equal(fake.calls.filter((c) => c[0] === 'finish_run').length, 1);
+  });
+});
+
+describe('Dataset.publish', () => {
+  it('returns a local_only PublishResult', async () => {
+    const d = ds(3);
+    const result = await d.publish();
+    assert.equal(result.status, 'local_only');
+    assert.equal(result.datasetName, 'd');
+    assert.equal(result.itemCount, 3);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the transport that reports an evaluation run to the platform over the public evaluation endpoints. A run is registered with a full scorer manifest, per-case results are upserted as they complete, and the run is finished with an aggregate main score. Registration returns a clickable run link, and a client-side run id makes registration idempotent so a retried run resolves to the same run instead of duplicating it. This also adds read-only dataset pulls so a run can reproduce the exact dataset version it scored. The wire format is byte-identical to the Python SDK.

Fixes: traceroot-ai/traceroot#1691

## How it works

```
register run  → POST /evaluation-runs            (scorer manifest + client_run_id)
per case      → POST /evaluation-runs/{id}/results   (status, main_score, duration, scores)
finish run    → POST /evaluation-runs/{id}/complete  (aggregate main_score + counts)
                → returns absolute run link (base + path fallback)
```

The client mints `clientRunId` up front and sends it on register; the backend treats it as the idempotency key. Result-reporting string fields are coerced to text (non-strings JSON-encoded), while dataset `input`/`expected` cross the boundary as native JSON so the backend owns the single encode/decode. Pass status uses an explicit pass threshold, else the main scorer's declared threshold, else a default of `1.0`; boolean main scores map to `1.0`/`0.0`. Every request emits the same snake_case wire JSON as the Python SDK.

## What's included

### Source
- `packages/traceroot/src/eval/platform.ts` — `PlatformTransport` (createRun → recordItemResult → finishRun) implementing the `EvalTransport` seam over `fetch`; builds the `scorers` manifest (name, version sentinel when unversioned, `scorer_type`, and the optional shared/code/llm-judge definition, absent fields omitted never null); aggregates the main score and resolves pass status against `effectiveThreshold`. Also adds `pullDataset` (current version) and `pullDatasetVersion` (exact immutable version, validated to belong to the dataset) — read data, not runs.

### Tests
- `packages/traceroot/tests/eval-platform.test.ts` — `PlatformTransport` wire payloads, dataset pull (native JSON, exact-version pin, mismatch, 404) with `fetch` mocked.
- `packages/traceroot/tests/eval-transport.test.ts` — transport seam wiring and cloud-only default behavior (parity with the Python transport test).

## Test plan

- [ ] Register a run and confirm the manifest carries the full scorer definition; unknown fields are tolerated.
- [ ] Confirm per-case results carry status, main score, and duration, and the run finishes with the aggregate.
- [ ] Re-register with the same client run id and confirm it resolves to the same run, not a duplicate.
- [ ] Confirm the printed run link is the absolute link when present, and the base + path fallback otherwise.
- [ ] Confirm a run reports byte-identical wire JSON to the Python SDK for the same inputs.
